### PR TITLE
feat: phase 1B — github CLI wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ fabric/
 ├── cli.py           # typer app — register, sync (real); tick/dispatch/status/pause/resume/logs (Phase 1 stubs)
 ├── config.py        # pydantic v2 models for .fabric/config.yaml + load_config (strict, extra="forbid")
 ├── registry.py      # ~/.fabric/projects.yaml reader/writer + register(repo_path)
+├── github.py        # `gh` CLI wrapper — sync, injectable subprocess runner, pydantic models with camelCase aliases
 ├── render.py        # Jinja2 env (StrictUndefined, keep_trailing_newline=True), overlay resolution, render_skill
 ├── state.py         # SQLite DAO at $FABRIC_HOME/state.db — schema_version + Decision-1 tables, forward-only migrations
 ├── sync.py          # iterates SKILL_NAMES, writes or --checks, SyncResult+SkillDrift with unified diffs
@@ -49,6 +50,7 @@ tests/
 ├── test_sync.py       # write, idempotent, --check exit codes
 ├── test_cli_sync.py   # typer CliRunner end-to-end
 ├── test_state.py      # SQLite schema, migrations, DAO, FK cascade
+├── test_github.py     # gh CLI wrapper — argv, JSON parsing, set_html_comment idempotency
 └── test_parity.py     # byte-for-byte gate against teach-me-eng-bot (see below)
 ```
 
@@ -80,8 +82,8 @@ python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
 # tests
-pytest -q                                                    # 71 tests, parity skipped
-TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 76 tests, parity active
+pytest -q                                                    # 96 tests, parity skipped
+TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 101 tests, parity active
 
 # CLI smoke
 fabric --help

--- a/fabric/github.py
+++ b/fabric/github.py
@@ -1,0 +1,372 @@
+"""Thin sync wrapper around the `gh` CLI.
+
+We invoke `gh` with explicit `--repo owner/name` so cwd doesn't matter,
+and rely on `gh auth login` having been done out of band — credential
+management isn't this module's job.
+
+The subprocess runner is injectable via the `runner` keyword argument
+on every public function so tests can pass a fake without monkeypatching
+(see `dev-flow` SKILL: "Inject collaborators as keyword args"). Async
+callers (1C dispatcher, 1D scheduler, 1E server) wrap each call in
+`asyncio.to_thread` rather than colour the API with `await`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class GhError(Exception):
+    """`gh` returned non-zero, or its stdout couldn't be parsed."""
+
+
+SubprocessRunner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+
+def _default_runner(args: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, text=True, check=False, **kwargs)
+
+
+def _run_gh(
+    args: Sequence[str],
+    *,
+    stdin: str | None = None,
+    runner: SubprocessRunner = _default_runner,
+) -> str:
+    kwargs: dict[str, Any] = {}
+    if stdin is not None:
+        kwargs["input"] = stdin
+    result = runner(["gh", *args], **kwargs)
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise GhError(f"gh {' '.join(args)} -> exit {result.returncode}: {stderr}")
+    return result.stdout
+
+
+def _run_gh_json(
+    args: Sequence[str],
+    *,
+    runner: SubprocessRunner = _default_runner,
+) -> Any:
+    out = _run_gh(args, runner=runner)
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as e:
+        raise GhError(f"gh {' '.join(args)} -> invalid JSON: {e}") from e
+
+
+# ---- output models ----
+
+
+class _GhModel(BaseModel):
+    """Pydantic base: snake_case attrs, camelCase aliases (gh's JSON style)."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="ignore",  # gh adds fields we don't model — let them pass
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+
+class Author(_GhModel):
+    login: str = ""
+
+
+class Label(_GhModel):
+    name: str
+
+
+class IssueComment(_GhModel):
+    body: str = ""
+    author: Author | None = None
+    created_at: str = ""
+    url: str = ""
+
+
+class IssueSummary(_GhModel):
+    number: int
+    title: str = ""
+    labels: list[Label] = []
+    author: Author | None = None
+    url: str = ""
+    created_at: str = ""
+
+
+class IssueDetail(IssueSummary):
+    body: str = ""
+    state: str = ""
+    comments: list[IssueComment] = []
+
+
+class PRSummary(_GhModel):
+    number: int
+    title: str = ""
+    state: str = ""
+    head_ref_name: str = ""
+    url: str = ""
+
+
+class CommentRef(_GhModel):
+    url: str = ""
+
+
+# ---- public API ----
+
+
+def list_issues(
+    repo: str,
+    *,
+    label_query: str | None = None,
+    state: str = "open",
+    limit: int = 100,
+    runner: SubprocessRunner = _default_runner,
+) -> list[IssueSummary]:
+    """List issues in `repo`. `label_query` is a GH search expression."""
+    args = [
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        state,
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,labels,author,url,createdAt",
+    ]
+    if label_query:
+        args += ["--search", label_query]
+    raw = _run_gh_json(args, runner=runner)
+    if not isinstance(raw, list):
+        raise GhError(f"expected list from `gh issue list`, got {type(raw).__name__}")
+    return [IssueSummary.model_validate(item) for item in raw]
+
+
+def get_issue(
+    repo: str,
+    number: int,
+    *,
+    runner: SubprocessRunner = _default_runner,
+) -> IssueDetail:
+    """Issue body + comments + labels + author + state."""
+    args = [
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        repo,
+        "--json",
+        "number,title,body,labels,author,comments,url,createdAt,state",
+    ]
+    raw = _run_gh_json(args, runner=runner)
+    return IssueDetail.model_validate(raw)
+
+
+def add_labels(
+    repo: str,
+    number: int,
+    labels: Sequence[str],
+    *,
+    runner: SubprocessRunner = _default_runner,
+) -> None:
+    if not labels:
+        return
+    args = ["issue", "edit", str(number), "--repo", repo]
+    for lab in labels:
+        args += ["--add-label", lab]
+    _run_gh(args, runner=runner)
+
+
+def remove_labels(
+    repo: str,
+    number: int,
+    labels: Sequence[str],
+    *,
+    runner: SubprocessRunner = _default_runner,
+) -> None:
+    if not labels:
+        return
+    args = ["issue", "edit", str(number), "--repo", repo]
+    for lab in labels:
+        args += ["--remove-label", lab]
+    _run_gh(args, runner=runner)
+
+
+def comment(
+    repo: str,
+    number: int,
+    body: str,
+    *,
+    runner: SubprocessRunner = _default_runner,
+) -> CommentRef:
+    """Post a top-level comment on `repo#number`. Returns the comment URL."""
+    out = _run_gh(
+        ["issue", "comment", str(number), "--repo", repo, "--body", body],
+        runner=runner,
+    )
+    return CommentRef(url=out.strip())
+
+
+_ISSUE_PR_LINK_RE = re.compile(r"#issuecomment-(\d+)$")
+
+
+def find_pr_for_issue(
+    repo: str,
+    issue_number: int,
+    *,
+    runner: SubprocessRunner = _default_runner,
+) -> PRSummary | None:
+    """Best-effort lookup of a PR that references this issue.
+
+    Searches PR bodies for "#N". GitHub's search returns recent matches first;
+    we take the first hit. None if no PR references the issue.
+    """
+    args = [
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "all",
+        "--limit",
+        "5",
+        "--search",
+        f'in:body "#{issue_number}"',
+        "--json",
+        "number,title,state,headRefName,url",
+    ]
+    raw = _run_gh_json(args, runner=runner)
+    if not isinstance(raw, list) or not raw:
+        return None
+    return PRSummary.model_validate(raw[0])
+
+
+_REVIEW_ACTIONS = {"approve", "request-changes", "comment"}
+
+
+def review_pr(
+    repo: str,
+    pr_number: int,
+    *,
+    action: str,
+    body: str | None = None,
+    runner: SubprocessRunner = _default_runner,
+) -> None:
+    if action not in _REVIEW_ACTIONS:
+        raise GhError(f"unsupported review action: {action!r}")
+    args = ["pr", "review", str(pr_number), "--repo", repo, f"--{action}"]
+    if body is not None:
+        args += ["--body", body]
+    _run_gh(args, runner=runner)
+
+
+_MERGE_METHODS = {"squash", "merge", "rebase"}
+
+
+def merge_pr(
+    repo: str,
+    pr_number: int,
+    *,
+    method: str = "squash",
+    delete_branch: bool = True,
+    runner: SubprocessRunner = _default_runner,
+) -> None:
+    if method not in _MERGE_METHODS:
+        raise GhError(f"unsupported merge method: {method!r}")
+    args = ["pr", "merge", str(pr_number), "--repo", repo, f"--{method}"]
+    if delete_branch:
+        args.append("--delete-branch")
+    _run_gh(args, runner=runner)
+
+
+_HTML_COMMENT_NS = "agent-fabric"
+_COMMENT_ID_RE = re.compile(r"#issuecomment-(\d+)\b")
+
+
+def _parse_comment_id(url: str) -> int | None:
+    m = _COMMENT_ID_RE.search(url or "")
+    return int(m.group(1)) if m else None
+
+
+def set_html_comment(
+    repo: str,
+    issue_number: int,
+    *,
+    marker: str,
+    value: str,
+    runner: SubprocessRunner = _default_runner,
+) -> CommentRef:
+    """Idempotently set a fabric-managed comment carrying a small payload.
+
+    The comment body is `<!-- agent-fabric:{marker} -->\\n{value}`. Subsequent
+    calls with the same `marker` edit the existing comment instead of
+    creating a duplicate. Used by the cycle counter (1C) and any future
+    fabric-managed metadata mirrored to GH.
+    """
+    sentinel = f"<!-- {_HTML_COMMENT_NS}:{marker} -->"
+    body = f"{sentinel}\n{value}"
+
+    detail_raw = _run_gh_json(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "comments",
+        ],
+        runner=runner,
+    )
+    for c in detail_raw.get("comments", []) or []:
+        c_body = c.get("body", "")
+        if not c_body.startswith(sentinel):
+            continue
+        comment_id = _parse_comment_id(c.get("url", ""))
+        if comment_id is None:
+            continue
+        _run_gh(
+            [
+                "api",
+                "-X",
+                "PATCH",
+                f"/repos/{repo}/issues/comments/{comment_id}",
+                "--input",
+                "-",
+            ],
+            stdin=json.dumps({"body": body}),
+            runner=runner,
+        )
+        return CommentRef(url=c.get("url", ""))
+
+    return comment(repo, issue_number, body, runner=runner)
+
+
+__all__ = [
+    "Author",
+    "CommentRef",
+    "GhError",
+    "IssueComment",
+    "IssueDetail",
+    "IssueSummary",
+    "Label",
+    "PRSummary",
+    "SubprocessRunner",
+    "add_labels",
+    "comment",
+    "find_pr_for_issue",
+    "get_issue",
+    "list_issues",
+    "merge_pr",
+    "remove_labels",
+    "review_pr",
+    "set_html_comment",
+]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from fabric.github import (
+    GhError,
+    add_labels,
+    comment,
+    find_pr_for_issue,
+    get_issue,
+    list_issues,
+    merge_pr,
+    remove_labels,
+    review_pr,
+    set_html_comment,
+)
+
+
+@dataclass
+class FakeResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class FakeRunner:
+    """Records every invocation, returns canned responses in order."""
+
+    responses: list[FakeResult] = field(default_factory=list)
+    calls: list[list[str]] = field(default_factory=list)
+    inputs: list[str | None] = field(default_factory=list)
+
+    def __call__(self, args: list[str], **kwargs: Any) -> FakeResult:
+        self.calls.append(list(args))
+        self.inputs.append(kwargs.get("input"))
+        if not self.responses:
+            return FakeResult()
+        return self.responses.pop(0)
+
+    def queue(self, stdout: str = "", returncode: int = 0, stderr: str = "") -> None:
+        self.responses.append(FakeResult(returncode=returncode, stdout=stdout, stderr=stderr))
+
+
+# ---------- error path ----------
+
+
+def test_run_gh_raises_on_nonzero() -> None:
+    r = FakeRunner()
+    r.queue(returncode=1, stderr="not authenticated")
+    with pytest.raises(GhError, match="not authenticated"):
+        list_issues("me/r", runner=r)
+
+
+def test_run_gh_json_raises_on_invalid_json() -> None:
+    r = FakeRunner()
+    r.queue(stdout="not-json")
+    with pytest.raises(GhError, match="invalid JSON"):
+        list_issues("me/r", runner=r)
+
+
+# ---------- list_issues ----------
+
+
+def test_list_issues_invokes_correct_argv() -> None:
+    r = FakeRunner()
+    r.queue(stdout="[]")
+    list_issues("owner/repo", runner=r)
+    assert r.calls[0] == [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        "owner/repo",
+        "--state",
+        "open",
+        "--limit",
+        "100",
+        "--json",
+        "number,title,labels,author,url,createdAt",
+    ]
+
+
+def test_list_issues_passes_label_query() -> None:
+    r = FakeRunner()
+    r.queue(stdout="[]")
+    list_issues("owner/repo", label_query='label:"state:needs-planning"', runner=r)
+    assert "--search" in r.calls[0]
+    idx = r.calls[0].index("--search")
+    assert r.calls[0][idx + 1] == 'label:"state:needs-planning"'
+
+
+def test_list_issues_parses_camelcase_to_snake() -> None:
+    payload = [
+        {
+            "number": 7,
+            "title": "Hi",
+            "url": "https://example/7",
+            "createdAt": "2026-05-01T10:00:00Z",
+            "labels": [{"name": "state:needs-planning"}],
+            "author": {"login": "valdisd96"},
+        }
+    ]
+    r = FakeRunner()
+    r.queue(stdout=json.dumps(payload))
+    issues = list_issues("me/r", runner=r)
+    assert len(issues) == 1
+    assert issues[0].number == 7
+    assert issues[0].created_at == "2026-05-01T10:00:00Z"  # camelCase alias
+    assert issues[0].labels[0].name == "state:needs-planning"
+    assert issues[0].author and issues[0].author.login == "valdisd96"
+
+
+def test_list_issues_ignores_unmodeled_fields() -> None:
+    payload = [{"number": 1, "title": "x", "url": "u", "createdAt": "t", "extraField": 42}]
+    r = FakeRunner()
+    r.queue(stdout=json.dumps(payload))
+    issues = list_issues("me/r", runner=r)
+    assert issues[0].number == 1
+
+
+def test_list_issues_rejects_non_list_response() -> None:
+    r = FakeRunner()
+    r.queue(stdout='{"oops": "object not list"}')
+    with pytest.raises(GhError, match="expected list"):
+        list_issues("me/r", runner=r)
+
+
+# ---------- get_issue ----------
+
+
+def test_get_issue_parses_full_detail() -> None:
+    payload = {
+        "number": 1,
+        "title": "T",
+        "body": "B",
+        "url": "u",
+        "createdAt": "t",
+        "state": "OPEN",
+        "labels": [],
+        "author": {"login": "a"},
+        "comments": [
+            {"body": "hi", "author": {"login": "b"}, "createdAt": "t2", "url": "u#1"}
+        ],
+    }
+    r = FakeRunner()
+    r.queue(stdout=json.dumps(payload))
+    issue = get_issue("me/r", 1, runner=r)
+    assert issue.number == 1
+    assert issue.body == "B"
+    assert issue.state == "OPEN"
+    assert len(issue.comments) == 1
+    assert issue.comments[0].author and issue.comments[0].author.login == "b"
+
+
+# ---------- add_labels / remove_labels ----------
+
+
+def test_add_labels_emits_one_arg_per_label() -> None:
+    r = FakeRunner()
+    r.queue()
+    add_labels("me/r", 1, ["state:in-progress", "type:feature"], runner=r)
+    args = r.calls[0]
+    assert args.count("--add-label") == 2
+    flat = " ".join(args)
+    assert "state:in-progress" in flat
+    assert "type:feature" in flat
+
+
+def test_add_labels_noop_on_empty_sequence() -> None:
+    r = FakeRunner()
+    add_labels("me/r", 1, [], runner=r)
+    assert r.calls == []
+
+
+def test_remove_labels_emits_one_arg_per_label() -> None:
+    r = FakeRunner()
+    r.queue()
+    remove_labels("me/r", 1, ["state:needs-planning"], runner=r)
+    assert r.calls[0].count("--remove-label") == 1
+
+
+# ---------- comment ----------
+
+
+def test_comment_returns_url_and_passes_body() -> None:
+    r = FakeRunner()
+    r.queue(stdout="https://github.com/me/r/issues/1#issuecomment-99\n")
+    ref = comment("me/r", 1, "hello", runner=r)
+    assert ref.url == "https://github.com/me/r/issues/1#issuecomment-99"
+    args = r.calls[0]
+    body_idx = args.index("--body")
+    assert args[body_idx + 1] == "hello"
+
+
+# ---------- find_pr_for_issue ----------
+
+
+def test_find_pr_for_issue_returns_first_match() -> None:
+    payload = [
+        {
+            "number": 5,
+            "title": "Closes #1",
+            "state": "OPEN",
+            "headRefName": "feat/x",
+            "url": "https://example/pr/5",
+        }
+    ]
+    r = FakeRunner()
+    r.queue(stdout=json.dumps(payload))
+    pr = find_pr_for_issue("me/r", 1, runner=r)
+    assert pr is not None
+    assert pr.number == 5
+    assert pr.head_ref_name == "feat/x"
+    assert "in:body" in r.calls[0][r.calls[0].index("--search") + 1]
+
+
+def test_find_pr_for_issue_returns_none_when_empty() -> None:
+    r = FakeRunner()
+    r.queue(stdout="[]")
+    assert find_pr_for_issue("me/r", 1, runner=r) is None
+
+
+# ---------- review_pr ----------
+
+
+@pytest.mark.parametrize("action", ["approve", "request-changes", "comment"])
+def test_review_pr_each_action_emits_correct_flag(action: str) -> None:
+    r = FakeRunner()
+    r.queue()
+    review_pr("me/r", 1, action=action, body="lgtm", runner=r)
+    assert f"--{action}" in r.calls[0]
+    assert "lgtm" in r.calls[0]
+
+
+def test_review_pr_invalid_action_raises() -> None:
+    r = FakeRunner()
+    with pytest.raises(GhError, match="unsupported review action"):
+        review_pr("me/r", 1, action="nuke", runner=r)
+
+
+def test_review_pr_omits_body_when_none() -> None:
+    r = FakeRunner()
+    r.queue()
+    review_pr("me/r", 1, action="approve", body=None, runner=r)
+    assert "--body" not in r.calls[0]
+
+
+# ---------- merge_pr ----------
+
+
+def test_merge_pr_default_squash_with_delete() -> None:
+    r = FakeRunner()
+    r.queue()
+    merge_pr("me/r", 1, runner=r)
+    args = r.calls[0]
+    assert "--squash" in args
+    assert "--delete-branch" in args
+
+
+def test_merge_pr_can_skip_branch_delete() -> None:
+    r = FakeRunner()
+    r.queue()
+    merge_pr("me/r", 1, delete_branch=False, runner=r)
+    assert "--delete-branch" not in r.calls[0]
+
+
+def test_merge_pr_unsupported_method_raises() -> None:
+    r = FakeRunner()
+    with pytest.raises(GhError, match="unsupported merge method"):
+        merge_pr("me/r", 1, method="cherry-pick", runner=r)
+
+
+# ---------- set_html_comment (idempotent marker) ----------
+
+
+def test_set_html_comment_creates_when_no_marker() -> None:
+    r = FakeRunner()
+    r.queue(stdout=json.dumps({"comments": []}))  # issue view
+    r.queue(stdout="https://example/c1\n")  # comment create
+    ref = set_html_comment("me/r", 1, marker="cycle", value="3", runner=r)
+    assert ref.url == "https://example/c1"
+    # second call → comment, with sentinel + value
+    body_arg = r.calls[1][r.calls[1].index("--body") + 1]
+    assert body_arg.startswith("<!-- agent-fabric:cycle -->")
+    assert body_arg.endswith("\n3")
+
+
+def test_set_html_comment_edits_when_marker_exists() -> None:
+    existing = {
+        "comments": [
+            {
+                "body": "<!-- agent-fabric:cycle -->\nold",
+                "url": "https://github.com/me/r/issues/1#issuecomment-42",
+            }
+        ]
+    }
+    r = FakeRunner()
+    r.queue(stdout=json.dumps(existing))  # issue view
+    r.queue(stdout="")  # api PATCH
+    ref = set_html_comment("me/r", 1, marker="cycle", value="4", runner=r)
+    assert ref.url == "https://github.com/me/r/issues/1#issuecomment-42"
+    patch_args = r.calls[1]
+    assert patch_args[:4] == ["gh", "api", "-X", "PATCH"]
+    assert "/repos/me/r/issues/comments/42" in patch_args
+    # body sent as JSON via stdin
+    body_payload = json.loads(r.inputs[1] or "")
+    assert body_payload["body"].startswith("<!-- agent-fabric:cycle -->")
+    assert body_payload["body"].endswith("\n4")
+
+
+def test_set_html_comment_ignores_other_markers() -> None:
+    existing = {
+        "comments": [
+            {
+                "body": "<!-- agent-fabric:other -->\nfoo",
+                "url": "https://github.com/me/r/issues/1#issuecomment-99",
+            }
+        ]
+    }
+    r = FakeRunner()
+    r.queue(stdout=json.dumps(existing))
+    r.queue(stdout="https://example/new\n")
+    set_html_comment("me/r", 1, marker="cycle", value="1", runner=r)
+    # second call should be a fresh comment, not a PATCH
+    assert "issue" in r.calls[1] and "comment" in r.calls[1]


### PR DESCRIPTION
Closes #15. Second sub-PR of Phase 1 (#2). Stacks on top of 1A but doesn't import from `fabric/state.py` directly — the schema is the receiving end of this module's outputs (used by 1C onward).

## Summary

- `fabric/github.py` — sync wrapper around `gh`, dependency-injectable subprocess runner, pydantic-v2 models with snake_case attrs + camelCase aliases (gh's JSON style).
- `tests/test_github.py` — 25 tests with a `FakeRunner` that records argv + stdin and replays canned stdout.

## API surface (per issue #15)

```python
list_issues(repo, *, label_query=None, state="open", limit=100) -> list[IssueSummary]
get_issue(repo, n) -> IssueDetail
add_labels(repo, n, labels)
remove_labels(repo, n, labels)
comment(repo, n, body) -> CommentRef
find_pr_for_issue(repo, n) -> PRSummary | None
review_pr(repo, pr_n, *, action, body=None)
merge_pr(repo, pr_n, *, method="squash", delete_branch=True)
set_html_comment(repo, n, *, marker, value) -> CommentRef
```

## Design notes

- **Module-level functions, not a class.** Matches `fabric/state.py` and `fabric/registry.py`. Per the dev-flow SKILL, collaborators are injected as keyword args (`runner=...`) so tests don't have to monkeypatch.
- **Pydantic v2 with `alias_generator=to_camel`** + `populate_by_name=True`: snake_case attrs, camelCase aliases auto-generated. `extra="ignore"` so future gh fields don't break parsing.
- **`set_html_comment` is idempotent.** Lists comments, finds one whose body starts with `<!-- agent-fabric:<marker> -->`, PATCHes via `gh api` (body sent as JSON over stdin — avoids `--field` quoting issues with multiline values). Will back the cycle counter in 1C; primitive is generic so future fabric metadata mirrors can reuse it.
- **`find_pr_for_issue` is a heuristic.** Searches PR bodies for `"#N"`. GitHub doesn't expose a direct "find linked PRs for an open issue" endpoint via `gh`. If the heuristic turns out flaky in 1D's scheduler, we can add a follow-up that walks the issue timeline events.
- **No new dependencies** — pydantic was already pulled in by `fabric/config.py`.

## Test plan

- [x] `pytest -q` → 96 passed, 5 skipped (parity)
- [x] `python -m py_compile` clean
- [x] `fabric --help` imports cleanly
- [ ] CI green on this PR
- [ ] Manual smoke (deferred to 1D end-to-end): list/comment against a real repo

## Followups (out of scope, tracked elsewhere)

- 1C (#16) — Dispatcher uses `set_html_comment` for the cycle counter HTML mirror.
- 1D (#17) — Scheduler uses `list_issues` per project per tick; `find_pr_for_issue` may need refinement here.
- 1E (#18) — REST endpoints will likely move output models from `fabric/github.py` to `fabric/api_models.py` (or import them).