### PR TITLE
feat: phase 0A scaffold — pyproject, config schema, registry, CLI stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ logs/
 .DS_Store
 .idea/
 .vscode/
+
+# Claude Code per-user state
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,30 @@ The first project it manages is [`teach-me-eng-bot`](https://github.com/valdisd9
 
 ## Status
 
-Phase 0 (extract & generalize) — not started. Phases tracked as GitHub issues.
+Phase 0 (extract & generalize) — in progress. Phases tracked as GitHub issues.
+
+## Install (dev)
+
+```bash
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## CLI
+
+| Command | Phase | Purpose |
+|---|---|---|
+| `fabric register <repo-path>` | 0A | Validate `<path>/.fabric/config.yaml` and add to `~/.fabric/projects.yaml`. |
+| `fabric sync <project> [--check]` | 0B | Re-render skill templates into `<project>/.claude/skills/`. `--check` exits non-zero on drift. |
+| `fabric tick` | 1 | One-shot poll-and-dispatch (debug). |
+| `fabric dispatch <project> <issue> <stage>` | 1 | Force-dispatch a stage. |
+| `fabric status` | 1 | Text dump of the current queue. |
+| `fabric pause [--reason]` / `fabric resume` | 1 | Toggle the global pause flag. |
+| `fabric logs <project> <issue> [--follow]` | 1 | Tail agent logs. |
+
+Phase-1 commands are stubbed (exit code 2) until the scheduler/dispatcher land.
+
+`$FABRIC_HOME` overrides the default registry directory (`~/.fabric`); the systemd unit on the Pi sets it to `/var/lib/fabric`.
 
 ## Roadmap
 

--- a/fabric/__init__.py
+++ b/fabric/__init__.py
@@ -1,0 +1,5 @@
+"""agent-fabric: multi-project Claude-Code pipeline driver."""
+
+from __future__ import annotations
+
+__version__ = "0.0.1"

--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -1,0 +1,105 @@
+"""`fabric` CLI entry point.
+
+Phase 0A wires all eight subcommands listed in DESIGN.md "CLI modes" so the
+surface is discoverable; only `register` does real work this milestone.
+The rest stub out with exit code 2 so accidental invocations fail loudly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from fabric.registry import RegistryError, register as registry_register
+
+app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    help="Multi-project agent fabric CLI.",
+)
+
+_NOT_IMPLEMENTED_EXIT = 2
+
+
+def _stub(name: str) -> None:
+    typer.echo(f"fabric {name}: not implemented in phase 0", err=True)
+    raise typer.Exit(_NOT_IMPLEMENTED_EXIT)
+
+
+@app.command()
+def register(
+    repo_path: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+        help="Path to a project containing a valid .fabric/config.yaml",
+    ),
+) -> None:
+    """Add a project to ~/.fabric/projects.yaml."""
+    try:
+        result = registry_register(repo_path)
+    except RegistryError as e:
+        typer.echo(f"register: {e}", err=True)
+        raise typer.Exit(1) from e
+    verb = "updated" if result.replaced else "registered"
+    typer.echo(f"{verb} {result.entry.name} -> {result.entry.path} ({result.entry.repo})")
+
+
+@app.command()
+def sync(
+    project: str = typer.Argument(..., help="Project name or path"),
+    check: bool = typer.Option(False, "--check", help="Exit non-zero on drift; do not write."),
+) -> None:
+    """Re-render skill templates into the project's .claude/skills/."""
+    _stub("sync")
+
+
+@app.command()
+def tick() -> None:
+    """One-shot poll-and-dispatch (debug)."""
+    _stub("tick")
+
+
+@app.command()
+def dispatch(
+    project: str = typer.Argument(...),
+    issue: int = typer.Argument(...),
+    stage: str = typer.Argument(...),
+) -> None:
+    """Force-dispatch an agent stage on an issue."""
+    _stub("dispatch")
+
+
+@app.command()
+def status() -> None:
+    """Text dump of current queue state."""
+    _stub("status")
+
+
+@app.command()
+def pause(reason: str = typer.Option("", "--reason", help="Pause reason recorded in state.")) -> None:
+    """Set the global pause flag."""
+    _stub("pause")
+
+
+@app.command()
+def resume() -> None:
+    """Clear the global pause flag."""
+    _stub("resume")
+
+
+@app.command()
+def logs(
+    project: str = typer.Argument(...),
+    issue: int = typer.Argument(...),
+    follow: bool = typer.Option(False, "--follow", "-f"),
+) -> None:
+    """Tail the latest agent log for an issue."""
+    _stub("logs")
+
+
+if __name__ == "__main__":
+    app()

--- a/fabric/config.py
+++ b/fabric/config.py
@@ -1,0 +1,136 @@
+"""Pydantic schema + loader for `.fabric/config.yaml`.
+
+The schema is the public contract between the fabric and managed projects;
+managed projects pin a `fabric_version` and depend on its stability.
+DESIGN.md "Per-project layout & config" is the source of truth for shape.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+
+class ConfigError(Exception):
+    """Raised when a project's `.fabric/config.yaml` is missing or invalid."""
+
+
+_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+class _Strict(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class Project(_Strict):
+    name: str = Field(min_length=1)
+    repo: str
+    trusted_authors: list[str] = Field(default_factory=list)
+
+    @field_validator("repo")
+    @classmethod
+    def _check_repo(cls, v: str) -> str:
+        if not _REPO_RE.match(v):
+            raise ValueError("must be in 'owner/repo' form")
+        return v
+
+
+class Build(_Strict):
+    setup_cmd: str | None = None
+    test_cmd: str
+    lint_cmd: str | None = None
+
+
+class Module(_Strict):
+    path: str = Field(min_length=1)
+    role: str = Field(min_length=1)
+
+
+class Safety(_Strict):
+    blocked_paths: list[str] = Field(default_factory=list)
+    destructive_db_patterns: list[str] = Field(default_factory=list)
+    notes: str = ""
+
+
+class Labels(_Strict):
+    state_prefix: str = "state:"
+    type_prefix: str = "type:"
+    area_prefix: str = "area:"
+    area_labels: list[str] = Field(default_factory=list)
+
+
+class Pipeline(_Strict):
+    cycle_limit: int = Field(default=5, gt=0)
+    retry_count: int = Field(default=3, ge=0)
+    retry_backoff_seconds: list[int] = Field(default_factory=lambda: [60, 300, 900])
+    daily_dispatch_cap: int = Field(default=30, gt=0)
+
+    @field_validator("retry_backoff_seconds")
+    @classmethod
+    def _check_backoff(cls, v: list[int]) -> list[int]:
+        if any(s < 0 for s in v):
+            raise ValueError("retry_backoff_seconds entries must be non-negative")
+        return v
+
+
+class FabricConfig(_Strict):
+    project: Project
+    build: Build
+    modules: list[Module] = Field(default_factory=list)
+    safety: Safety = Field(default_factory=Safety)
+    labels: Labels = Field(default_factory=Labels)
+    pipeline: Pipeline = Field(default_factory=Pipeline)
+    fabric_version: str
+
+
+def load_config(path: str | Path) -> FabricConfig:
+    """Load a `.fabric/config.yaml` from disk and validate it.
+
+    Raises `ConfigError` with field-path context on any problem.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise ConfigError(f"{p}: file not found")
+    try:
+        raw = yaml.safe_load(p.read_text())
+    except yaml.YAMLError as e:
+        raise ConfigError(f"{p}: invalid YAML: {e}") from e
+    if raw is None:
+        raise ConfigError(f"{p}: file is empty")
+    if not isinstance(raw, dict):
+        raise ConfigError(f"{p}: top level must be a mapping, got {type(raw).__name__}")
+    try:
+        return FabricConfig.model_validate(raw)
+    except ValidationError as e:
+        raise ConfigError(f"{p}: {_format_validation_error(e)}") from e
+
+
+def _format_validation_error(e: ValidationError) -> str:
+    parts: list[str] = []
+    for err in e.errors():
+        loc = ".".join(str(x) for x in err["loc"]) or "<root>"
+        parts.append(f"{loc}: {err['msg']}")
+    return "; ".join(parts)
+
+
+def load_project_config(project_path: str | Path) -> FabricConfig:
+    """Load `<project_path>/.fabric/config.yaml`."""
+    return load_config(Path(project_path) / ".fabric" / "config.yaml")
+
+
+__all__ = [
+    "Build",
+    "ConfigError",
+    "FabricConfig",
+    "Labels",
+    "Module",
+    "Pipeline",
+    "Project",
+    "Safety",
+    "load_config",
+    "load_project_config",
+]

--- a/fabric/registry.py
+++ b/fabric/registry.py
@@ -1,0 +1,137 @@
+"""Project registry — `~/.fabric/projects.yaml`.
+
+A flat list of `{name, path, repo}` triples. The CLI's `register` command
+populates it; future scheduler / dispatcher / sync code reads it to know
+which repos to act on.
+
+Path resolution:
+  - `$FABRIC_HOME` overrides the default (`~/.fabric`); the systemd unit
+    on the Pi sets it to `/var/lib/fabric`.
+  - All `path` entries are stored as absolute paths (resolved at register
+    time) so the registry is portable to a working directory other than
+    where it was written.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from fabric.config import ConfigError, FabricConfig, load_project_config
+
+
+class RegistryError(Exception):
+    """Raised when registry I/O fails or input is unusable."""
+
+
+@dataclass(frozen=True)
+class ProjectEntry:
+    name: str
+    path: str
+    repo: str
+
+
+def fabric_home() -> Path:
+    """Directory holding the registry, state DB, and runtime files."""
+    raw = os.environ.get("FABRIC_HOME")
+    return Path(raw).expanduser() if raw else Path.home() / ".fabric"
+
+
+def registry_path() -> Path:
+    return fabric_home() / "projects.yaml"
+
+
+def load_registry() -> list[ProjectEntry]:
+    p = registry_path()
+    if not p.exists():
+        return []
+    try:
+        raw = yaml.safe_load(p.read_text())
+    except yaml.YAMLError as e:
+        raise RegistryError(f"{p}: invalid YAML: {e}") from e
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise RegistryError(f"{p}: top level must be a list, got {type(raw).__name__}")
+    entries: list[ProjectEntry] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise RegistryError(f"{p}: entry {i} must be a mapping")
+        try:
+            entries.append(ProjectEntry(name=item["name"], path=item["path"], repo=item["repo"]))
+        except KeyError as e:
+            raise RegistryError(f"{p}: entry {i} missing required key {e}") from e
+    return entries
+
+
+def save_registry(entries: list[ProjectEntry]) -> None:
+    p = registry_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload: list[dict[str, Any]] = [asdict(e) for e in entries]
+    p.write_text(yaml.safe_dump(payload, sort_keys=False))
+
+
+@dataclass
+class RegisterResult:
+    entry: ProjectEntry
+    replaced: bool  # True if an existing entry with the same name was overwritten
+
+
+def register(repo_path: str | Path) -> RegisterResult:
+    """Validate `<repo_path>/.fabric/config.yaml` and add it to the registry.
+
+    Re-registering an existing `name` updates `path` and `repo` in place.
+    Returns the resulting entry plus whether a previous entry was replaced.
+    """
+    abs_path = Path(repo_path).expanduser().resolve()
+    if not abs_path.is_dir():
+        raise RegistryError(f"{abs_path}: not a directory")
+
+    try:
+        config: FabricConfig = load_project_config(abs_path)
+    except ConfigError as e:
+        raise RegistryError(str(e)) from e
+
+    new_entry = ProjectEntry(
+        name=config.project.name,
+        path=str(abs_path),
+        repo=config.project.repo,
+    )
+
+    entries = load_registry()
+    replaced = False
+    for i, existing in enumerate(entries):
+        if existing.name == new_entry.name:
+            entries[i] = new_entry
+            replaced = True
+            break
+    if not replaced:
+        entries.append(new_entry)
+
+    save_registry(entries)
+    return RegisterResult(entry=new_entry, replaced=replaced)
+
+
+def find(name: str) -> ProjectEntry | None:
+    """Return the entry for `name`, or None if not registered."""
+    for e in load_registry():
+        if e.name == name:
+            return e
+    return None
+
+
+__all__ = [
+    "ProjectEntry",
+    "RegisterResult",
+    "RegistryError",
+    "fabric_home",
+    "find",
+    "load_registry",
+    "register",
+    "registry_path",
+    "save_registry",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-fabric"
+version = "0.0.1"
+description = "Multi-project agent fabric — drives the plan-exec → test-writer → review-pr Claude pipeline across N repos."
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [{ name = "Uladzislau Vauchok" }]
+dependencies = [
+    "typer>=0.12",
+    "pydantic>=2.6",
+    "jinja2>=3.1",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[project.scripts]
+fabric = "fabric.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["fabric"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/fixtures/bad_extra_field.yaml
+++ b/tests/fixtures/bad_extra_field.yaml
@@ -1,0 +1,9 @@
+project:
+  name: x
+  repo: owner/repo
+  unexpected_field: oops
+
+build:
+  test_cmd: "pytest"
+
+fabric_version: "0.0.1"

--- a/tests/fixtures/bad_missing_test_cmd.yaml
+++ b/tests/fixtures/bad_missing_test_cmd.yaml
@@ -1,0 +1,8 @@
+project:
+  name: x
+  repo: owner/repo
+
+build:
+  setup_cmd: ":"
+
+fabric_version: "0.0.1"

--- a/tests/fixtures/bad_negative_cycle_limit.yaml
+++ b/tests/fixtures/bad_negative_cycle_limit.yaml
@@ -1,0 +1,11 @@
+project:
+  name: x
+  repo: owner/repo
+
+build:
+  test_cmd: "pytest"
+
+pipeline:
+  cycle_limit: 0
+
+fabric_version: "0.0.1"

--- a/tests/fixtures/bad_repo_format.yaml
+++ b/tests/fixtures/bad_repo_format.yaml
@@ -1,0 +1,8 @@
+project:
+  name: x
+  repo: not-a-valid-repo
+
+build:
+  test_cmd: "pytest"
+
+fabric_version: "0.0.1"

--- a/tests/fixtures/good.yaml
+++ b/tests/fixtures/good.yaml
@@ -1,0 +1,36 @@
+project:
+  name: teach-me-eng-bot
+  repo: valdisd96/teach-me-eng-bot
+  trusted_authors: [valdisd96]
+
+build:
+  setup_cmd: "source .venv/bin/activate"
+  test_cmd: "python -m pytest -q"
+
+modules:
+  - path: bot.py
+    role: "python-telegram-bot wiring"
+  - path: vocab.py
+    role: "vocab CRUD"
+
+safety:
+  blocked_paths:
+    - .github/workflows/**
+  destructive_db_patterns:
+    - "DROP COLUMN"
+  notes: |
+    FSRS columns are load-bearing.
+
+labels:
+  state_prefix: "state:"
+  type_prefix: "type:"
+  area_prefix: "area:"
+  area_labels: [bot, vocab]
+
+pipeline:
+  cycle_limit: 5
+  retry_count: 3
+  retry_backoff_seconds: [60, 300, 900]
+  daily_dispatch_cap: 30
+
+fabric_version: "0.0.1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fabric.config import ConfigError, FabricConfig, load_config
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_load_good_config() -> None:
+    cfg = load_config(FIXTURES / "good.yaml")
+    assert isinstance(cfg, FabricConfig)
+    assert cfg.project.name == "teach-me-eng-bot"
+    assert cfg.project.repo == "valdisd96/teach-me-eng-bot"
+    assert cfg.build.test_cmd == "python -m pytest -q"
+    assert cfg.modules[0].path == "bot.py"
+    assert cfg.labels.area_labels == ["bot", "vocab"]
+    assert cfg.pipeline.cycle_limit == 5
+    assert cfg.fabric_version == "0.0.1"
+
+
+def test_missing_file_raises() -> None:
+    with pytest.raises(ConfigError, match="file not found"):
+        load_config(FIXTURES / "does_not_exist.yaml")
+
+
+def test_bad_repo_format_includes_field_path() -> None:
+    with pytest.raises(ConfigError) as exc:
+        load_config(FIXTURES / "bad_repo_format.yaml")
+    assert "project.repo" in str(exc.value)
+    assert "owner/repo" in str(exc.value)
+
+
+def test_missing_required_field_includes_field_path() -> None:
+    with pytest.raises(ConfigError) as exc:
+        load_config(FIXTURES / "bad_missing_test_cmd.yaml")
+    assert "build.test_cmd" in str(exc.value)
+
+
+def test_extra_field_rejected() -> None:
+    with pytest.raises(ConfigError) as exc:
+        load_config(FIXTURES / "bad_extra_field.yaml")
+    msg = str(exc.value)
+    assert "project" in msg
+    assert "unexpected_field" in msg
+
+
+def test_invalid_pipeline_value_rejected() -> None:
+    with pytest.raises(ConfigError) as exc:
+        load_config(FIXTURES / "bad_negative_cycle_limit.yaml")
+    assert "pipeline.cycle_limit" in str(exc.value)
+
+
+def test_empty_file_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "empty.yaml"
+    p.write_text("")
+    with pytest.raises(ConfigError, match="empty"):
+        load_config(p)
+
+
+def test_invalid_yaml_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "bad.yaml"
+    p.write_text("project: [unclosed")
+    with pytest.raises(ConfigError, match="invalid YAML"):
+        load_config(p)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from fabric.registry import (
+    ProjectEntry,
+    RegistryError,
+    fabric_home,
+    find,
+    load_registry,
+    register,
+    registry_path,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def isolated_fabric_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "fabric-home"
+    monkeypatch.setenv("FABRIC_HOME", str(home))
+    return home
+
+
+def _make_project(root: Path, fixture: str = "good.yaml") -> Path:
+    """Create a fake project at `root` with `.fabric/config.yaml` from fixtures."""
+    fabric_dir = root / ".fabric"
+    fabric_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(FIXTURES / fixture, fabric_dir / "config.yaml")
+    return root
+
+
+def test_fabric_home_uses_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FABRIC_HOME", str(tmp_path / "custom"))
+    assert fabric_home() == tmp_path / "custom"
+
+
+def test_fabric_home_defaults_to_dot_fabric(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FABRIC_HOME", raising=False)
+    assert fabric_home() == Path.home() / ".fabric"
+
+
+def test_load_registry_returns_empty_when_missing(isolated_fabric_home: Path) -> None:
+    assert load_registry() == []
+
+
+def test_register_writes_entry(isolated_fabric_home: Path, tmp_path: Path) -> None:
+    project = _make_project(tmp_path / "proj")
+    result = register(project)
+    assert result.replaced is False
+    assert result.entry.name == "teach-me-eng-bot"
+    assert result.entry.repo == "valdisd96/teach-me-eng-bot"
+    assert Path(result.entry.path) == project.resolve()
+    assert registry_path().exists()
+    assert load_registry() == [result.entry]
+
+
+def test_register_dedupes_by_name_and_updates_path(
+    isolated_fabric_home: Path, tmp_path: Path
+) -> None:
+    first = _make_project(tmp_path / "first")
+    register(first)
+
+    second = _make_project(tmp_path / "second")
+    result = register(second)
+
+    assert result.replaced is True
+    assert Path(result.entry.path) == second.resolve()
+
+    entries = load_registry()
+    assert len(entries) == 1
+    assert Path(entries[0].path) == second.resolve()
+
+
+def test_register_rejects_missing_config(
+    isolated_fabric_home: Path, tmp_path: Path
+) -> None:
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    with pytest.raises(RegistryError, match="file not found"):
+        register(bare)
+
+
+def test_register_rejects_invalid_config(
+    isolated_fabric_home: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "bad", fixture="bad_repo_format.yaml")
+    with pytest.raises(RegistryError) as exc:
+        register(project)
+    assert "project.repo" in str(exc.value)
+
+
+def test_register_rejects_non_directory(
+    isolated_fabric_home: Path, tmp_path: Path
+) -> None:
+    f = tmp_path / "f.txt"
+    f.write_text("hi")
+    with pytest.raises(RegistryError, match="not a directory"):
+        register(f)
+
+
+def test_find_returns_entry(isolated_fabric_home: Path, tmp_path: Path) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    entry = find("teach-me-eng-bot")
+    assert isinstance(entry, ProjectEntry)
+    assert entry.repo == "valdisd96/teach-me-eng-bot"
+
+
+def test_find_returns_none_for_unknown(isolated_fabric_home: Path) -> None:
+    assert find("nope") is None


### PR DESCRIPTION
## Summary

First milestone of #1 (Phase 0). Lays down the Python package surface and the two pieces of state that live at this layer:

- **`.fabric/config.yaml`** — per-project contract, parsed and validated by pydantic v2 in `fabric/config.py`. Strict models (`extra="forbid"`) so schema drift surfaces immediately.
- **`~/.fabric/projects.yaml`** — host-level registry of `{name, path, repo}`, managed in `fabric/registry.py`. Honours `$FABRIC_HOME`. Dedupes by project name (re-register updates path/repo in place).
- **CLI** — typer app at `fabric/cli.py`. `register` is real; the other seven (`sync`, `tick`, `dispatch`, `status`, `pause`, `resume`, `logs`) print "not implemented in phase 0" and exit 2 so the surface is discoverable now and untouched callers fail loudly.

`pip install -e ".[dev]"` then `fabric --help` to see all eight commands. README has an updated CLI table.

`.claude/settings.local.json` added to `.gitignore` (per-user state, not a repo artifact).

## Out of scope (next sub-issues)

- Renderer + `fabric sync` → #6 (Phase 0B).
- Template conversion + parity → #7 (Phase 0C).
- Drift CI template → #8 (Phase 0D).

## Test plan

- [x] `pip install -e ".[dev]"` in a fresh venv.
- [x] `fabric --help` lists all 8 subcommands.
- [x] `fabric tick` (and the other 6 stubs) exit with code 2 and a "not implemented" message.
- [x] `pytest -q` → 18 passed:
  - good config loads, all field types parse correctly
  - missing file, empty file, invalid YAML each rejected with a useful message
  - bad `project.repo` format rejected with `project.repo` in the message
  - missing `build.test_cmd` rejected with that field path
  - extra/unexpected field rejected
  - `pipeline.cycle_limit: 0` rejected with field path
  - `fabric_home()` honours `$FABRIC_HOME` and falls back to `~/.fabric`
  - `register` writes a fresh entry, dedupes by name on re-register, rejects missing/invalid configs and non-directories
  - `find()` returns the entry / None
- [ ] End-to-end `fabric register <real-project>` deferred until #7 lands a real `.fabric/config.yaml` for teach-me-eng-bot.

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)