### PR TITLE
feat: phase 0B skill renderer + fabric sync

### DIFF
--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import typer
 
 from fabric.registry import RegistryError, register as registry_register
+from fabric.sync import SyncError, sync as run_sync
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -51,10 +52,39 @@ def register(
 @app.command()
 def sync(
     project: str = typer.Argument(..., help="Project name or path"),
-    check: bool = typer.Option(False, "--check", help="Exit non-zero on drift; do not write."),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Exit 1 on drift; do not write. Use in CI.",
+    ),
 ) -> None:
-    """Re-render skill templates into the project's .claude/skills/."""
-    _stub("sync")
+    """Re-render skill templates into the project's .claude/skills/.
+
+    Exit codes: 0 clean (or wrote files), 1 drift (--check only),
+    2 error (config invalid, project not found, template missing).
+    """
+    try:
+        result = run_sync(project, check=check)
+    except SyncError as e:
+        typer.echo(f"sync: {e}", err=True)
+        raise typer.Exit(2) from e
+
+    if check:
+        if not result.drift:
+            typer.echo(f"sync: {project} is clean")
+            return
+        for d in result.drift:
+            typer.echo(d.unified_diff(result.project_path))
+        files = ", ".join(d.name for d in result.drift)
+        typer.echo(f"sync: drift detected in {len(result.drift)} skill(s): {files}", err=True)
+        raise typer.Exit(1)
+
+    if result.written:
+        for name in result.written:
+            typer.echo(f"wrote {name}")
+        typer.echo(f"sync: {len(result.written)} skill(s) updated")
+    else:
+        typer.echo(f"sync: {project} already up to date")
 
 
 @app.command()

--- a/fabric/render.py
+++ b/fabric/render.py
@@ -1,0 +1,126 @@
+"""Jinja2 skill renderer.
+
+Each fabric-managed skill ships as `skill_templates/<name>/SKILL.md.j2` in
+the fabric repo. A managed project may override any skill by placing a
+sibling file at `<project>/.fabric/skills/<name>/SKILL.md.j2` — overlays
+beat defaults at the whole-skill level (no section-level inheritance, by
+design — see DESIGN.md "Override grain").
+
+The Jinja environment uses StrictUndefined so a typo in a template (or a
+missing config field) raises rather than silently rendering an empty
+string. `keep_trailing_newline=True` preserves the file's final newline,
+which matters for the byte-for-byte parity check in Phase 0C.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from jinja2 import (
+    ChoiceLoader,
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+    TemplateNotFound,
+)
+
+from fabric.config import FabricConfig
+
+#: Skills the fabric ships templates for. `dev-flow` is intentionally
+#: project-internal and not in this list.
+SKILL_NAMES: tuple[str, ...] = (
+    "plan-exec",
+    "test-writer",
+    "review-pr",
+    "clarify-issue",
+    "epic-decompose",
+)
+
+SKILL_TEMPLATE_FILENAME = "SKILL.md.j2"
+SKILL_OUTPUT_FILENAME = "SKILL.md"
+
+
+class RenderError(Exception):
+    """Raised when a skill template is missing or fails to render."""
+
+
+def default_fabric_root() -> Path:
+    """Repo root containing `skill_templates/` (used when no override given)."""
+    return Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class TemplateSources:
+    """Search roots for `<name>/SKILL.md.j2`, in precedence order."""
+
+    overlay: Path  # <project>/.fabric/skills
+    default: Path  # <fabric_root>/skill_templates
+
+    def loader(self) -> ChoiceLoader:
+        return ChoiceLoader(
+            [
+                FileSystemLoader(str(self.overlay)),
+                FileSystemLoader(str(self.default)),
+            ]
+        )
+
+
+def template_sources(project_path: Path, fabric_root: Path | None = None) -> TemplateSources:
+    root = fabric_root or default_fabric_root()
+    return TemplateSources(
+        overlay=project_path / ".fabric" / "skills",
+        default=root / "skill_templates",
+    )
+
+
+def _make_env(sources: TemplateSources) -> Environment:
+    return Environment(
+        loader=sources.loader(),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+        autoescape=False,
+        trim_blocks=False,
+        lstrip_blocks=False,
+    )
+
+
+def render_skill(
+    name: str,
+    project_path: Path,
+    config: FabricConfig,
+    *,
+    fabric_root: Path | None = None,
+) -> str:
+    """Render skill `name` for `project_path` against `config`.
+
+    Looks first in the project's `.fabric/skills/<name>/SKILL.md.j2`, then
+    in the fabric's bundled `skill_templates/<name>/SKILL.md.j2`. Missing
+    in both is `RenderError`.
+    """
+    sources = template_sources(project_path, fabric_root)
+    env = _make_env(sources)
+    template_name = f"{name}/{SKILL_TEMPLATE_FILENAME}"
+    try:
+        template = env.get_template(template_name)
+    except TemplateNotFound as e:
+        raise RenderError(
+            f"skill template not found: {name} "
+            f"(searched {sources.overlay} then {sources.default})"
+        ) from e
+    try:
+        return template.render(**config.model_dump())
+    except Exception as e:
+        raise RenderError(f"render failed for {name}: {e}") from e
+
+
+__all__ = [
+    "RenderError",
+    "SKILL_NAMES",
+    "SKILL_OUTPUT_FILENAME",
+    "SKILL_TEMPLATE_FILENAME",
+    "TemplateSources",
+    "default_fabric_root",
+    "render_skill",
+    "template_sources",
+]

--- a/fabric/sync.py
+++ b/fabric/sync.py
@@ -1,0 +1,137 @@
+"""`fabric sync` — re-render all fabric-managed skills into a project.
+
+Two modes:
+  - default: write the rendered output to `<project>/.claude/skills/<name>/SKILL.md`.
+  - `--check`: render to memory and compare against on-disk; report drift.
+
+Idempotency: a clean tree should sync to a no-op (sync; sync; → no diff).
+Tested by `tests/test_sync.py::test_sync_is_idempotent`.
+
+Project lookup: the `project` argument is treated as a registered name first
+(via `fabric.registry.find`), then as a filesystem path. So both
+`fabric sync teach-me-eng-bot` and `fabric sync .` work.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from fabric.config import ConfigError, load_project_config
+from fabric.registry import find
+from fabric.render import (
+    SKILL_NAMES,
+    SKILL_OUTPUT_FILENAME,
+    RenderError,
+    render_skill,
+)
+
+
+class SyncError(Exception):
+    """Raised when sync cannot proceed (project not found, config invalid, etc.)."""
+
+
+@dataclass
+class SkillDrift:
+    name: str
+    expected: str  # what the template renders to now
+    actual: str  # what's currently on disk
+
+    def unified_diff(self, project_path: Path) -> str:
+        rel = (
+            project_path
+            / ".claude"
+            / "skills"
+            / self.name
+            / SKILL_OUTPUT_FILENAME
+        )
+        return "".join(
+            difflib.unified_diff(
+                self.actual.splitlines(keepends=True),
+                self.expected.splitlines(keepends=True),
+                fromfile=f"{rel} (on disk)",
+                tofile=f"{rel} (rendered)",
+            )
+        )
+
+
+@dataclass
+class SyncResult:
+    project_path: Path
+    written: list[str] = field(default_factory=list)
+    drift: list[SkillDrift] = field(default_factory=list)
+
+
+def resolve_project(arg: str) -> Path:
+    """Treat `arg` as a registered name first, then as a path."""
+    entry = find(arg)
+    if entry is not None:
+        return Path(entry.path)
+    candidate = Path(arg).expanduser().resolve()
+    if candidate.is_dir():
+        return candidate
+    raise SyncError(
+        f"project '{arg}' not found in registry and is not a directory on disk"
+    )
+
+
+def sync(
+    project: str | Path,
+    *,
+    check: bool = False,
+    fabric_root: Path | None = None,
+) -> SyncResult:
+    """Render all fabric-managed skills for `project`.
+
+    Writes to disk unless `check=True`, in which case drift is collected and
+    returned without modifying the project.
+    """
+    project_path = (
+        resolve_project(project) if isinstance(project, str) else Path(project).resolve()
+    )
+    if not project_path.is_dir():
+        raise SyncError(f"{project_path}: not a directory")
+
+    try:
+        config = load_project_config(project_path)
+    except ConfigError as e:
+        raise SyncError(str(e)) from e
+
+    result = SyncResult(project_path=project_path)
+    skills_dir = project_path / ".claude" / "skills"
+
+    for name in SKILL_NAMES:
+        try:
+            rendered = render_skill(
+                name, project_path, config, fabric_root=fabric_root
+            )
+        except RenderError as e:
+            raise SyncError(str(e)) from e
+
+        out_file = skills_dir / name / SKILL_OUTPUT_FILENAME
+        actual = out_file.read_text() if out_file.exists() else ""
+
+        if check:
+            if actual != rendered:
+                result.drift.append(
+                    SkillDrift(name=name, expected=rendered, actual=actual)
+                )
+            continue
+
+        if actual == rendered:
+            continue
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        out_file.write_text(rendered)
+        result.written.append(name)
+
+    return result
+
+
+__all__ = [
+    "SkillDrift",
+    "SyncError",
+    "SyncResult",
+    "resolve_project",
+    "sync",
+]

--- a/skill_templates/clarify-issue/SKILL.md.j2
+++ b/skill_templates/clarify-issue/SKILL.md.j2
@@ -1,0 +1,9 @@
+---
+name: clarify-issue
+description: PLACEHOLDER for {{ project.name }} — real template lands in Phase 0C (#7).
+version: 0.0.1
+---
+
+# clarify-issue — placeholder
+
+For the `{{ project.name }}` project.

--- a/skill_templates/epic-decompose/SKILL.md.j2
+++ b/skill_templates/epic-decompose/SKILL.md.j2
@@ -1,0 +1,9 @@
+---
+name: epic-decompose
+description: PLACEHOLDER — real template lands in Phase 0C (#7).
+version: 0.0.1
+---
+
+# epic-decompose — placeholder
+
+Cycle limit: `{{ pipeline.cycle_limit }}`.

--- a/skill_templates/plan-exec/SKILL.md.j2
+++ b/skill_templates/plan-exec/SKILL.md.j2
@@ -1,0 +1,12 @@
+---
+name: plan-exec
+description: PLACEHOLDER for {{ project.name }} — real template lands in Phase 0C (#7).
+version: 0.0.1
+---
+
+# plan-exec — placeholder
+
+Project: `{{ project.name }}` ({{ project.repo }}).
+Test command: `{{ build.test_cmd }}`.
+
+This file is rendered by `fabric sync`. Edit `skill_templates/plan-exec/SKILL.md.j2` in the fabric, not the rendered output.

--- a/skill_templates/review-pr/SKILL.md.j2
+++ b/skill_templates/review-pr/SKILL.md.j2
@@ -1,0 +1,13 @@
+---
+name: review-pr
+description: PLACEHOLDER — real template lands in Phase 0C (#7).
+version: 0.0.1
+---
+
+# review-pr — placeholder
+
+State labels are prefixed `{{ labels.state_prefix }}`.
+
+Blocked paths (must not be modified):
+{% for p in safety.blocked_paths %}- `{{ p }}`
+{% endfor %}

--- a/skill_templates/test-writer/SKILL.md.j2
+++ b/skill_templates/test-writer/SKILL.md.j2
@@ -1,0 +1,13 @@
+---
+name: test-writer
+description: PLACEHOLDER — real template lands in Phase 0C (#7).
+version: 0.0.1
+---
+
+# test-writer — placeholder
+
+Test command: `{{ build.test_cmd }}`
+
+Modules in scope:
+{% for m in modules %}- `{{ m.path }}` — {{ m.role }}
+{% endfor %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def fabric_root() -> Path:
+    """Path to the fabric repo root (so tests find `skill_templates/`)."""
+    return REPO_ROOT
+
+
+@pytest.fixture
+def isolated_fabric_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "fabric-home"
+    monkeypatch.setenv("FABRIC_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """Create a fake project with a valid `.fabric/config.yaml`."""
+    root = tmp_path / "proj"
+    fabric_dir = root / ".fabric"
+    fabric_dir.mkdir(parents=True)
+    shutil.copy(FIXTURES / "good.yaml", fabric_dir / "config.yaml")
+    return root

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from fabric.cli import app
+from fabric.render import SKILL_NAMES, SKILL_OUTPUT_FILENAME
+
+runner = CliRunner()
+
+
+def _skill_path(project: Path, name: str) -> Path:
+    return project / ".claude" / "skills" / name / SKILL_OUTPUT_FILENAME
+
+
+def test_cli_sync_writes(project: Path) -> None:
+    result = runner.invoke(app, ["sync", str(project)])
+    assert result.exit_code == 0, result.output
+    for name in SKILL_NAMES:
+        assert _skill_path(project, name).exists()
+
+
+def test_cli_sync_check_clean_returns_zero(project: Path) -> None:
+    runner.invoke(app, ["sync", str(project)])
+    result = runner.invoke(app, ["sync", str(project), "--check"])
+    assert result.exit_code == 0, result.output
+    assert "clean" in result.output
+
+
+def test_cli_sync_check_drift_returns_one(project: Path) -> None:
+    runner.invoke(app, ["sync", str(project)])
+    edited = _skill_path(project, "plan-exec")
+    edited.write_text("changed\n")
+
+    result = runner.invoke(app, ["sync", str(project), "--check"])
+    assert result.exit_code == 1, result.output
+    assert "plan-exec" in result.output
+
+
+def test_cli_sync_invalid_config_returns_two(tmp_path: Path) -> None:
+    project = tmp_path / "bad"
+    fabric_dir = project / ".fabric"
+    fabric_dir.mkdir(parents=True)
+    (fabric_dir / "config.yaml").write_text("project:\n  name: x\n  repo: bad\n")
+    result = runner.invoke(app, ["sync", str(project)])
+    assert result.exit_code == 2
+
+
+def test_cli_sync_unknown_project_returns_two(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["sync", str(tmp_path / "missing")])
+    assert result.exit_code == 2

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,13 +18,6 @@ from fabric.registry import (
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
-@pytest.fixture
-def isolated_fabric_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    home = tmp_path / "fabric-home"
-    monkeypatch.setenv("FABRIC_HOME", str(home))
-    return home
-
-
 def _make_project(root: Path, fixture: str = "good.yaml") -> Path:
     """Create a fake project at `root` with `.fabric/config.yaml` from fixtures."""
     fabric_dir = root / ".fabric"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fabric.config import load_project_config
+from fabric.render import (
+    SKILL_NAMES,
+    RenderError,
+    render_skill,
+    template_sources,
+)
+
+
+def test_render_skill_uses_default_when_no_overlay(project: Path, fabric_root: Path) -> None:
+    config = load_project_config(project)
+    out = render_skill("plan-exec", project, config, fabric_root=fabric_root)
+    assert "plan-exec" in out
+    # Default template references project.name + build.test_cmd
+    assert config.project.name in out
+    assert config.build.test_cmd in out
+
+
+def test_overlay_wins_over_default(project: Path, fabric_root: Path) -> None:
+    overlay = project / ".fabric" / "skills" / "plan-exec"
+    overlay.mkdir(parents=True)
+    (overlay / "SKILL.md.j2").write_text("OVERLAY: {{ project.name }}\n")
+
+    config = load_project_config(project)
+    out = render_skill("plan-exec", project, config, fabric_root=fabric_root)
+    assert out.startswith("OVERLAY:")
+    assert config.project.name in out
+
+
+def test_overlay_only_affects_named_skill(project: Path, fabric_root: Path) -> None:
+    overlay = project / ".fabric" / "skills" / "plan-exec"
+    overlay.mkdir(parents=True)
+    (overlay / "SKILL.md.j2").write_text("OVERLAY\n")
+
+    config = load_project_config(project)
+    other = render_skill("test-writer", project, config, fabric_root=fabric_root)
+    assert "OVERLAY" not in other
+    assert "test-writer" in other
+
+
+def test_missing_template_raises(project: Path, tmp_path: Path) -> None:
+    config = load_project_config(project)
+    bare_fabric = tmp_path / "bare-fabric"
+    (bare_fabric / "skill_templates").mkdir(parents=True)
+    with pytest.raises(RenderError, match="not found"):
+        render_skill("plan-exec", project, config, fabric_root=bare_fabric)
+
+
+def test_undefined_variable_in_overlay_raises(project: Path, fabric_root: Path) -> None:
+    overlay = project / ".fabric" / "skills" / "plan-exec"
+    overlay.mkdir(parents=True)
+    (overlay / "SKILL.md.j2").write_text("{{ does_not_exist }}\n")
+
+    config = load_project_config(project)
+    with pytest.raises(RenderError, match="render failed"):
+        render_skill("plan-exec", project, config, fabric_root=fabric_root)
+
+
+def test_all_default_templates_render(project: Path, fabric_root: Path) -> None:
+    config = load_project_config(project)
+    for name in SKILL_NAMES:
+        out = render_skill(name, project, config, fabric_root=fabric_root)
+        assert out.endswith("\n"), f"{name} should preserve trailing newline"
+        assert len(out) > 0
+
+
+def test_template_sources_paths(project: Path, fabric_root: Path) -> None:
+    sources = template_sources(project, fabric_root=fabric_root)
+    assert sources.overlay == project / ".fabric" / "skills"
+    assert sources.default == fabric_root / "skill_templates"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fabric.registry import register
+from fabric.render import SKILL_NAMES, SKILL_OUTPUT_FILENAME
+from fabric.sync import SyncError, resolve_project, sync
+
+
+def _skill_path(project: Path, name: str) -> Path:
+    return project / ".claude" / "skills" / name / SKILL_OUTPUT_FILENAME
+
+
+def test_sync_writes_all_skills(project: Path, fabric_root: Path) -> None:
+    result = sync(project, fabric_root=fabric_root)
+    assert sorted(result.written) == sorted(SKILL_NAMES)
+    for name in SKILL_NAMES:
+        assert _skill_path(project, name).is_file()
+
+
+def test_sync_is_idempotent(project: Path, fabric_root: Path) -> None:
+    sync(project, fabric_root=fabric_root)
+    snapshot = {n: _skill_path(project, n).read_text() for n in SKILL_NAMES}
+
+    second = sync(project, fabric_root=fabric_root)
+    assert second.written == []
+    for name, original in snapshot.items():
+        assert _skill_path(project, name).read_text() == original
+
+
+def test_check_clean_after_sync(project: Path, fabric_root: Path) -> None:
+    sync(project, fabric_root=fabric_root)
+    result = sync(project, check=True, fabric_root=fabric_root)
+    assert result.drift == []
+    assert result.written == []
+
+
+def test_check_detects_drift(project: Path, fabric_root: Path) -> None:
+    sync(project, fabric_root=fabric_root)
+    edited = _skill_path(project, "plan-exec")
+    edited.write_text(edited.read_text() + "MANUAL EDIT\n")
+
+    result = sync(project, check=True, fabric_root=fabric_root)
+    assert len(result.drift) == 1
+    assert result.drift[0].name == "plan-exec"
+    assert "MANUAL EDIT" in result.drift[0].actual
+    assert "MANUAL EDIT" not in result.drift[0].expected
+
+
+def test_check_does_not_write(project: Path, fabric_root: Path) -> None:
+    skills_dir = project / ".claude" / "skills"
+    assert not skills_dir.exists()
+    result = sync(project, check=True, fabric_root=fabric_root)
+    # Drift = "all of them missing"
+    assert {d.name for d in result.drift} == set(SKILL_NAMES)
+    assert not skills_dir.exists()
+
+
+def test_drift_unified_diff_includes_paths(project: Path, fabric_root: Path) -> None:
+    sync(project, fabric_root=fabric_root)
+    edited = _skill_path(project, "plan-exec")
+    edited.write_text("totally different\n")
+
+    result = sync(project, check=True, fabric_root=fabric_root)
+    diff = result.drift[0].unified_diff(project)
+    assert "plan-exec" in diff
+    assert "totally different" in diff
+
+
+def test_sync_rejects_invalid_config(tmp_path: Path, fabric_root: Path) -> None:
+    project = tmp_path / "bad"
+    fabric_dir = project / ".fabric"
+    fabric_dir.mkdir(parents=True)
+    (fabric_dir / "config.yaml").write_text("project:\n  name: x\n  repo: invalid\n")
+    with pytest.raises(SyncError):
+        sync(project, fabric_root=fabric_root)
+
+
+def test_sync_rejects_missing_project(tmp_path: Path, fabric_root: Path) -> None:
+    with pytest.raises(SyncError):
+        sync(tmp_path / "nope", fabric_root=fabric_root)
+
+
+def test_resolve_project_by_path(tmp_path: Path) -> None:
+    p = tmp_path / "real"
+    p.mkdir()
+    assert resolve_project(str(p)) == p.resolve()
+
+
+def test_resolve_project_by_registered_name(
+    isolated_fabric_home: Path, project: Path
+) -> None:
+    register(project)
+    assert resolve_project("teach-me-eng-bot") == project.resolve()
+
+
+def test_resolve_project_unknown_raises(isolated_fabric_home: Path) -> None:
+    with pytest.raises(SyncError, match="not found"):
+        resolve_project("definitely-not-a-project")


### PR DESCRIPTION
## Summary

Second milestone of #1. Adds the rendering pipeline so a project's `.fabric/config.yaml` produces committed `.claude/skills/<name>/SKILL.md` files.

- **`fabric/render.py`** — Jinja2 env (`StrictUndefined`, autoescape off, `keep_trailing_newline=True`). `render_skill(name, project_path, config, fabric_root=...)`. Overlay resolution: `<project>/.fabric/skills/<name>/SKILL.md.j2` beats `<fabric_root>/skill_templates/<name>/SKILL.md.j2`. `fabric_root` is injectable so tests don't depend on the bundled placeholders.
- **`fabric/sync.py`** — `sync(project, *, check=False, fabric_root=None) -> SyncResult`. Iterates the 5 fabric-shipped skills, writes (or compares) each. `SkillDrift.unified_diff()` for human-readable diff output. `resolve_project()` tries the registry name first, falls back to a filesystem path.
- **CLI** — `fabric sync <project> [--check]` is real now. Exit codes documented in the help: 0 clean / wrote files, 1 drift (with `--check`), 2 error (config invalid, project not found, template missing).
- **Placeholder skill templates** — 5 minimal `.j2` files under `skill_templates/`. Each exercises a different slice of the config (project, build, modules, labels+safety, pipeline) so the renderer is meaningfully tested. Real teach-me-eng-bot-derived content lands in #7.

## Test plan

- [x] `pytest -q` → 41 passed.
- [x] Render tests: default-vs-overlay precedence, overlay scoped to one skill, missing template → `RenderError`, undefined variable in overlay → `RenderError`, every default template renders, trailing newline preserved.
- [x] Sync tests: writes all 5 skills, idempotent (no rewrite when on disk matches), `--check` clean returns no drift, `--check` detects manual edits, `--check` does not write to disk, unified diff includes path, invalid config → `SyncError`, missing project dir → `SyncError`.
- [x] Resolve tests: by path, by registered name, unknown name raises.
- [x] CLI tests via typer's `CliRunner`: exit 0 on write, exit 0 on clean check, exit 1 on drift check (with skill name in output), exit 2 on invalid config, exit 2 on unknown project.
- [x] End-to-end walk against a temp project: `sync` → 5 written → `sync --check` clean → manual edit → `sync --check` shows unified diff and exits 1.
- [ ] Real `fabric sync teach-me-eng-bot` deferred — teach-me-eng-bot won't have `.fabric/config.yaml` until #7.

## Out of scope

- Real skill content → #7 (Phase 0C).
- Drift CI workflow template → #8 (Phase 0D).

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)