### PR TITLE
feat: phase 0C teach-me-eng-bot template parity

### DIFF
--- a/examples/teach-me-eng-bot.config.yaml
+++ b/examples/teach-me-eng-bot.config.yaml
@@ -1,0 +1,64 @@
+# Example .fabric/config.yaml for teach-me-eng-bot.
+#
+# When this file lives at <teach-me-eng-bot>/.fabric/config.yaml,
+# `fabric sync teach-me-eng-bot` reproduces the project's current
+# .claude/skills/{plan-exec,test-writer,review-pr,clarify-issue,epic-decompose}/SKILL.md
+# byte-for-byte. dev-flow/ is project-internal and not touched by sync.
+
+project:
+  name: teach-me-eng-bot
+  repo: valdisd96/teach-me-eng-bot
+  trusted_authors: [valdisd96]
+
+build:
+  setup_cmd: "source .venv/bin/activate"
+  test_cmd: "python -m pytest -q"
+  lint_cmd: null
+
+modules:
+  - path: bot.py
+    role: "python-telegram-bot wiring + handlers + scheduler bootstrap"
+  - path: vocab.py
+    role: "vocab CRUD, mention scanning, FSRS rating, weighted-random select_word"
+  - path: scheduler.py
+    role: "push planning + APScheduler runner"
+  - path: llm.py
+    role: "Anthropic SSE wrapper + prompt assembly"
+  - path: translator.py
+    role: "EN/RU translation for /translate"
+  - path: db.py
+    role: "SQLite schema + migrations"
+  - path: config_flow.py
+    role: "/start onboarding state machine"
+  - path: prompts.py
+    role: "Anthropic prompt templates"
+  - path: sysinfo.py
+    role: "/status diagnostic output"
+
+safety:
+  blocked_paths:
+    - .github/workflows/**
+    - teach-me-eng-bot.service
+    - install-service.sh
+  destructive_db_patterns:
+    - "DROP COLUMN"
+    - "DROP TABLE"
+    - "ALTER COLUMN .* DROP"
+  notes: |
+    db.py migrations may add columns but never drop. FSRS columns
+    (stability, difficulty, state, step, due, reps, lapses, last_review)
+    are load-bearing and must not be touched.
+
+labels:
+  state_prefix: "state:"
+  type_prefix: "type:"
+  area_prefix: "area:"
+  area_labels: [bot, vocab, scheduler, llm, translator, config, db]
+
+pipeline:
+  cycle_limit: 5
+  retry_count: 3
+  retry_backoff_seconds: [60, 300, 900]
+  daily_dispatch_cap: 30
+
+fabric_version: "0.0.1"

--- a/skill_templates/clarify-issue/SKILL.md.j2
+++ b/skill_templates/clarify-issue/SKILL.md.j2
@@ -1,9 +1,72 @@
 ---
 name: clarify-issue
-description: PLACEHOLDER for {{ project.name }} — real template lands in Phase 0C (#7).
-version: 0.0.1
+description: Use this skill when, partway through working on a GitHub issue, you hit genuine ambiguity that you cannot resolve from the body, the codebase, or `dev-flow` rules. Posts a focused question as an issue comment, flips the state label to `state:clarification-needed`, and stops work on the issue. Do not invoke for self-resolvable uncertainty.
+version: 1.0.0
 ---
 
-# clarify-issue — placeholder
+# clarify-issue
 
-For the `{{ project.name }}` project.
+A worker agent's escape hatch when an issue's body is missing a load-bearing decision. Posts the specific question, parks the issue, and stops.
+
+## When to invoke
+
+You are mid-implementation on issue #N and one of these is true:
+- The issue body is silent on a behaviour choice that materially changes the diff (e.g. "should the new field be nullable?", "default tone for new chats — funny or mixed?").
+- Two reasonable interpretations of the body lead to different module changes.
+- A constraint in the codebase (e.g. existing schema, an FSRS invariant) collides with what the body asks for.
+
+## When **not** to invoke
+
+- You can resolve the question by reading more code, the plan doc, or `CLAUDE.md`. Read first; clarify only if those are silent too.
+- You are uncertain about a small naming choice. Pick one and proceed; the user can rename in review if they care.
+- You haven't started yet. If the body is unclear before you begin, ask the user in chat — don't post an issue comment for the planning round.
+
+The bar is: *would another reasonable agent make a different decision here, and would that decision survive into a different PR shape?*
+
+## The flow
+
+### 1. Frame the question precisely
+
+Bad: "I'm not sure about the design."
+Good: "Should `/resetvocab` also clear `push_log` for that chat, or only `words`?"
+
+One question is best. Two if they're tightly coupled. Never a list of vague items.
+
+### 2. Post it as an issue comment
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+**Clarification needed before proceeding**
+
+<the precise question>
+
+Context: <one sentence — what you've already decided, what's left>.
+Proceeding once labelled back to `state:in-progress`.
+EOF
+)"
+```
+
+### 3. Flip the state label
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:clarification-needed"
+```
+
+### 4. Stop
+
+Do **not** keep coding speculatively while waiting. Do **not** open the PR. Do **not** push the branch yet — your in-progress work stays local. Tell the user, in one sentence, what you posted and that you're paused.
+
+## After the user answers
+
+When the user answers (in chat or by editing the issue) and tells you to resume:
+1. Flip the label back: `--remove-label "state:clarification-needed" --add-label "state:in-progress"`.
+2. Resume from where you stopped. Do not re-run earlier steps that already succeeded.
+
+## Hard rules
+
+- **Don't** close the issue.
+- **Don't** convert the issue to a draft / change its title.
+- **Don't** open multiple clarification comments on the same issue without the user's input — if you have a follow-up, reply to your own comment as a thread.
+- **Don't** apply `state:clarification-needed` if the issue isn't already `state:in-progress` (you shouldn't be working on it in that case).

--- a/skill_templates/epic-decompose/SKILL.md.j2
+++ b/skill_templates/epic-decompose/SKILL.md.j2
@@ -1,9 +1,207 @@
 ---
 name: epic-decompose
-description: PLACEHOLDER — real template lands in Phase 0C (#7).
-version: 0.0.1
+description: Pre-Stage-1 skill for issues labelled `type:epic`. Runs headless from `scripts/agent-epic-decompose.sh` on a single epic and decomposes it into a set of child issues that the regular plan-exec → test-writer → reviewer pipeline can ship. Multi-round Socratic Q&A with the user across many invocations (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files the children with `Refs #<parent>`, and parks the parent at `state:tracking`. Does NOT cut branches, write code, or open PRs.
+version: 1.0.0
 ---
 
-# epic-decompose — placeholder
+# epic-decompose
 
-Cycle limit: `{{ pipeline.cycle_limit }}`.
+Decomposition stage for big features. Splits a `type:epic` parent issue into smaller child issues that the existing pipeline can ship one at a time. One agent invocation = one round; a full decomposition typically spans several Q&A rounds before a proposal is approved.
+
+## Hard boundaries
+
+You MAY:
+- `gh issue view`, `gh issue list`, `gh issue create` (file children).
+- `gh issue comment`, `gh issue edit` (labels) on the parent.
+- Read code to ground your understanding of where the change would land.
+
+You MUST NOT:
+- Edit code, create branches, commit, push, or open PRs. Decomposition is research and planning only — implementation belongs to plan-exec on each *child* issue.
+- Decompose anything that is **not** labelled `type:epic`. Bounce back to plan-exec if you were dispatched on the wrong issue.
+- File child issues until the user has explicitly approved your latest proposal with the `/decompose-ok` magic phrase.
+
+## Inputs and exit conditions
+
+Dispatched at one of two states:
+- `state:needs-planning` — the entry/resume state. Either the first round, or the user resumed after a clarification answer or feedback on a proposal.
+- `state:awaiting-decompose-approval` — defensive; the runner script accepts this too. In practice the user flips back to `needs-planning` when they want the next dispatch to act.
+
+Exits the run by flipping to one of:
+- `state:clarification-needed` — you posted a question, awaiting answer.
+- `state:awaiting-decompose-approval` — you posted a proposed child list, awaiting `/decompose-ok`.
+- `state:tracking` — children filed, parent now waits for them to merge.
+- `state:blocked` — round cap exhausted or unresolvable error (rare).
+
+## The decision tree (do this every dispatch)
+
+Read the issue body and **all** comments. Then walk this tree top-down — first match wins:
+
+1. **Approval detected.** A user comment that contains `/decompose-ok` exists and is dated *after* your most recent `<!-- agent-decompose v1 -->` proposal comment.
+   → File the children (see §4), flip to `state:tracking`, exit.
+
+2. **Round cap hit.** You've already posted ≥ 8 `<!-- agent-decompose-q v1 -->` question comments.
+   → Force a proposal anyway, but tag it `**Confidence: low — round cap reached.**` (see §3 with the tag added), flip to `state:awaiting-decompose-approval`, exit.
+
+3. **Ready to propose.** You have enough information to draft a credible child-issue list — every must-answer question from §5 has either been answered or is genuinely deferrable.
+   → Post the proposal (see §3), flip to `state:awaiting-decompose-approval`, exit.
+
+4. **Need more information.** Default branch.
+   → Post one focused question (see §2), flip to `state:clarification-needed`, exit.
+
+**Bias toward more questions, not fewer.** The cost of a wrong cut-line is multiple ill-shaped child issues. The cost of one extra Q&A round is one tick. Err on the side of asking.
+
+## 1. First step on every dispatch — flip to in-progress
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:needs-planning,state:awaiting-decompose-approval" \
+  --add-label "state:in-progress"
+```
+
+`gh` ignores `--remove-label` for labels that aren't present, so the same command works from either entry state.
+
+## 2. Question round
+
+One question per round. The single most load-bearing unknown — what would change the *shape* of the decomposition if answered the other way.
+
+Bad: "What are your thoughts on the architecture?"
+Good: "Should the part-of-speech classifier run at `/add` time (one-shot, stored on the row) or lazily on first push (cached)? The two paths split the work very differently."
+
+Marker `<!-- agent-decompose-q v1 -->` is mandatory — the round counter and future dispatches read it.
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-decompose-q v1 -->
+**Decomposition question (round <K> of up to 8)**
+
+<the precise question>
+
+Context: <one sentence — what you've already concluded, what depends on this>.
+
+When you answer, flip the label back to `state:needs-planning` to re-enter the loop.
+EOF
+)"
+```
+
+Then flip the state and exit:
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:clarification-needed"
+```
+
+Print `paused at round <K>: clarification posted` and stop. Do not propose in the same round you ask.
+
+## 3. Propose round
+
+A proposal is a complete, dependency-ordered child list. Every child should be small enough that plan-exec can ship it as one focused PR (~300 LOC, one area), with crisp acceptance criteria.
+
+Marker `<!-- agent-decompose v1 -->` is mandatory.
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-decompose v1 -->
+## Proposed decomposition for #<N>
+
+**Confidence:** high | medium | low — round cap reached (use this tag if you hit §H2).
+
+**One-line shape:** <how the children fit together>.
+
+### Child 1 — <imperative title>
+- **Labels:** `type:feat`, `priority:high`, `area:vocab`
+- **Goal:** <one sentence>
+- **Acceptance criteria:**
+  - AC1: <given X, when Y, then Z>
+  - AC2: <invariant>
+- **Depends on:** none (or "child #2 must merge first")
+- **Out of scope:** <what is explicitly NOT in this child>
+
+### Child 2 — ...
+
+---
+
+**Reply `/decompose-ok` to approve.** Then flip `state:awaiting-decompose-approval` → `state:needs-planning` and the next dispatch will file these as child issues. To request changes, comment your feedback and flip back to `state:needs-planning` — I'll revise.
+EOF
+)"
+```
+
+Then:
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:awaiting-decompose-approval"
+```
+
+Print `proposal posted: <N> children, awaiting approval` and exit.
+
+**Sizing rule of thumb.** Aim for 3–8 children. Fewer than 3 → not really an epic; suggest just unlabelling `type:epic` and letting plan-exec handle it. More than 8 → either the epic is too big to plan in one pass (suggest splitting the epic itself), or you're slicing too thin (consolidate).
+
+## 4. File-children round (after `/decompose-ok`)
+
+Triggered when §A1 of the decision tree matches. For each child in the most recent proposal, in the order you listed them:
+
+```bash
+gh issue create \
+  --title "<imperative title>" \
+  --label "type:feat,priority:medium,area:vocab,state:needs-planning" \
+  --body "$(cat <<EOF
+<one-paragraph problem statement, lifted from the proposal>
+
+## Acceptance criteria
+- AC1: ...
+- AC2: ...
+
+## Out of scope
+- ...
+
+Part of epic #<N>.
+Refs #<N>
+EOF
+)"
+```
+
+Capture each new issue number from the URL `gh issue create` prints. Then post one closing comment on the parent that lists the child links and flip to `state:tracking`:
+
+```bash
+gh issue comment <N> --body "$(cat <<EOF
+<!-- agent-decompose-filed v1 -->
+**Decomposition filed.** Children:
+
+- #<C1> — <title>
+- #<C2> — <title>
+- ...
+
+Parent will auto-close once all children are closed (orchestrator coordinator).
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:tracking"
+```
+
+Print `filed <K> children for epic #<N>: <numbers>` and exit.
+
+> **Coordinator caveat:** the auto-close-on-children-done coordinator lives in the orchestrator (separate increment). Until that ships, the parent stays at `state:tracking` and the user closes it manually after all children merge. Mention this in the closing comment if the orchestrator is not yet deployed.
+
+## 5. What "must-answer" questions look like for an epic
+
+A non-exhaustive checklist of the kinds of unknowns to clear before proposing. Walk through these mentally on every Q-round and pick the most load-bearing unanswered one:
+
+- **Scope edges.** What is explicitly *not* in scope for this epic? (Without this you'll over-decompose.)
+- **Storage shape.** New tables / columns? Migration concerns?
+- **User-facing surface.** New slash commands? Inline UI? `/start` flow changes?
+- **Dependency order.** What must merge before what? Are any children blockers vs leaves?
+- **Integration points.** Does this touch the LLM call site, the scheduler, the translator, the FSRS state machine?
+- **Test seams.** Anything that needs a refactor *first* to be testable, before the feature children land?
+- **External services / config.** New env vars? New API keys? Quotas?
+- **Naming.** Names of new commands, modules, labels — pick *or* ask.
+
+## After-the-loop notes
+
+- **You don't run plan-exec on the parent.** Once children are filed, the parent's job is over. plan-exec will be dispatched separately on each child by the normal pipeline.
+- **Don't overlap with `clarify-issue`.** That skill is for *implementation* clarifications during plan-exec; epic-decompose has its own Q&A flow with its own marker so the two histories don't tangle.
+- **Don't cycle past 8 questions** without forcing a proposal. The round cap exists so an over-cautious agent can't deadlock the epic.
+- **One commit-style discipline.** Every child issue's acceptance criteria should map cleanly to tests in test-writer's spec format (numbered, behavioural, not implementation). Test-writer reads only the AC block — sloppy ACs here become sloppy tests downstream.

--- a/skill_templates/plan-exec/SKILL.md.j2
+++ b/skill_templates/plan-exec/SKILL.md.j2
@@ -1,12 +1,238 @@
 ---
 name: plan-exec
-description: PLACEHOLDER for {{ project.name }} — real template lands in Phase 0C (#7).
-version: 0.0.1
+description: Stage 1 of the autonomous pipeline. Runs headless from scripts/agent-plan-exec.sh on a single GitHub issue that is unlabelled (fresh) or at state:needs-planning or state:needs-rework. Reads the issue + any prior PR review comments, decides whether user input is needed (invoke clarify-issue if so), then follows dev-flow to cut a branch, post a `<!-- agent-plan v1 -->` comment that pairs intent with a behavioural spec, implement the change, smoke-test, and commit. Does NOT push, does NOT open a PR — those are Stage 2 (test-writer). Hands off by flipping the label to state:tests-pending.
+version: 1.2.0
 ---
 
-# plan-exec — placeholder
+# plan-exec
 
-Project: `{{ project.name }}` ({{ project.repo }}).
-Test command: `{{ build.test_cmd }}`.
+Stage 1 of the issue → merged pipeline (see `workflow.md`). One Claude session, plan + implement combined. Expects to be invoked headless via `scripts/agent-plan-exec.sh <issue#>` — no human is in the loop.
 
-This file is rendered by `fabric sync`. Edit `skill_templates/plan-exec/SKILL.md.j2` in the fabric, not the rendered output.
+## Hard boundaries
+
+You MAY:
+- Read code, edit code, write new files.
+- `git checkout`, `git branch`, `git commit` (locally only).
+- Run `pytest` for smoke checks.
+- Comment on the issue (`gh issue comment`).
+- Flip issue labels (`gh issue edit`).
+
+You MUST NOT:
+- `git push` — that's Stage 2 (test-writer).
+- `gh pr create` / `gh pr edit` — Stage 2.
+- `gh pr merge` — Stage 3 (reviewer).
+- `gh issue close` — happens automatically when the reviewer merges (via `Closes #N` in the PR body).
+
+## The flow
+
+### 1. Read everything
+
+```bash
+gh issue view <N> --json number,title,body,labels,author,comments
+```
+
+If the issue is at `state:needs-rework`, also fetch the PR's review comments — they're the spec for this cycle:
+
+```bash
+PR=$(gh pr list --search "Closes #<N>" --state all --json number -q '.[0].number')
+[[ -n "$PR" ]] && gh pr view "$PR" --json comments,reviews,headRefName
+```
+
+### 2. Verify state and flip to in-progress
+
+The valid starting states are:
+- **unlabelled** — fresh issue, never picked up. Treat exactly like `state:needs-planning`. The runner script accepts this as the equivalent of "fresh".
+- `state:needs-planning` — explicitly labelled fresh.
+- `state:needs-rework` — coming back from a Stage-2 bounce or Stage-3 rejection.
+
+The runner script enforces these are the only inputs; double-check anyway. Flip to in-progress:
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:needs-planning,state:needs-rework" \
+  --add-label "state:in-progress"
+```
+
+`gh` silently ignores `--remove-label` for labels not present, so the same command works whether the issue was unlabelled, `state:needs-planning`, or `state:needs-rework`.
+
+### 3. Decide: clarify or proceed?
+
+Invoke `clarify-issue` only when:
+- The body is silent on a behaviour choice that **materially changes the diff** (e.g. "should the new field be nullable?").
+- Two reasonable interpretations of the body lead to different module changes.
+- The change is too large for one focused PR (~300 LOC, one area). Ask the user to split.
+- A code constraint collides with what the body asks for (existing schema, FSRS invariant, etc.).
+
+Do NOT clarify for:
+- Naming choices — pick what matches the codebase.
+- Small implementation details — make the most reasonable call.
+- Anything answerable by reading more code or `CLAUDE.md`.
+
+The bar: *would another reasonable agent make a different decision here that would survive into a different PR shape?*
+
+### 4. Branch
+
+**First cycle (`state:needs-planning`):**
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b <type>/<topic>
+```
+
+`<type>` comes from the `type:*` label (`feat` / `fix` / `chore` / `refactor`). If absent, infer from the change kind and add the label:
+
+```bash
+gh issue edit <N> --add-label "type:fix"
+```
+
+`<topic>` is a kebab-case summary of the issue title, ~3–5 words.
+
+**Rework cycle (`state:needs-rework`):**
+
+```bash
+BRANCH=$(gh pr view "$PR" --json headRefName -q '.headRefName')
+git fetch origin "$BRANCH"
+git checkout "$BRANCH" && git pull --ff-only
+```
+
+### 5. Apply missing labels
+
+The issue should carry `type:*`, `priority:*`, and ideally `area:*`. Add what's missing:
+
+- `priority:medium` is the default if absent.
+- `area:*` matches the modules you'll touch.
+
+```bash
+gh issue edit <N> --add-label "<comma,separated,labels>"
+```
+
+### 6. Post the plan + behavioural spec
+
+Before writing any code, post a single issue comment with two halves:
+
+- **Plan** — your reasoning. Stage 2 reads it for orientation; Stage 3 deliberately ignores it.
+- **Behavioral spec** — the contract Stage 2 derives every test from. Test-writer is spec-driven and is forbidden from reading function bodies, so this section is its only input. A vague spec produces vague tests; an absent spec bounces the issue back to you.
+
+The comment **must** start with the marker line `<!-- agent-plan v1 -->`. The marker is what test-writer searches for and what review-pr filters out.
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-plan v1 -->
+## Plan
+
+**Goal:** <one-sentence restatement of what the issue asks>
+
+**Approach:** <one paragraph: where the change lives, why this shape over alternatives>
+
+**Files to change:**
+- `<path>` — <what changes there>
+- ...
+
+**Out of scope:** <anything explicit you are NOT doing this cycle, if relevant>
+
+## Behavioral spec
+
+**Public API** (signatures and types only — no bodies):
+- `module.func(arg: Type, ...) -> ReturnType` — one-line purpose
+- raises `ExceptionType` when ...
+
+**Acceptance criteria** (numbered; tests cite these IDs):
+- AC1: <given X, when Y, then Z>
+- AC2: <invariant — never observe state where ...>
+
+**Edge cases:**
+- empty / single / many / boundary (max, off-by-one)
+- null / missing / malformed input
+- unicode, whitespace, leading-trailing
+
+**Error conditions:**
+- <input> → <exception type / failure mode>
+
+**Examples** (input → output pairs):
+- f("") → ...
+EOF
+)"
+```
+
+Length guide: Plan half ≤ 15 lines, Behavioral spec half ≤ 25 lines. A plan that reads like a transcript is useless; a spec that hand-waves is worse. Enumerate edge cases — empty / single / many / boundary / null / unicode — before writing a line of code, even if some end up not applying.
+
+**Cosmetic / refactor escape hatch.** When the diff genuinely changes no behaviour (docstring tweaks, comment fixes, whitespace, a no-op rename), replace the entire Behavioral spec block with the single line `**Behavioral spec:** none — cosmetic / refactor only.`. Test-writer treats that line as authoritative permission to skip test creation. Do not abuse this — if there is any new code path, the full spec is mandatory.
+
+On rework cycles post a *new* comment (do not edit prior ones); test-writer reads the latest, and the older plans stay as history.
+
+### 7. Implement
+
+Follow the `dev-flow` skill. Specifically:
+- Keep the diff focused on this issue's scope.
+- Match the project's module layout — `bot.py` is wiring; logic lives in `vocab.py`, `llm.py`, `scheduler.py`, etc.
+- Keep helpers pure and injectable. Test seams matter for Stage 2.
+- Update `.env.example` and the env table in `CLAUDE.md` if you add a new variable.
+- If you add, rename, or remove a slash command, update `COMMANDS` in `bot.py` (drives `/help` and Telegram's `set_my_commands`), the `HELP_TEXT` getting-started prose if user flow changes, and the `CLAUDE.md` Bot commands table — otherwise the feature is invisible in the bot UI.
+
+**Do NOT write tests yourself.** Stage 2 (test-writer) writes the tests in a fresh session. You write the implementation only. The exception: if existing tests need updating because behaviour legitimately changed, update them as part of your commit.
+
+### 8. Smoke check
+
+Before committing, prove the code at least compiles and existing tests still pass:
+
+```bash
+python -m py_compile $(git diff --name-only main -- '*.py')
+{% if build.setup_cmd %}{{ build.setup_cmd }} && {% endif %}{{ build.test_cmd }}
+```
+
+If existing tests now fail, fix the code (not the tests) until the suite is green. New-code-path coverage is Stage 2's job, not yours.
+
+### 9. Commit
+
+One focused commit. Subject ≤ 70 chars, imperative mood. Body explains the why. End the body with `Refs #<N>` (not `Closes #<N>` — Stage 2's PR carries the closer).
+
+```bash
+git add <changed-files>
+git commit -m "$(cat <<'EOF'
+<imperative subject>
+
+<one-paragraph why>
+
+Refs #<N>
+EOF
+)"
+```
+
+Don't `git add -A` or `git add .` — name the files you changed to avoid pulling in stray local artefacts.
+
+### 10. Hand off
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:in-progress" \
+  --add-label "state:tests-pending"
+```
+
+Print one summary line and exit:
+
+```
+done: <branch-name> at <short-sha>, ready for test-writer
+```
+
+## Rework specifics
+
+When invoked at `state:needs-rework`:
+- The PR is already open. The branch is on origin. Make new commits, **don't amend** earlier ones — the test-writer will push them as the PR's next push.
+- Treat the reviewer's comments + the original issue body together as the spec. If they conflict, that's a `clarify-issue` case — the user resolves.
+- Don't open a new PR. The existing one picks up your commits when Stage 2 pushes.
+
+## Escalating to state:blocked
+
+You generally don't set `state:blocked` — that's reserved for the orchestrator (cycle limit) and the reviewer (safety triggers). The exception: the issue requests something genuinely impossible (referenced model/file/API doesn't exist).
+
+```bash
+gh issue comment <N> --body "Cannot proceed: <reason>"
+gh issue edit <N> --remove-label "state:in-progress" --add-label "state:blocked"
+```
+
+## What "done" looks like
+
+- A branch with one new commit on it.
+- Smoke tests pass on that commit.
+- Issue is at `state:tests-pending`.
+- No `git push`. No PR. No merge.

--- a/skill_templates/review-pr/SKILL.md.j2
+++ b/skill_templates/review-pr/SKILL.md.j2
@@ -1,13 +1,170 @@
 ---
 name: review-pr
-description: PLACEHOLDER — real template lands in Phase 0C (#7).
-version: 0.0.1
+description: Stage 3 of the autonomous pipeline. FRESH session. Invoked headlessly by scripts/agent-review.sh against an issue at state:in-review. Reads the issue body + human Q&A comments + full PR diff (incl tests). Deliberately ignores `<!-- agent-plan v1 -->` comments — those are plan-exec's stated intent, and reviewing against intent biases the verdict toward "did the agent do what it said" instead of "does the diff solve the issue." Re-runs pytest as the merge gate. Outcomes are exactly one of three branches — APPROVE (gh pr merge --squash --delete-branch; the issue auto-closes via Closes #N), REJECT (gh pr review --request-changes with specific comments + flip issue to state:needs-rework), or BLOCK (flip to state:blocked + comment why; never merge). Block triggers are explicit in the safety checklist — secrets, CI tampering, schema risk, suspicious deps, service files, scope drift big enough to look like a different change.
+version: 1.1.0
 ---
 
-# review-pr — placeholder
+# review-pr
 
-State labels are prefixed `{{ labels.state_prefix }}`.
+Stage 3 of the issue → merged pipeline (`workflow.md`). FRESH session. You are the last line of defense before code lands on `main` — the orchestrator merges based on your verdict.
 
-Blocked paths (must not be modified):
-{% for p in safety.blocked_paths %}- `{{ p }}`
-{% endfor %}
+## Hard boundaries
+
+You MAY:
+- Read code, tests, the issue body, comments, the PR diff.
+- Run `pytest` (the merge gate).
+- `gh pr view` / `gh pr diff` / `gh pr review`.
+- `gh pr merge --squash --delete-branch` (only on APPROVE).
+- `gh issue comment` and `gh issue edit` (label flips).
+
+You MUST NOT:
+- Edit, write, or create any file outside `logs/`.
+- `git commit` or `git push` anything.
+- Open a new PR. Switch branches arbitrarily.
+- Approve when pytest is red.
+- Approve when the safety checklist trips.
+- Re-run a stage's work (you are not Stage 1 or 2).
+
+## The flow
+
+### 1. Resolve the PR for the issue
+
+```bash
+PR=$(gh pr list --search "Closes #<N>" --state open --json number -q '.[0].number // ""')
+if [[ -z "$PR" ]]; then
+    echo "no open PR found for issue #<N>" >&2
+    exit 1
+fi
+```
+
+If multiple open PRs reference the issue, that's a bug — comment on the issue, flip to `state:blocked`, and exit. Do not merge any of them.
+
+### 2. Read everything
+
+Read the issue body + human Q&A comments + PR title/body + full diff. **Filter out any comment whose body starts with `<!-- agent-plan`** — those are plan-exec's stated intent, not human Q&A. Reading them biases the review toward "did the agent do what it said it would" instead of "does the diff actually solve the issue."
+
+```bash
+gh issue view <N> --json title,body,comments \
+  --jq '{title, body, comments: [.comments[] | select((.body | startswith("<!-- agent-plan")) | not)]}'
+gh pr view "$PR" --json title,body,headRefName,baseRefName,additions,deletions,changedFiles
+gh pr diff "$PR"
+```
+
+Capture: the issue's intent (body + clarification Q&A only), what the PR claims to do (title + body), and the full diff.
+
+### 3. Switch to the PR branch and re-run pytest
+
+```bash
+BRANCH=$(gh pr view "$PR" --json headRefName -q '.headRefName')
+git fetch origin "$BRANCH"
+git checkout "$BRANCH" && git pull --ff-only
+{% if build.setup_cmd %}{{ build.setup_cmd }} && {% endif %}{{ build.test_cmd }}
+```
+
+If pytest is **red**, this is an automatic REJECT — Stage 2 should not have pushed red. Skip to step 5 (REJECT) with the failure as the rework reason.
+
+### 4. Run the safety checklist
+
+For each trigger below, scan the diff. Any single hit → BLOCK (skip to step 6). Multiple unrelated triggers → still BLOCK; one comment listing all of them.
+
+- **Secrets / credentials.** API keys, OAuth tokens, passwords, `Bearer` headers with literal values, JWT tokens, `.pem` keys, hard-coded `.env` values. Look for high-entropy strings ≥ 20 chars in non-test code, `Authorization: ` headers in code, anything matching `[A-Za-z0-9_-]{40,}` adjacent to `key`/`token`/`secret`. False positives are acceptable cost — block and let the user clear.
+- **CI / workflow tampering.** Any change under `.github/workflows/**`. New action that fetches arbitrary URLs, disables a check, alters `permissions:` block, or adds a new secret reference. Block on any non-trivial change here; tiny changes (e.g. version bump in an existing pinned action) are still worth a human eye.
+- **Schema / data-loss risk.** Changes to `db.py` that drop columns, alter primary keys, change foreign-key cascades, or modify FSRS columns (`stability`, `difficulty`, `state`, `step`, `due`, `reps`, `lapses`, `last_review`). Adding a column is fine; removing or rewriting one is not.
+- **Dependency additions.** New entries in `requirements.txt`. Verify the package name is the canonical one (no typo-squatting — e.g. `python-telegrm-bot` is wrong). Verify version pinning is present. If unfamiliar, block and ask the user to vet.
+- **Service / install scripts.** Any change to `teach-me-eng-bot.service` or `install-service.sh`. These run on the live host; humans should eyeball.
+- **Scope drift.** PR diff is materially larger than the issue body suggests, OR touches modules unrelated to the issue. Examples: issue says "fix typo in /help text" but PR refactors three modules. This is REJECT (rework, scope reduction), not BLOCK — unless the unrelated changes themselves trip a safety trigger.
+
+### 5. Run the quality checklist
+
+These are REJECT conditions (recoverable rework, not block):
+
+- **Test coverage.** New code paths in non-test files without corresponding test additions. Exception: pure docstring/comment/whitespace changes; rename of a private helper; doc-only edits.
+- **`dev-flow` compliance.** Branch prefix matches the issue's `type:*` label. New env-var added to `.env.example` and the env table in `CLAUDE.md`. No new comments that just narrate what well-named code already says.
+- **Issue scope.** PR addresses what the issue actually asked for. Cross-reference the issue body's exit criteria (if any) against the diff's behaviour.
+- **Module conventions.** Logic lives in `vocab.py`/`llm.py`/`scheduler.py`/etc., not in `bot.py`. Pure helpers don't open HTTP clients or hit SQLite — they take dependencies as arguments. (See `compute_weight`, `plan_push_times`, `_parse_sse_delta` for the pattern.)
+- **Test quality.** New tests actually exercise the new behaviour (would fail without the change). No tests that just call the function and `assert True`.
+
+### 6. Decide the outcome — exactly one of three
+
+#### APPROVE — merge
+
+```bash
+gh pr review "$PR" --approve --body "Stage 3 review passed. Merging."
+gh pr merge "$PR" --squash --delete-branch
+gh issue edit <N> --remove-label "state:in-review"
+```
+
+The squash-merge closes the issue automatically (via `Closes #<N>` in the PR body). The label removal is belt-and-braces in case GitHub flakes.
+
+After merge, print: `merged: PR #<P> for issue #<N>; branch deleted`.
+
+#### REJECT — rework cycle
+
+```bash
+gh pr review "$PR" --request-changes --body "$(cat <<'EOF'
+**Stage 3 — needs-rework**
+
+<one-paragraph summary of what's wrong>
+
+Specifics:
+- <bullet 1: file:line — what to change and why>
+- <bullet 2>
+- ...
+
+Returning to plan-exec for the next cycle.
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:in-review" \
+  --add-label "state:needs-rework"
+```
+
+Print: `rework: PR #<P> bounced for issue #<N>`.
+
+#### BLOCK — needs human attention
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+**Stage 3 — blocked**
+
+Reviewer halted auto-merge for the following reason(s):
+
+- <trigger 1: file:line — concrete description, e.g. "API key literal in llm.py:42">
+- <trigger 2 if any>
+
+This needs a human to decide. Once resolved, re-label to \`state:in-review\` to retry, or to \`state:needs-rework\` to send back to plan-exec.
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:in-review" \
+  --add-label "state:blocked"
+```
+
+Do **not** also leave a PR review — block is for the user, not the bot. Print: `blocked: PR #<P> for issue #<N>; reason posted on issue`.
+
+### 7. Exit
+
+After whichever branch, exit. Do not loop.
+
+## How the three outcomes differ
+
+|  | APPROVE | REJECT | BLOCK |
+|---|---|---|---|
+| pytest | green | red OR green-but-flawed | green or red — orthogonal |
+| Safety checklist | clean | clean | tripped |
+| Quality checklist | clean | tripped | orthogonal |
+| Action | merge + delete branch | request-changes review + flip needs-rework | issue comment + flip blocked |
+| Pipeline next step | issue closed | plan-exec rework cycle | human |
+
+If two outcomes seem to apply (e.g. red pytest **and** secret in diff), choose **BLOCK** — it's the more conservative call, and the human resolution covers both issues.
+
+## What you must NOT do
+
+- Suggest code in a review comment when the right call is BLOCK or REJECT. You don't write code in this stage.
+- Approve a PR with red pytest "because the failure looks unrelated". Pytest is the gate; flakes are the user's problem to triage by re-running the script.
+- Re-run pytest more than once trying to get green. Flake-hunting belongs to plan-exec / test-writer, not Stage 3.
+- Leave the issue at `state:in-review` after deciding. Always flip exactly once.
+- Merge with a different strategy (`--merge` / `--rebase`). The pipeline assumes squash so each issue maps to one main commit.
+- **Read `<!-- agent-plan` comments.** Those are plan-exec's stated intent. Reviewing against intent rather than the diff biases the verdict — the reviewer's job is to judge what the code does against what the issue asked for, not to grade the implementer's plan adherence. Filter them out at the `gh issue view` step (see step 2).

--- a/skill_templates/test-writer/SKILL.md.j2
+++ b/skill_templates/test-writer/SKILL.md.j2
@@ -1,13 +1,265 @@
 ---
 name: test-writer
-description: PLACEHOLDER — real template lands in Phase 0C (#7).
-version: 0.0.1
+description: Stage 2 of the autonomous pipeline. FRESH session — spec-driven, not diff-driven. Invoked headlessly by scripts/agent-test-write.sh on a state:tests-pending issue. Locates the implementation branch left by plan-exec, reads the Behavioral spec block in the latest `<!-- agent-plan v1 -->` comment, lists public signatures from the diff (never bodies), outputs a test plan mapping each acceptance criterion to a test, writes tests that cite their AC IDs, runs pytest, and verifies AC traceability. On green commits the tests, pushes, opens or updates the PR with `Closes #<N>`, flips state:tests-pending → state:in-review. On red after confirming the failure traces back to a numbered AC, comments on the issue with the failure, flips to state:needs-rework, and leaves draft tests local-only. Bounces back if the spec block is missing. Never modifies code outside tests/.
+version: 1.2.0
 ---
 
-# test-writer — placeholder
+# test-writer
 
-Test command: `{{ build.test_cmd }}`
+Stage 2 of the issue → merged pipeline (`workflow.md`). FRESH session — you do not see plan-exec's reasoning live, only the **Behavioral spec** block it published in the latest `<!-- agent-plan v1 -->` comment. The point: test what the spec promises, not what the diff happens to do. Tests derived from implementation are coupled to implementation; tests derived from the spec survive refactors and catch drift.
 
-Modules in scope:
-{% for m in modules %}- `{{ m.path }}` — {{ m.role }}
-{% endfor %}
+## Hard boundaries
+
+You MAY:
+- Read the **Behavioral spec** block of the latest `<!-- agent-plan v1 -->` comment.
+- Read existing files under `tests/` (style, fixtures, mocking patterns).
+- Read public signatures from the diff (top-level `def` / `async def` / `class` lines, and signatures of changed methods). **Lines, not bodies.**
+- Read `CLAUDE.md`, `.env.example`, `requirements.txt`, `tests/conftest.py` for project conventions.
+- Edit / create files **inside `tests/`** only.
+- Run `pytest`.
+- `git add tests/...; git commit ...` (tests-only commits).
+- `git push` (only when tests are green).
+- `gh pr create` / `gh pr edit` (when tests are green).
+- Comment on the issue.
+- Flip issue labels.
+
+You MUST NOT:
+- Read function / method **bodies** of files outside `tests/`. The Behavioral spec is your only input for *what* to test; signatures are for *what symbols exist*. If the spec is missing or thin, bounce back — never recover by reading the implementation.
+- Infer behaviour from the diff. Drift between the spec and the diff is plan-exec's bug, not yours to paper over.
+- Edit any file outside `tests/`. If the code under test is wrong, that's plan-exec's job on the next cycle.
+- `gh pr merge` — Stage 3.
+- `gh issue close`.
+- `git push` when tests are red.
+- Add `Closes #<N>` to a PR that already exists for that issue (avoids dup-close warnings on merge).
+
+## The flow
+
+### 1. Locate the branch
+
+Try the PR first (rework cycles will have one open):
+
+```bash
+PR=$(gh pr list --search "Closes #<N>" --state open --json number -q '.[0].number // ""')
+if [[ -n "$PR" ]]; then
+    BRANCH=$(gh pr view "$PR" --json headRefName -q '.headRefName')
+else
+    # First cycle — plan-exec's local commit references the issue with `Refs #<N>`.
+    BRANCH=$(git log --all --grep="Refs #<N>" --format="%D" -1 \
+             | tr ',' '\n' | sed 's/^ *//' \
+             | grep -v '^HEAD' | grep -v '^origin/' \
+             | head -1)
+fi
+
+if [[ -z "$BRANCH" ]]; then
+    echo "could not locate branch for issue #<N>" >&2
+    exit 1
+fi
+
+git fetch origin "$BRANCH" 2>/dev/null || true
+git checkout "$BRANCH"
+```
+
+### 2. Read the Behavioral spec
+
+Fetch the **latest** `<!-- agent-plan v1 -->` comment (rework cycles append fresh ones) and extract its Behavioral spec block. This is your only authoritative input.
+
+```bash
+COMMENT=$(gh issue view <N> --json comments -q \
+  '[.comments[] | select(.body | startswith("<!-- agent-plan"))] | last | .body // ""')
+
+SPEC=$(printf '%s\n' "$COMMENT" | awk '/^## Behavioral spec/,0')
+```
+
+Branch on what you find:
+
+- **`**Behavioral spec:** none — cosmetic / refactor only.`** — plan-exec declared this diff is behaviour-free. Confirm via the signatures-only diff in step 3 that no new public symbols appear. If signatures *are* added, plan-exec was lying; bounce back. Otherwise skip to step 8 and push without a test commit.
+- **A populated spec block** — proceed to step 3.
+- **No spec block, or the block is empty / hand-wavy** (no numbered ACs, no edge cases, no error conditions) — bounce back. Test-writer is spec-driven; you do not infer the spec from the code. Comment template:
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+**Test-writer bounce-back**
+
+The latest \`<!-- agent-plan v1 -->\` comment lacks a usable **Behavioral spec** section (or it lacks numbered acceptance criteria, edge cases, and error conditions). Test-writer is spec-driven; without a contract to assert against, no tests can be derived.
+
+Returning to plan-exec to add the spec block per the plan-exec skill template.
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:tests-pending" \
+  --add-label "state:needs-rework"
+```
+
+Then **stop**. No push, no draft tests committed.
+
+### 3. List public signatures (no bodies)
+
+You may verify that the public API listed in the spec actually exists in the diff, and that no new public symbols are missing from the spec. Read **signatures only** — never function bodies.
+
+```bash
+git diff main...HEAD -U0 -- '*.py' ':!tests/' \
+  | grep -E '^\+\s*(def |async def |class )' \
+  | sed 's/^+//'
+```
+
+If the spec lists a symbol the diff does not define, or the diff defines a public symbol the spec omits, that is spec/code drift — bounce back. Do not paper over by writing tests for what you guess the symbol does.
+
+### 4. Output the test plan
+
+Before writing a single test, print a plan to stdout that maps each AC, each enumerated edge case, and each error condition to a named test. This is the spec → test traceability that gives the suite its value.
+
+```
+Test plan for issue #<N>:
+
+  test_<name>             # AC1 — <one-line restatement>
+  test_<name>             # AC2
+  test_<name>             # AC3, AC4 — combined (collapsing two ACs into one test is fine if explicit)
+  test_<name>             # edge: empty input
+  test_<name>             # edge: max boundary
+  test_<name>             # error: bad type → ValueError
+```
+
+Every numbered AC must appear at least once. Every edge case and error condition the spec lists must appear at least once. If you cannot map an AC to a concrete test (e.g. it's an internal property the spec mistakenly exposes), bounce back rather than fudge.
+
+### 5. Write the tests
+
+Edit or create files in `tests/` only. Match the existing project style — open `tests/conftest.py` and 2–3 representative `test_*.py` files first:
+
+- One test file per source module (`test_vocab.py` covers `vocab.py`).
+- Pure helpers tested directly. Async paths use `pytest.mark.asyncio`.
+- Mock at architectural seams only — `httpx.MockTransport`, the temp-DB `conn` fixture in `conftest.py`, `bench=` injection on `/status` readers. Never mock internal collaborators (private helpers, module-private state). Mocking internals couples tests to implementation.
+- One concept per test function. Names describe the behaviour, not the function-under-test.
+- `from __future__ import annotations` at the top of each test module.
+
+Each test must carry an inline comment matching its line in the test plan from step 4:
+
+```python
+def test_import_skips_blank_rows(conn):  # AC5 — blank rows go to skipped_empty
+    ...
+
+def test_import_rejects_over_max_rows(conn):  # error: > 5000 rows → ValueError
+    ...
+```
+
+Assertions should diagnose, not just match — `assert summary.added == 3, f"expected 3 new, got {summary.added}"` is more useful than `assert summary.added == 3`. Boundary coverage from the spec's edge-case list is mandatory.
+
+### 6. Run pytest
+
+```bash
+{% if build.setup_cmd %}{{ build.setup_cmd }} && {% endif %}{{ build.test_cmd }}
+```
+
+#### Green → step 7.
+
+#### Red → self-check, then either fix-test or bounce back.
+
+A failing test means one of:
+
+- **Your test is wrong.** Re-read the AC the test cites. Does your assertion actually restate the AC, or did you slip in an assumption? If the test does not faithfully encode the AC, fix the test, re-run.
+- **The code violates its own spec.** If the test correctly mirrors a numbered AC and still fails, the diff does not satisfy what plan-exec promised. Bounce back:
+
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+**Test-writer bounce-back**
+
+Stage 2 ran on branch \`<BRANCH>\` but pytest fails. Each failing test traces back to a numbered AC in the latest behavioural spec.
+
+\`\`\`
+<paste the last 30 lines of pytest output>
+\`\`\`
+
+The diff does not satisfy its own spec. Returning to plan-exec.
+EOF
+)"
+
+gh issue edit <N> \
+  --remove-label "state:tests-pending" \
+  --add-label "state:needs-rework"
+```
+
+Then **stop**. No push, no failing-test commit. Draft tests stay local.
+
+The bar for bouncing back: *the failing test cites a numbered AC, and a reasonable agent reading only the spec would write the same assertion.*
+
+### 7. Verify AC traceability
+
+Before pushing, confirm that every AC in the spec has at least one test, and every AC referenced in the new tests actually exists in the spec:
+
+```bash
+SPEC_ACS=$(printf '%s\n' "$SPEC" | grep -oE 'AC[0-9]+' | sort -u)
+TEST_ACS=$(git diff main...HEAD -- tests/ | grep -oE 'AC[0-9]+' | sort -u)
+
+if [[ "$SPEC_ACS" != "$TEST_ACS" ]]; then
+  echo "AC drift — spec vs tests:"
+  diff <(echo "$SPEC_ACS") <(echo "$TEST_ACS")
+  # missing-test (AC in spec, not in tests) → add the test
+  # phantom-AC  (AC in tests, not in spec) → remove citation or bounce back
+fi
+```
+
+If the diff is non-empty, do **not** push. Either add the missing test or remove the spurious citation. If you cannot reconcile (e.g. the test cites an AC the spec never had — meaning you imagined the AC), bounce back; that is a hallucination signal you should not silently launder.
+
+### 8. Commit, push, open or update the PR
+
+If you wrote new tests:
+
+```bash
+git add tests/
+git commit -m "test: cover new code paths for #<N>
+
+<one-line summary of what's tested>
+
+Refs #<N>"
+```
+
+Push:
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+If a PR is **already open** (rework cycle): the push updated it. No `gh pr create`.
+
+If **no PR exists** (first cycle): open one with `Closes #<N>`:
+
+```bash
+gh pr create --base main \
+  --title "<infer from issue title or commit subject>" \
+  --body "$(cat <<'EOF'
+Closes #<N>
+
+## Summary
+<one or two lines from the issue body>
+
+## Test plan
+- [x] Stage 2 added tests for the new code paths
+- [x] \`pytest\` is green
+EOF
+)"
+```
+
+If the diff was purely cosmetic and you wrote no new tests, still push and open/update the PR. Note it in the test plan: `- [n/a] No code paths changed; existing suite still green`.
+
+### 9. Flip the label
+
+```bash
+gh issue edit <N> \
+  --remove-label "state:tests-pending" \
+  --add-label "state:in-review"
+```
+
+### 10. Exit
+
+Print one line: `done: pushed <BRANCH> at <short-sha>, PR #<P> ready for review`.
+
+## Hard rules
+
+- **Spec-driven, not diff-driven.** Tests come from the Behavioral spec block. The diff is for verifying signatures and detecting drift — never for inferring behaviour.
+- **No function bodies.** Read public signatures, read `tests/`, read project conventions. Anything else is forbidden — even if the spec is sparse, recover by bouncing back, not by peeking.
+- **Every test cites an AC** (or `# edge:` / `# error:`). No tag, no commit. AC drift between spec and tests is a push blocker.
+- **Never modify non-test files.** If the code is wrong, return to Stage 1.
+- **Never push red.** A failing test on the branch breaks Stage 3's re-run gate.
+- **One PR per issue.** If `gh pr list --search "Closes #<N>" --state open` returns a PR, push to its branch — never open a duplicate.
+- **No `Closes #<N>` on rework pushes.** The closer lives on the original PR; another `Closes #<N>` would create a dup-close warning.
+- **Don't commit local-only artefacts.** Use `git add tests/...` with explicit paths, not `git add .`.

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,0 +1,66 @@
+"""Byte-for-byte parity check against teach-me-eng-bot's live skills.
+
+Renders each fabric-shipped template against `examples/teach-me-eng-bot.config.yaml`
+and compares to the file in the sibling teach-me-eng-bot checkout. Skips when
+`$TEACH_ME_ENG_BOT_PATH` is unset so CI without the sibling repo doesn't fail;
+hard-fails on any byte difference when the env var is set.
+
+`dev-flow/SKILL.md` is intentionally NOT compared — it is project-internal and
+not managed by the fabric.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+from pathlib import Path
+
+import pytest
+
+from fabric.config import load_config
+from fabric.render import (
+    SKILL_NAMES,
+    SKILL_OUTPUT_FILENAME,
+    render_skill,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_CONFIG = REPO_ROOT / "examples" / "teach-me-eng-bot.config.yaml"
+
+
+def _project_root() -> Path | None:
+    raw = os.environ.get("TEACH_ME_ENG_BOT_PATH")
+    if not raw:
+        return None
+    p = Path(raw).expanduser().resolve()
+    return p if p.is_dir() else None
+
+
+@pytest.mark.parametrize("name", SKILL_NAMES)
+def test_template_matches_teach_me_eng_bot(name: str, tmp_path: Path) -> None:
+    project_root = _project_root()
+    if project_root is None:
+        pytest.skip("TEACH_ME_ENG_BOT_PATH not set; skipping parity check")
+
+    expected_file = project_root / ".claude" / "skills" / name / SKILL_OUTPUT_FILENAME
+    if not expected_file.exists():
+        pytest.fail(f"missing expected skill file: {expected_file}")
+    expected = expected_file.read_text()
+
+    fake_project = tmp_path / "fake-project"
+    fake_project.mkdir()
+    config = load_config(EXAMPLE_CONFIG)
+    rendered = render_skill(name, fake_project, config, fabric_root=REPO_ROOT)
+
+    if rendered == expected:
+        return
+
+    diff = "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            rendered.splitlines(keepends=True),
+            fromfile=str(expected_file),
+            tofile=f"<rendered {name}>",
+        )
+    )
+    pytest.fail(f"parity mismatch for {name}:\n{diff}")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -16,9 +16,9 @@ from fabric.render import (
 def test_render_skill_uses_default_when_no_overlay(project: Path, fabric_root: Path) -> None:
     config = load_project_config(project)
     out = render_skill("plan-exec", project, config, fabric_root=fabric_root)
-    assert "plan-exec" in out
-    # Default template references project.name + build.test_cmd
-    assert config.project.name in out
+    # Frontmatter `name:` is the most stable hook into the rendered content.
+    assert "name: plan-exec" in out
+    # plan-exec's template substitutes the smoke command (setup_cmd && test_cmd).
     assert config.build.test_cmd in out
 
 


### PR DESCRIPTION
## Summary

Third milestone of #1. Replaces the placeholder templates from #10 with the real teach-me-eng-bot content, ships an example config, and proves byte-for-byte parity end-to-end.

- **`skill_templates/{plan-exec,test-writer,review-pr,clarify-issue,epic-decompose}/SKILL.md.j2`** — verbatim copies of teach-me-eng-bot's current skills, with the smoke-command swapped out for `{% if build.setup_cmd %}{{ build.setup_cmd }} && {% endif %}{{ build.test_cmd }}`. That's the only knob that maps cleanly to current text without restructuring prose. Other knobs (modules, blocked_paths, FSRS notes) ride along in the config schema and are available to projects that want to overlay; templates that consume them are a future PR.

- **`examples/teach-me-eng-bot.config.yaml`** — full config for teach-me-eng-bot: 9 modules with roles, blocked paths (workflows, service files), destructive DB patterns (DROP COLUMN/TABLE), FSRS-column-as-load-bearing notes, area labels, pipeline defaults.

- **`tests/test_parity.py`** — parametrized over all 5 skill names. Renders the template against the example config, byte-compares to `$TEACH_ME_ENG_BOT_PATH/.claude/skills/<name>/SKILL.md`. Skips cleanly when the env var is unset; hard-fails with unified diff when set and any byte differs. Currently green for all 5 with `TEACH_ME_ENG_BOT_PATH=/Users/.../teach-me-eng-bot`.

- **One test from #10 updated**: `test_render_skill_uses_default_when_no_overlay` was tied to the placeholder template's content. Reworded to check `name: plan-exec` frontmatter + `test_cmd` substitution — both stable hooks into the real template.

`dev-flow` is intentionally not in `SKILL_NAMES` so `fabric sync` leaves teach-me-eng-bot's `dev-flow/SKILL.md` alone.

## End-to-end cutover walkthrough (verified locally)

```bash
$ export FABRIC_HOME=$(mktemp -d)
$ cp examples/teach-me-eng-bot.config.yaml \
     /Users/.../teach-me-eng-bot/.fabric/config.yaml
$ fabric register /Users/.../teach-me-eng-bot
registered teach-me-eng-bot -> /Users/.../teach-me-eng-bot (valdisd96/teach-me-eng-bot)
$ fabric sync teach-me-eng-bot
sync: teach-me-eng-bot already up to date
$ git -C /Users/.../teach-me-eng-bot diff -- .claude/skills
                                                                # empty
$ fabric sync teach-me-eng-bot --check
sync: teach-me-eng-bot is clean                                 # exit 0
```

`dev-flow/SKILL.md` mtime unchanged after sync — confirmed the fabric does not touch project-internal skills.

## Test plan

- [x] `pytest -q` (no env var) → 46 passed (parity tests skipped).
- [x] `TEACH_ME_ENG_BOT_PATH=/Users/.../teach-me-eng-bot pytest -q` → 51 passed (5 parity tests now active).
- [x] Manual cutover walkthrough above.
- [ ] Committing `.fabric/config.yaml` into teach-me-eng-bot itself is intentionally **not** part of this PR — that's a teach-me-eng-bot-side change that should land after this PR ships.

## Acceptance for #7

- [x] `tests/test_parity.py` passes locally with `TEACH_ME_ENG_BOT_PATH` set.
- [x] `fabric sync` against the real teach-me-eng-bot checkout produces an empty `git diff` for the 5 fabric-managed skills.
- [x] `dev-flow/SKILL.md` is untouched by sync.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)