### PR TITLE
feat: phase 1A — SQLite state store + repo CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: pip install -e ".[dev]"
+      - name: Run tests
+        run: pytest -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ fabric/
 ├── config.py        # pydantic v2 models for .fabric/config.yaml + load_config (strict, extra="forbid")
 ├── registry.py      # ~/.fabric/projects.yaml reader/writer + register(repo_path)
 ├── render.py        # Jinja2 env (StrictUndefined, keep_trailing_newline=True), overlay resolution, render_skill
+├── state.py         # SQLite DAO at $FABRIC_HOME/state.db — schema_version + Decision-1 tables, forward-only migrations
 ├── sync.py          # iterates SKILL_NAMES, writes or --checks, SyncResult+SkillDrift with unified diffs
 └── skill_templates/ # the 5 .j2 files — package data, ships in the wheel
 
@@ -40,13 +41,14 @@ examples/
 └── github-actions/fabric-sync-check.yml # drift CI workflow projects copy into .github/workflows/
 
 tests/
-├── conftest.py        # shared fixtures (fabric_root, isolated_fabric_home, project)
+├── conftest.py        # shared fixtures (fabric_root, isolated_fabric_home, project, isolated_state_db)
 ├── fixtures/          # YAML fixtures for config/registry tests
 ├── test_config.py     # schema + load_config
 ├── test_registry.py   # ~/.fabric/projects.yaml CRUD
 ├── test_render.py     # overlay precedence, StrictUndefined, missing-template
 ├── test_sync.py       # write, idempotent, --check exit codes
 ├── test_cli_sync.py   # typer CliRunner end-to-end
+├── test_state.py      # SQLite schema, migrations, DAO, FK cascade
 └── test_parity.py     # byte-for-byte gate against teach-me-eng-bot (see below)
 ```
 
@@ -78,8 +80,8 @@ python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
 # tests
-pytest -q                                                    # 41 tests, parity skipped
-TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 46 tests, parity active
+pytest -q                                                    # 71 tests, parity skipped
+TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 76 tests, parity active
 
 # CLI smoke
 fabric --help

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -1,0 +1,513 @@
+"""SQLite state store at `$FABRIC_HOME/state.db`.
+
+Schema follows DESIGN.md "Decision 1 — State storage". The DAO layer is
+plain `sqlite3` so callers (sync CLI, async server) can use the same API;
+async callers wrap each call in `asyncio.to_thread` rather than colour
+the whole module with `await`. SQLite at our scale (single writer, low
+TPS) handles connection-per-call without ceremony.
+
+Forward-only migrations: each entry in `_MIGRATIONS` is `(version, sql)`
+applied in order at `init_db()` time and recorded in `schema_version`.
+Later phases add columns by appending entries — never editing past ones.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fabric.registry import fabric_home
+
+
+class StateError(Exception):
+    """Raised on schema or DAO failures we want to surface explicitly."""
+
+
+@dataclass(frozen=True)
+class ProjectRow:
+    name: str
+    path: str
+    repo: str
+    fabric_version: str | None
+    registered_at: str
+
+
+@dataclass(frozen=True)
+class IssueRow:
+    project: str
+    number: int
+    state_label: str | None
+    type_label: str | None
+    priority_label: str | None
+    area_label: str | None
+    title: str | None
+    url: str | None
+    cycle_count: int
+    last_seen_at: str
+
+
+@dataclass(frozen=True)
+class DispatchRow:
+    id: int
+    project: str
+    issue: int
+    stage: str
+    started_at: str
+    ended_at: str | None
+    exit_code: int | None
+    log_path: str | None
+    triggered_by: str
+
+
+@dataclass(frozen=True)
+class NotificationRow:
+    id: int
+    kind: str
+    project: str
+    issue: int
+    created_at: str
+    delivered_to: str | None
+    acknowledged_at: str | None
+
+
+def state_db_path() -> Path:
+    return fabric_home() / "state.db"
+
+
+_SCHEMA_V1 = """
+CREATE TABLE projects (
+  name TEXT PRIMARY KEY,
+  path TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  fabric_version TEXT,
+  registered_at TEXT NOT NULL
+);
+
+CREATE TABLE issues (
+  project TEXT NOT NULL,
+  number INTEGER NOT NULL,
+  state_label TEXT,
+  type_label TEXT,
+  priority_label TEXT,
+  area_label TEXT,
+  title TEXT,
+  url TEXT,
+  cycle_count INTEGER NOT NULL DEFAULT 0,
+  last_seen_at TEXT NOT NULL,
+  PRIMARY KEY (project, number),
+  FOREIGN KEY (project) REFERENCES projects(name) ON DELETE CASCADE
+);
+
+CREATE TABLE dispatches (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project TEXT NOT NULL,
+  issue INTEGER NOT NULL,
+  stage TEXT NOT NULL,
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  exit_code INTEGER,
+  log_path TEXT,
+  triggered_by TEXT NOT NULL,
+  FOREIGN KEY (project) REFERENCES projects(name) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_dispatches_project_issue ON dispatches(project, issue);
+CREATE INDEX idx_dispatches_started ON dispatches(started_at);
+
+CREATE TABLE notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  kind TEXT NOT NULL,
+  project TEXT NOT NULL,
+  issue INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  delivered_to TEXT,
+  acknowledged_at TEXT,
+  FOREIGN KEY (project) REFERENCES projects(name) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_notifications_unacked
+  ON notifications(acknowledged_at, created_at);
+
+CREATE TABLE quota_log (
+  project TEXT NOT NULL,
+  day TEXT NOT NULL,
+  dispatches INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (project, day),
+  FOREIGN KEY (project) REFERENCES projects(name) ON DELETE CASCADE
+);
+
+CREATE TABLE settings (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+"""
+
+_MIGRATIONS: list[tuple[int, str]] = [(1, _SCHEMA_V1)]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _utc_today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+@contextmanager
+def connect(db_path: Path | None = None) -> Iterator[sqlite3.Connection]:
+    """Yield a sqlite3 connection with our pragmas applied."""
+    p = db_path or state_db_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(p)
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.row_factory = sqlite3.Row
+        yield conn
+    finally:
+        conn.close()
+
+
+def init_db(db_path: Path | None = None) -> Path:
+    """Apply pending forward migrations. Idempotent. Returns DB path."""
+    p = db_path or state_db_path()
+    with connect(p) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_version ("
+            "  version INTEGER PRIMARY KEY,"
+            "  applied_at TEXT NOT NULL"
+            ")"
+        )
+        applied = {r[0] for r in conn.execute("SELECT version FROM schema_version")}
+        for version, sql in _MIGRATIONS:
+            if version in applied:
+                continue
+            conn.executescript(sql)
+            conn.execute(
+                "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+                (version, _utc_now()),
+            )
+            conn.commit()
+    return p
+
+
+# ---- settings DAO ----
+
+
+def get_setting(key: str, default: str | None = None) -> str | None:
+    with connect() as conn:
+        row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+        return row["value"] if row else default
+
+
+def set_setting(key: str, value: str) -> None:
+    with connect() as conn:
+        conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        conn.commit()
+
+
+def delete_setting(key: str) -> None:
+    with connect() as conn:
+        conn.execute("DELETE FROM settings WHERE key = ?", (key,))
+        conn.commit()
+
+
+# ---- projects DAO ----
+
+
+def upsert_project(
+    *, name: str, path: str, repo: str, fabric_version: str | None = None
+) -> None:
+    with connect() as conn:
+        conn.execute(
+            "INSERT INTO projects (name, path, repo, fabric_version, registered_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(name) DO UPDATE SET "
+            "  path = excluded.path, "
+            "  repo = excluded.repo, "
+            "  fabric_version = excluded.fabric_version",
+            (name, path, repo, fabric_version, _utc_now()),
+        )
+        conn.commit()
+
+
+def list_projects() -> list[ProjectRow]:
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT name, path, repo, fabric_version, registered_at "
+            "FROM projects ORDER BY name"
+        ).fetchall()
+        return [ProjectRow(**dict(r)) for r in rows]
+
+
+def delete_project(name: str) -> None:
+    with connect() as conn:
+        conn.execute("DELETE FROM projects WHERE name = ?", (name,))
+        conn.commit()
+
+
+# ---- issues DAO ----
+
+
+def upsert_issue(
+    *,
+    project: str,
+    number: int,
+    state_label: str | None = None,
+    type_label: str | None = None,
+    priority_label: str | None = None,
+    area_label: str | None = None,
+    title: str | None = None,
+    url: str | None = None,
+) -> None:
+    with connect() as conn:
+        conn.execute(
+            "INSERT INTO issues (project, number, state_label, type_label, "
+            "                    priority_label, area_label, title, url, last_seen_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(project, number) DO UPDATE SET "
+            "  state_label = excluded.state_label, "
+            "  type_label = excluded.type_label, "
+            "  priority_label = excluded.priority_label, "
+            "  area_label = excluded.area_label, "
+            "  title = excluded.title, "
+            "  url = excluded.url, "
+            "  last_seen_at = excluded.last_seen_at",
+            (
+                project,
+                number,
+                state_label,
+                type_label,
+                priority_label,
+                area_label,
+                title,
+                url,
+                _utc_now(),
+            ),
+        )
+        conn.commit()
+
+
+def get_issue(project: str, number: int) -> IssueRow | None:
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM issues WHERE project = ? AND number = ?", (project, number)
+        ).fetchone()
+        return IssueRow(**dict(row)) if row else None
+
+
+def list_issues(project: str | None = None) -> list[IssueRow]:
+    with connect() as conn:
+        if project is None:
+            rows = conn.execute("SELECT * FROM issues ORDER BY project, number").fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM issues WHERE project = ? ORDER BY number", (project,)
+            ).fetchall()
+        return [IssueRow(**dict(r)) for r in rows]
+
+
+def set_cycle_count(project: str, number: int, count: int) -> None:
+    """Overwrite cycle_count. Used by the 1C max-of-both cold-boot logic."""
+    if count < 0:
+        raise StateError("cycle_count must be non-negative")
+    with connect() as conn:
+        result = conn.execute(
+            "UPDATE issues SET cycle_count = ? WHERE project = ? AND number = ?",
+            (count, project, number),
+        )
+        if result.rowcount == 0:
+            raise StateError(f"issue {project}#{number} not found")
+        conn.commit()
+
+
+# ---- dispatches DAO ----
+
+
+def record_dispatch(
+    *,
+    project: str,
+    issue: int,
+    stage: str,
+    started_at: str | None = None,
+    ended_at: str | None = None,
+    exit_code: int | None = None,
+    log_path: str | None = None,
+    triggered_by: str = "manual",
+) -> int:
+    """Insert a dispatch row. `started_at` defaults to now-UTC.
+
+    Pass `ended_at`/`exit_code`/`log_path` for one-step recording, or omit
+    them and call `complete_dispatch` after the subprocess exits.
+    """
+    with connect() as conn:
+        cur = conn.execute(
+            "INSERT INTO dispatches (project, issue, stage, started_at, ended_at, "
+            "                        exit_code, log_path, triggered_by) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                project,
+                issue,
+                stage,
+                started_at or _utc_now(),
+                ended_at,
+                exit_code,
+                log_path,
+                triggered_by,
+            ),
+        )
+        conn.commit()
+        if cur.lastrowid is None:
+            raise StateError("INSERT into dispatches returned no rowid")
+        return cur.lastrowid
+
+
+def complete_dispatch(
+    dispatch_id: int,
+    *,
+    ended_at: str | None = None,
+    exit_code: int,
+    log_path: str | None = None,
+) -> None:
+    """Mark an in-flight dispatch row complete."""
+    with connect() as conn:
+        result = conn.execute(
+            "UPDATE dispatches SET ended_at = ?, exit_code = ?, log_path = ? WHERE id = ?",
+            (ended_at or _utc_now(), exit_code, log_path, dispatch_id),
+        )
+        if result.rowcount == 0:
+            raise StateError(f"dispatch {dispatch_id} not found")
+        conn.commit()
+
+
+def latest_dispatch(project: str, issue: int) -> DispatchRow | None:
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM dispatches WHERE project = ? AND issue = ? "
+            "ORDER BY started_at DESC, id DESC LIMIT 1",
+            (project, issue),
+        ).fetchone()
+        return DispatchRow(**dict(row)) if row else None
+
+
+def recent_dispatches(*, project: str | None = None, limit: int = 50) -> list[DispatchRow]:
+    with connect() as conn:
+        if project is None:
+            rows = conn.execute(
+                "SELECT * FROM dispatches ORDER BY started_at DESC, id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM dispatches WHERE project = ? "
+                "ORDER BY started_at DESC, id DESC LIMIT ?",
+                (project, limit),
+            ).fetchall()
+        return [DispatchRow(**dict(r)) for r in rows]
+
+
+# ---- quota DAO ----
+
+
+def inc_quota(project: str, *, day: str | None = None) -> int:
+    """Bump dispatch count for (project, day-UTC). Returns new count."""
+    d = day or _utc_today()
+    with connect() as conn:
+        conn.execute(
+            "INSERT INTO quota_log (project, day, dispatches) VALUES (?, ?, 1) "
+            "ON CONFLICT(project, day) DO UPDATE SET "
+            "  dispatches = quota_log.dispatches + 1",
+            (project, d),
+        )
+        row = conn.execute(
+            "SELECT dispatches FROM quota_log WHERE project = ? AND day = ?",
+            (project, d),
+        ).fetchone()
+        conn.commit()
+        return int(row[0])
+
+
+def quota_today(project: str, *, day: str | None = None) -> int:
+    d = day or _utc_today()
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT dispatches FROM quota_log WHERE project = ? AND day = ?",
+            (project, d),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+
+# ---- notifications DAO ----
+
+
+def add_notification(*, kind: str, project: str, issue: int) -> int:
+    with connect() as conn:
+        cur = conn.execute(
+            "INSERT INTO notifications (kind, project, issue, created_at) VALUES (?, ?, ?, ?)",
+            (kind, project, issue, _utc_now()),
+        )
+        conn.commit()
+        if cur.lastrowid is None:
+            raise StateError("INSERT into notifications returned no rowid")
+        return cur.lastrowid
+
+
+def acknowledge_notification(
+    notification_id: int, *, delivered_to: str | None = None
+) -> None:
+    with connect() as conn:
+        result = conn.execute(
+            "UPDATE notifications SET acknowledged_at = ?, delivered_to = ? WHERE id = ?",
+            (_utc_now(), delivered_to, notification_id),
+        )
+        if result.rowcount == 0:
+            raise StateError(f"notification {notification_id} not found")
+        conn.commit()
+
+
+def list_unacked_notifications() -> list[NotificationRow]:
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM notifications WHERE acknowledged_at IS NULL "
+            "ORDER BY created_at, id"
+        ).fetchall()
+        return [NotificationRow(**dict(r)) for r in rows]
+
+
+__all__ = [
+    "DispatchRow",
+    "IssueRow",
+    "NotificationRow",
+    "ProjectRow",
+    "StateError",
+    "acknowledge_notification",
+    "add_notification",
+    "complete_dispatch",
+    "connect",
+    "delete_project",
+    "delete_setting",
+    "get_issue",
+    "get_setting",
+    "inc_quota",
+    "init_db",
+    "latest_dispatch",
+    "list_issues",
+    "list_projects",
+    "list_unacked_notifications",
+    "quota_today",
+    "recent_dispatches",
+    "record_dispatch",
+    "set_cycle_count",
+    "set_setting",
+    "state_db_path",
+    "upsert_issue",
+    "upsert_project",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,11 @@ def project(tmp_path: Path) -> Path:
     fabric_dir.mkdir(parents=True)
     shutil.copy(FIXTURES / "good.yaml", fabric_dir / "config.yaml")
     return root
+
+
+@pytest.fixture
+def isolated_state_db(isolated_fabric_home: Path) -> Path:
+    """Initialize an isolated state.db under FABRIC_HOME and return its path."""
+    from fabric.state import init_db
+
+    return init_db()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fabric.state import (
+    StateError,
+    acknowledge_notification,
+    add_notification,
+    complete_dispatch,
+    connect,
+    delete_project,
+    delete_setting,
+    get_issue,
+    get_setting,
+    inc_quota,
+    init_db,
+    latest_dispatch,
+    list_issues,
+    list_projects,
+    list_unacked_notifications,
+    quota_today,
+    recent_dispatches,
+    record_dispatch,
+    set_cycle_count,
+    set_setting,
+    state_db_path,
+    upsert_issue,
+    upsert_project,
+)
+
+
+# ---------- init / migrations ----------
+
+
+def test_state_db_path_under_fabric_home(isolated_fabric_home: Path) -> None:
+    assert state_db_path() == isolated_fabric_home / "state.db"
+
+
+def test_init_db_creates_tables(isolated_fabric_home: Path) -> None:
+    p = init_db()
+    assert p.exists()
+    expected = {
+        "schema_version",
+        "projects",
+        "issues",
+        "dispatches",
+        "notifications",
+        "quota_log",
+        "settings",
+    }
+    with connect(p) as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    found = {r["name"] for r in rows}
+    assert expected.issubset(found)
+
+
+def test_init_db_records_schema_version(isolated_state_db: Path) -> None:
+    with connect(isolated_state_db) as conn:
+        rows = conn.execute("SELECT version FROM schema_version").fetchall()
+    assert {r["version"] for r in rows} == {1}
+
+
+def test_init_db_is_idempotent(isolated_fabric_home: Path) -> None:
+    init_db()
+    init_db()  # second call must not fail or duplicate-record
+    with connect() as conn:
+        n = conn.execute("SELECT COUNT(*) AS n FROM schema_version").fetchone()["n"]
+    assert n == 1
+
+
+def test_pragmas_are_set(isolated_state_db: Path) -> None:
+    with connect(isolated_state_db) as conn:
+        journal = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    assert journal.lower() == "wal"
+    assert fk == 1
+
+
+# ---------- settings ----------
+
+
+def test_set_get_setting_roundtrip(isolated_state_db: Path) -> None:
+    set_setting("paused", "1")
+    assert get_setting("paused") == "1"
+
+
+def test_set_setting_overwrites(isolated_state_db: Path) -> None:
+    set_setting("paused", "1")
+    set_setting("paused", "0")
+    assert get_setting("paused") == "0"
+
+
+def test_get_setting_returns_default_when_missing(isolated_state_db: Path) -> None:
+    assert get_setting("missing") is None
+    assert get_setting("missing", default="0") == "0"
+
+
+def test_delete_setting(isolated_state_db: Path) -> None:
+    set_setting("paused", "1")
+    delete_setting("paused")
+    assert get_setting("paused") is None
+
+
+# ---------- projects ----------
+
+
+def test_upsert_project_inserts_and_lists(isolated_state_db: Path) -> None:
+    upsert_project(name="t1", path="/p/t1", repo="me/t1", fabric_version="0.0.1")
+    upsert_project(name="t2", path="/p/t2", repo="me/t2")
+    rows = list_projects()
+    assert [r.name for r in rows] == ["t1", "t2"]
+    assert rows[0].fabric_version == "0.0.1"
+    assert rows[1].fabric_version is None
+
+
+def test_upsert_project_updates_existing(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/old", repo="me/t")
+    upsert_project(name="t", path="/new", repo="me/t", fabric_version="0.1.0")
+    rows = list_projects()
+    assert len(rows) == 1
+    assert rows[0].path == "/new"
+    assert rows[0].fabric_version == "0.1.0"
+
+
+# ---------- issues ----------
+
+
+def test_upsert_issue_inserts(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    upsert_issue(
+        project="t",
+        number=1,
+        state_label="state:needs-planning",
+        priority_label="priority:high",
+        title="Hi",
+        url="https://example.com/1",
+    )
+    row = get_issue("t", 1)
+    assert row is not None
+    assert row.state_label == "state:needs-planning"
+    assert row.priority_label == "priority:high"
+    assert row.cycle_count == 0
+    assert row.last_seen_at  # timestamp populated
+
+
+def test_upsert_issue_updates_label_and_last_seen(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    upsert_issue(project="t", number=1, state_label="state:needs-planning")
+    first_seen = get_issue("t", 1).last_seen_at  # type: ignore[union-attr]
+
+    upsert_issue(project="t", number=1, state_label="state:in-progress")
+    second = get_issue("t", 1)
+    assert second is not None
+    assert second.state_label == "state:in-progress"
+    assert second.last_seen_at >= first_seen
+
+
+def test_get_issue_returns_none_for_unknown(isolated_state_db: Path) -> None:
+    assert get_issue("t", 999) is None
+
+
+def test_list_issues_filters_by_project(isolated_state_db: Path) -> None:
+    upsert_project(name="a", path="/a", repo="me/a")
+    upsert_project(name="b", path="/b", repo="me/b")
+    upsert_issue(project="a", number=1)
+    upsert_issue(project="a", number=2)
+    upsert_issue(project="b", number=1)
+
+    assert {r.number for r in list_issues("a")} == {1, 2}
+    assert {(r.project, r.number) for r in list_issues()} == {
+        ("a", 1),
+        ("a", 2),
+        ("b", 1),
+    }
+
+
+def test_set_cycle_count_updates(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    upsert_issue(project="t", number=1)
+    set_cycle_count("t", 1, 3)
+    row = get_issue("t", 1)
+    assert row is not None and row.cycle_count == 3
+
+
+def test_set_cycle_count_raises_when_missing(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    with pytest.raises(StateError, match="not found"):
+        set_cycle_count("t", 999, 1)
+
+
+def test_set_cycle_count_rejects_negative(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    upsert_issue(project="t", number=1)
+    with pytest.raises(StateError, match="non-negative"):
+        set_cycle_count("t", 1, -1)
+
+
+# ---------- dispatches ----------
+
+
+def test_record_dispatch_returns_id(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    did = record_dispatch(project="t", issue=1, stage="plan-exec", triggered_by="manual:cli")
+    assert isinstance(did, int) and did > 0
+
+
+def test_complete_dispatch_sets_fields(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    did = record_dispatch(project="t", issue=1, stage="plan-exec")
+    complete_dispatch(did, exit_code=0, log_path="/tmp/log.txt")
+    row = latest_dispatch("t", 1)
+    assert row is not None
+    assert row.exit_code == 0
+    assert row.log_path == "/tmp/log.txt"
+    assert row.ended_at is not None
+
+
+def test_complete_dispatch_raises_when_missing(isolated_state_db: Path) -> None:
+    with pytest.raises(StateError, match="not found"):
+        complete_dispatch(9999, exit_code=0)
+
+
+def test_latest_dispatch_returns_most_recent(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-01T10:00:00+00:00")
+    did2 = record_dispatch(
+        project="t", issue=1, stage="test-writer", started_at="2026-05-02T10:00:00+00:00"
+    )
+    row = latest_dispatch("t", 1)
+    assert row is not None
+    assert row.id == did2
+    assert row.stage == "test-writer"
+
+
+def test_recent_dispatches_orders_desc(isolated_state_db: Path) -> None:
+    upsert_project(name="a", path="/a", repo="me/a")
+    upsert_project(name="b", path="/b", repo="me/b")
+    record_dispatch(project="a", issue=1, stage="plan-exec", started_at="2026-05-01T10:00:00+00:00")
+    record_dispatch(project="b", issue=1, stage="plan-exec", started_at="2026-05-02T10:00:00+00:00")
+    record_dispatch(project="a", issue=2, stage="plan-exec", started_at="2026-05-03T10:00:00+00:00")
+
+    rows = recent_dispatches(limit=10)
+    assert [(r.project, r.issue) for r in rows] == [("a", 2), ("b", 1), ("a", 1)]
+
+    a_rows = recent_dispatches(project="a", limit=10)
+    assert [(r.project, r.issue) for r in a_rows] == [("a", 2), ("a", 1)]
+
+
+# ---------- quota ----------
+
+
+def test_inc_quota_increments(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    assert inc_quota("t", day="2026-05-04") == 1
+    assert inc_quota("t", day="2026-05-04") == 2
+    assert quota_today("t", day="2026-05-04") == 2
+
+
+def test_quota_today_returns_zero_when_missing(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    assert quota_today("t", day="2026-05-04") == 0
+
+
+def test_quota_isolated_per_day(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    inc_quota("t", day="2026-05-03")
+    inc_quota("t", day="2026-05-04")
+    inc_quota("t", day="2026-05-04")
+    assert quota_today("t", day="2026-05-03") == 1
+    assert quota_today("t", day="2026-05-04") == 2
+
+
+# ---------- notifications ----------
+
+
+def test_add_notification_returns_id(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    nid = add_notification(kind="clarification", project="t", issue=1)
+    assert isinstance(nid, int) and nid > 0
+
+
+def test_list_unacked_filters_acked(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    a = add_notification(kind="clarification", project="t", issue=1)
+    add_notification(kind="blocked", project="t", issue=2)
+    acknowledge_notification(a, delivered_to="telegram")
+
+    unacked = list_unacked_notifications()
+    assert {n.kind for n in unacked} == {"blocked"}
+
+
+def test_acknowledge_notification_raises_when_missing(isolated_state_db: Path) -> None:
+    with pytest.raises(StateError, match="not found"):
+        acknowledge_notification(9999)
+
+
+# ---------- foreign-key cascade ----------
+
+
+def test_delete_project_cascades(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    upsert_issue(project="t", number=1)
+    record_dispatch(project="t", issue=1, stage="plan-exec")
+    add_notification(kind="blocked", project="t", issue=1)
+    inc_quota("t", day="2026-05-04")
+
+    delete_project("t")
+
+    assert list_issues("t") == []
+    assert recent_dispatches(project="t") == []
+    assert list_unacked_notifications() == []
+    assert quota_today("t", day="2026-05-04") == 0


### PR DESCRIPTION
Closes #14. First sub-PR of Phase 1 (#2).

## Summary

- `fabric/state.py` — DAO layer over `$FABRIC_HOME/state.db` with the Decision-1 schema (`projects`, `issues`, `dispatches`, `notifications`, `quota_log`, `settings`) plus a `schema_version` table and forward-only migration runner.
- `.github/workflows/test.yml` — first repo-internal CI: `pytest -q` on push to main + on PR, Python 3.11. Parity gate skips when `TEACH_ME_ENG_BOT_PATH` unset.
- `tests/test_state.py` — 30 tests covering schema init, idempotent migrations, each DAO function, FK cascade behavior, quota daily roll-over.

## Design notes

- Sync `sqlite3` stdlib (no `aiosqlite` dep). Async callers in 1C/1D/1E will wrap each call in `asyncio.to_thread` — keeps the same module usable from CLI and server.
- Schema matches DESIGN.md "Decision 1" exactly. Columns the scheduler/TG bot need later (`projects.last_served_at`, `projects.paused`, `notifications.tg_message_id`, …) ship as forward migrations in 1D / 1F so the migration runner gets exercised in anger rather than on day one.
- `FK ON DELETE CASCADE` on every child table — `delete_project` cleans up issues/dispatches/notifications/quota_log atomically.
- Indexes on `dispatches(started_at)`, `dispatches(project, issue)`, `notifications(acknowledged_at, created_at)` for the per-tick queries the scheduler will hit.
- `init_db()` is idempotent; CI test verifies a second call doesn't duplicate `schema_version` rows.
- `connect()` context manager exposed for any caller that needs transactional control across multiple DAO calls (none in 1A; 1C/1D may use it).

## Test plan

- [x] `pytest -q` → 71 passed, 5 skipped (parity)
- [x] `python -m py_compile fabric/*.py` clean
- [x] `fabric --help` imports cleanly (no regression)
- [ ] CI run on this PR is green
- [ ] Manual: `python -c "from fabric.state import init_db; init_db()"` creates `~/.fabric/state.db`; second call is a no-op

## Followups (out of scope, tracked elsewhere)

- 1B (#15) GitHub client — uses no state-module code yet, but the `dispatches`/`issues` schema is the receiving end of its outputs.
- 1D (#17) Scheduler — adds `projects.last_served_at` and `projects.paused` as migration v2.
- 1F (#19) Telegram — adds `notifications.tg_message_id` and `tg_chat_id` as migration v3.