### PR TITLE
feat: phase 1C — dispatcher (claude -p subprocess)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ Conceptually identical to SCSS → CSS or `protoc` output: humans edit the sourc
 
 ```
 fabric/
-├── cli.py           # typer app — register, sync (real); tick/dispatch/status/pause/resume/logs (Phase 1 stubs)
+├── cli.py           # typer app — register, sync, dispatch (real); tick/status/pause/resume/logs (still stubs)
 ├── config.py        # pydantic v2 models for .fabric/config.yaml + load_config (strict, extra="forbid")
+├── dispatcher.py    # async single-flight `claude -p` runner — semaphore, log streaming, pubsub, cycle counter
 ├── registry.py      # ~/.fabric/projects.yaml reader/writer + register(repo_path)
 ├── github.py        # `gh` CLI wrapper — sync, injectable subprocess runner, pydantic models with camelCase aliases
 ├── render.py        # Jinja2 env (StrictUndefined, keep_trailing_newline=True), overlay resolution, render_skill
@@ -51,6 +52,7 @@ tests/
 ├── test_cli_sync.py   # typer CliRunner end-to-end
 ├── test_state.py      # SQLite schema, migrations, DAO, FK cascade
 ├── test_github.py     # gh CLI wrapper — argv, JSON parsing, set_html_comment idempotency
+├── test_dispatcher.py # claude -p subprocess, log streaming, single-flight, cycle counter, downgrade rules
 └── test_parity.py     # byte-for-byte gate against teach-me-eng-bot (see below)
 ```
 
@@ -82,8 +84,8 @@ python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
 # tests
-pytest -q                                                    # 96 tests, parity skipped
-TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 101 tests, parity active
+pytest -q                                                    # 112 tests, parity skipped
+TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 117 tests, parity active
 
 # CLI smoke
 fabric --help
@@ -103,7 +105,7 @@ fabric sync teach-me-eng-bot --check               # exit 0 / "is clean"
 - **Phase 2 — web dashboard.** HTMX kanban + action panel.
 - **Phase 3+** — multi-project hardening, GitHub App auth, webhook receiver.
 
-Phase-1 CLI commands today are real-but-stubbed: they exit code 2 with "not implemented in phase 0". This is deliberate — the surface is discoverable and accidental invocations fail loudly.
+Phase-1 CLI commands today are mixed: `dispatch` is real (1C); `tick`, `status`, `pause`, `resume`, `logs` still exit code 2 with "not implemented in phase 0". This is deliberate — the surface is discoverable and accidental invocations fail loudly.
 
 ## What's deliberately not parameterized yet
 

--- a/examples/teach-me-eng-bot.config.yaml
+++ b/examples/teach-me-eng-bot.config.yaml
@@ -61,4 +61,4 @@ pipeline:
   retry_backoff_seconds: [60, 300, 900]
   daily_dispatch_cap: 30
 
-fabric_version: "0.0.1"
+fabric_version: "0.1.0"

--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -1,12 +1,13 @@
 """`fabric` CLI entry point.
 
-Phase 0A wires all eight subcommands listed in DESIGN.md "CLI modes" so the
-surface is discoverable; only `register` does real work this milestone.
-The rest stub out with exit code 2 so accidental invocations fail loudly.
+Phase 0A wired all eight subcommands so the surface is discoverable;
+each lights up as its phase ships. As of Phase 1C, `dispatch` is real;
+`tick`, `status`, `pause`, `resume`, `logs` still stub out.
 """
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import typer
@@ -98,9 +99,36 @@ def dispatch(
     project: str = typer.Argument(...),
     issue: int = typer.Argument(...),
     stage: str = typer.Argument(...),
+    model: str = typer.Option(
+        "",
+        "--model",
+        help="Override model. Empty = default + downgrade rules.",
+    ),
 ) -> None:
     """Force-dispatch an agent stage on an issue."""
-    _stub("dispatch")
+    from fabric.dispatcher import Dispatcher, DispatchError
+    from fabric.state import init_db
+
+    init_db()
+    dispatcher = Dispatcher()
+    try:
+        result = asyncio.run(
+            dispatcher.dispatch(
+                project,
+                issue,
+                stage,
+                model=model or None,
+                triggered_by="manual:cli",
+            )
+        )
+    except DispatchError as e:
+        typer.echo(f"dispatch: {e}", err=True)
+        raise typer.Exit(1) from e
+
+    typer.echo(
+        f"dispatch: id={result.dispatch_id} exit={result.exit_code} "
+        f"duration={result.duration_s:.1f}s log={result.log_path}"
+    )
 
 
 @app.command()

--- a/fabric/config.py
+++ b/fabric/config.py
@@ -68,6 +68,7 @@ class Pipeline(_Strict):
     retry_count: int = Field(default=3, ge=0)
     retry_backoff_seconds: list[int] = Field(default_factory=lambda: [60, 300, 900])
     daily_dispatch_cap: int = Field(default=30, gt=0)
+    downgrade_low_priority: bool = False
 
     @field_validator("retry_backoff_seconds")
     @classmethod

--- a/fabric/dispatcher.py
+++ b/fabric/dispatcher.py
@@ -1,0 +1,328 @@
+"""Long-running `claude -p` subprocess runner.
+
+Single-flight via an `asyncio.Semaphore(1)` — exactly one agent stage
+runs in the fabric process at any time, by design (DESIGN.md Decision 3).
+Streams stdout to a per-dispatch log file under `$FABRIC_HOME/logs/...`
+and to an in-memory pubsub for live consumers (the FastAPI WS in 1E,
+the Telegram bot in 1F).
+
+The exact `claude -p` argv is intentionally minimal in this sub-PR;
+SMOKE.md (1G) will document the full prompt + system-prompt shape once
+the end-to-end smoke against teach-me-eng-bot has run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fabric import github as gh
+from fabric import state
+from fabric.config import FabricConfig, load_project_config
+from fabric.registry import ProjectEntry, fabric_home, find as find_project
+
+
+class DispatchError(Exception):
+    """Wrong project, missing config, or other dispatch-time failure."""
+
+
+class QuotaExceeded(DispatchError):
+    """Per-project daily dispatch cap reached."""
+
+
+@dataclass(frozen=True)
+class DispatchResult:
+    dispatch_id: int
+    exit_code: int
+    log_path: Path
+    duration_s: float
+
+
+SubprocessSpawner = Callable[..., Awaitable[asyncio.subprocess.Process]]
+
+_DEFAULT_MODEL = "claude-opus-4-7"
+_DOWNGRADE_MODEL = "claude-sonnet-4-6"
+_LOW_PRIORITY_LABEL = "priority:low"
+_CYCLE_MARKER = "cycle"
+_CYCLE_SENTINEL = f"<!-- agent-fabric:{_CYCLE_MARKER} -->"
+
+
+async def _default_spawner(args: list[str], **kwargs: Any) -> asyncio.subprocess.Process:
+    return await asyncio.create_subprocess_exec(*args, **kwargs)
+
+
+class Dispatcher:
+    """Owns the single-flight semaphore + the dispatch pubsub.
+
+    The constructor takes injectable collaborators for tests:
+    `spawner` for the `claude -p` subprocess, `gh_runner` for any gh
+    CLI calls (currently only the cycle-counter mirror).
+    """
+
+    def __init__(
+        self,
+        *,
+        fabric_home_path: Path | None = None,
+        spawner: SubprocessSpawner = _default_spawner,
+        gh_runner: gh.SubprocessRunner | None = None,
+    ) -> None:
+        self._home = fabric_home_path or fabric_home()
+        self._spawner = spawner
+        self._gh_runner: gh.SubprocessRunner = gh_runner or gh._default_runner
+        self._sem = asyncio.Semaphore(1)
+        self._subscribers: list[asyncio.Queue[dict[str, Any]]] = []
+
+    # ---- public API ----
+
+    async def dispatch(
+        self,
+        project: str,
+        issue: int,
+        stage: str,
+        *,
+        model: str | None = None,
+        triggered_by: str = "manual",
+    ) -> DispatchResult:
+        entry, config = self._load_project(project)
+        await self._ensure_state_project(entry, config)
+
+        used = await asyncio.to_thread(state.quota_today, project)
+        if used >= config.pipeline.daily_dispatch_cap:
+            raise QuotaExceeded(
+                f"{project} hit daily cap ({used}/{config.pipeline.daily_dispatch_cap})"
+            )
+
+        resolved_model = await self._resolve_model(project, issue, model, config)
+
+        async with self._sem:
+            return await self._run(
+                entry=entry,
+                issue=issue,
+                stage=stage,
+                model=resolved_model,
+                triggered_by=triggered_by,
+            )
+
+    async def bump_cycle(self, project: str, issue: int) -> int:
+        """`max(GH-comment, DB)` + 1, written back to both stores.
+
+        On a fresh `state.db` we still recover the right counter from the
+        GH HTML comment so a wiped+reinstalled fabric doesn't reset the
+        cycle cap to zero.
+        """
+        entry = find_project(project)
+        if entry is None:
+            raise DispatchError(f"project {project!r} not registered")
+        await self._ensure_state_project_simple(entry)
+
+        gh_n = await asyncio.to_thread(self._read_cycle_from_gh, entry.repo, issue)
+        issue_row = await asyncio.to_thread(state.get_issue, project, issue)
+        db_n = issue_row.cycle_count if issue_row is not None else 0
+        new = max(gh_n, db_n) + 1
+
+        if issue_row is None:
+            await asyncio.to_thread(state.upsert_issue, project=project, number=issue)
+        await asyncio.to_thread(state.set_cycle_count, project, issue, new)
+        await asyncio.to_thread(
+            gh.set_html_comment,
+            entry.repo,
+            issue,
+            marker=_CYCLE_MARKER,
+            value=str(new),
+            runner=self._gh_runner,
+        )
+        return new
+
+    def subscribe(self, *, maxsize: int = 1024) -> asyncio.Queue[dict[str, Any]]:
+        """Register a pubsub queue for dispatch_started/stdout/ended events."""
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
+        self._subscribers.append(q)
+        return q
+
+    # ---- internals ----
+
+    def _load_project(self, project: str) -> tuple[ProjectEntry, FabricConfig]:
+        entry = find_project(project)
+        if entry is None:
+            raise DispatchError(f"project {project!r} not registered")
+        try:
+            config = load_project_config(entry.path)
+        except Exception as e:
+            raise DispatchError(
+                f"project {project!r}: failed to load config from {entry.path}: {e}"
+            ) from e
+        return entry, config
+
+    async def _ensure_state_project(self, entry: ProjectEntry, config: FabricConfig) -> None:
+        await asyncio.to_thread(
+            state.upsert_project,
+            name=entry.name,
+            path=entry.path,
+            repo=entry.repo,
+            fabric_version=config.fabric_version,
+        )
+
+    async def _ensure_state_project_simple(self, entry: ProjectEntry) -> None:
+        await asyncio.to_thread(
+            state.upsert_project,
+            name=entry.name,
+            path=entry.path,
+            repo=entry.repo,
+        )
+
+    async def _resolve_model(
+        self, project: str, issue: int, override: str | None, config: FabricConfig
+    ) -> str:
+        if override:
+            return override
+        if not config.pipeline.downgrade_low_priority:
+            return _DEFAULT_MODEL
+        issue_row = await asyncio.to_thread(state.get_issue, project, issue)
+        if issue_row is not None and issue_row.priority_label == _LOW_PRIORITY_LABEL:
+            return _DOWNGRADE_MODEL
+        return _DEFAULT_MODEL
+
+    async def _run(
+        self,
+        *,
+        entry: ProjectEntry,
+        issue: int,
+        stage: str,
+        model: str,
+        triggered_by: str,
+    ) -> DispatchResult:
+        log_path = self._log_path(entry.name, issue, stage)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        started = datetime.now(timezone.utc)
+        dispatch_id = await asyncio.to_thread(
+            state.record_dispatch,
+            project=entry.name,
+            issue=issue,
+            stage=stage,
+            started_at=started.isoformat(timespec="seconds"),
+            triggered_by=triggered_by,
+        )
+
+        await self._publish(
+            {
+                "kind": "dispatch_started",
+                "dispatch_id": dispatch_id,
+                "project": entry.name,
+                "issue": issue,
+                "stage": stage,
+                "model": model,
+                "log_path": str(log_path),
+            }
+        )
+
+        argv = self._build_argv(model=model, project_path=entry.path, stage=stage, issue=issue)
+
+        proc = await self._spawner(
+            argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+
+        with log_path.open("w", encoding="utf-8") as logf:
+            assert proc.stdout is not None
+            async for line_bytes in proc.stdout:
+                line = line_bytes.decode(errors="replace")
+                logf.write(line)
+                logf.flush()
+                await self._publish(
+                    {
+                        "kind": "dispatch_stdout",
+                        "dispatch_id": dispatch_id,
+                        "project": entry.name,
+                        "issue": issue,
+                        "stage": stage,
+                        "line": line.rstrip("\n"),
+                    }
+                )
+
+        exit_code = await proc.wait()
+        ended = datetime.now(timezone.utc)
+
+        await asyncio.to_thread(
+            state.complete_dispatch,
+            dispatch_id,
+            ended_at=ended.isoformat(timespec="seconds"),
+            exit_code=exit_code,
+            log_path=str(log_path),
+        )
+        await asyncio.to_thread(state.inc_quota, entry.name)
+
+        await self._publish(
+            {
+                "kind": "dispatch_ended",
+                "dispatch_id": dispatch_id,
+                "project": entry.name,
+                "issue": issue,
+                "stage": stage,
+                "exit_code": exit_code,
+                "log_path": str(log_path),
+            }
+        )
+
+        return DispatchResult(
+            dispatch_id=dispatch_id,
+            exit_code=exit_code,
+            log_path=log_path,
+            duration_s=(ended - started).total_seconds(),
+        )
+
+    def _build_argv(self, *, model: str, project_path: str, stage: str, issue: int) -> list[str]:
+        return [
+            "claude",
+            "-p",
+            "--model",
+            model,
+            "--add-dir",
+            project_path,
+            f"Run the {stage} skill on issue #{issue}.",
+        ]
+
+    def _log_path(self, project: str, issue: int, stage: str) -> Path:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        return self._home / "logs" / project / str(issue) / f"{stage}-{ts}.log"
+
+    def _read_cycle_from_gh(self, repo: str, issue: int) -> int:
+        try:
+            detail = gh.get_issue(repo, issue, runner=self._gh_runner)
+        except gh.GhError:
+            return 0
+        for c in detail.comments:
+            if not c.body.startswith(_CYCLE_SENTINEL):
+                continue
+            tail = c.body[len(_CYCLE_SENTINEL):].strip()
+            try:
+                return int(tail.splitlines()[0]) if tail else 0
+            except ValueError:
+                continue
+        return 0
+
+    async def _publish(self, event: dict[str, Any]) -> None:
+        for q in list(self._subscribers):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                # slow subscriber: drop the oldest item to make room
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    q.get_nowait()
+                with contextlib.suppress(asyncio.QueueFull):
+                    q.put_nowait(event)
+
+
+__all__ = [
+    "Dispatcher",
+    "DispatchError",
+    "DispatchResult",
+    "QuotaExceeded",
+    "SubprocessSpawner",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-fabric"
-version = "0.0.1"
+version = "0.1.0"
 description = "Multi-project agent fabric — drives the plan-exec → test-writer → review-pr Claude pipeline across N repos."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/fixtures/good.yaml
+++ b/tests/fixtures/good.yaml
@@ -33,4 +33,4 @@ pipeline:
   retry_backoff_seconds: [60, 300, 900]
   daily_dispatch_cap: 30
 
-fabric_version: "0.0.1"
+fabric_version: "0.1.0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,19 @@ def test_load_good_config() -> None:
     assert cfg.modules[0].path == "bot.py"
     assert cfg.labels.area_labels == ["bot", "vocab"]
     assert cfg.pipeline.cycle_limit == 5
-    assert cfg.fabric_version == "0.0.1"
+    assert cfg.pipeline.downgrade_low_priority is False
+    assert cfg.fabric_version == "0.1.0"
+
+
+def test_downgrade_low_priority_can_be_enabled(tmp_path: Path) -> None:
+    text = (FIXTURES / "good.yaml").read_text().replace(
+        "daily_dispatch_cap: 30",
+        "daily_dispatch_cap: 30\n  downgrade_low_priority: true",
+    )
+    p = tmp_path / "cfg.yaml"
+    p.write_text(text)
+    cfg = load_config(p)
+    assert cfg.pipeline.downgrade_low_priority is True
 
 
 def test_missing_file_raises() -> None:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fabric import state
+from fabric.dispatcher import Dispatcher, DispatchError, QuotaExceeded
+from fabric.registry import register
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------- helpers ----------
+
+
+def _aiorun(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _make_project(root: Path) -> Path:
+    fabric_dir = root / ".fabric"
+    fabric_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(FIXTURES / "good.yaml", fabric_dir / "config.yaml")
+    return root
+
+
+@dataclass
+class _AsyncByteLines:
+    """Async iterator over a list of bytes lines (for proc.stdout)."""
+
+    lines: list[bytes]
+
+    def __aiter__(self) -> "_AsyncByteLines":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if not self.lines:
+            raise StopAsyncIteration
+        return self.lines.pop(0)
+
+
+@dataclass
+class FakeProc:
+    stdout: _AsyncByteLines
+    exit_code: int = 0
+
+    async def wait(self) -> int:
+        return self.exit_code
+
+
+@dataclass
+class FakeSpawner:
+    """Records argv per call, returns scripted FakeProc instances."""
+
+    lines: list[str] = field(default_factory=list)
+    exit_code: int = 0
+    calls: list[list[str]] = field(default_factory=list)
+    on_call: Any = None
+
+    async def __call__(self, args: list[str], **kwargs: Any) -> FakeProc:
+        self.calls.append(list(args))
+        if self.on_call is not None:
+            await self.on_call()
+        bytes_lines = [(line + "\n").encode() for line in self.lines]
+        return FakeProc(stdout=_AsyncByteLines(bytes_lines), exit_code=self.exit_code)
+
+
+@dataclass
+class _GhRunResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class FakeGhRunner:
+    responses: list[_GhRunResult] = field(default_factory=list)
+    calls: list[list[str]] = field(default_factory=list)
+    inputs: list[str | None] = field(default_factory=list)
+
+    def __call__(self, args: list[str], **kwargs: Any) -> _GhRunResult:
+        self.calls.append(list(args))
+        self.inputs.append(kwargs.get("input"))
+        if not self.responses:
+            return _GhRunResult()
+        return self.responses.pop(0)
+
+    def queue(self, stdout: str = "", returncode: int = 0) -> None:
+        self.responses.append(_GhRunResult(returncode=returncode, stdout=stdout))
+
+
+# ---------- dispatch happy path ----------
+
+
+def test_dispatch_runs_subprocess_and_writes_log(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner(lines=["hello", "world"], exit_code=0)
+    d = Dispatcher(spawner=spawner)
+
+    result = _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    assert result.exit_code == 0
+    assert result.log_path.exists()
+    log = result.log_path.read_text()
+    assert "hello" in log and "world" in log
+
+
+def test_dispatch_argv_uses_default_model_and_project_path(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+
+    _aiorun(d.dispatch("teach-me-eng-bot", 7, "plan-exec"))
+
+    args = spawner.calls[0]
+    assert args[:3] == ["claude", "-p", "--model"]
+    assert "claude-opus-4-7" in args
+    assert "--add-dir" in args
+    assert str(project.resolve()) in args
+    assert any("plan-exec" in a and "issue #7" in a for a in args)
+
+
+def test_dispatch_records_started_completed_and_quota(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    d = Dispatcher(spawner=FakeSpawner(exit_code=0))
+
+    _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    latest = state.latest_dispatch("teach-me-eng-bot", 1)
+    assert latest is not None
+    assert latest.exit_code == 0
+    assert latest.ended_at is not None
+    assert latest.log_path is not None
+    assert state.quota_today("teach-me-eng-bot") == 1
+
+
+def test_dispatch_propagates_nonzero_exit(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    d = Dispatcher(spawner=FakeSpawner(lines=["boom"], exit_code=2))
+
+    res = _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    assert res.exit_code == 2
+    latest = state.latest_dispatch("teach-me-eng-bot", 1)
+    assert latest is not None and latest.exit_code == 2
+
+
+# ---------- error paths ----------
+
+
+def test_dispatch_unknown_project_raises(isolated_state_db: Path) -> None:
+    d = Dispatcher(spawner=FakeSpawner())
+    with pytest.raises(DispatchError, match="not registered"):
+        _aiorun(d.dispatch("nope", 1, "plan-exec"))
+
+
+def test_dispatch_quota_cap_raises(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    # good.yaml's pipeline.daily_dispatch_cap == 30; pre-fill the quota
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+    for _ in range(30):
+        state.inc_quota("teach-me-eng-bot")
+
+    d = Dispatcher(spawner=FakeSpawner())
+    with pytest.raises(QuotaExceeded, match="30/30"):
+        _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+
+# ---------- model resolution ----------
+
+
+def test_dispatch_explicit_model_override(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+
+    _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec", model="some-other-model"))
+
+    assert "some-other-model" in spawner.calls[0]
+
+
+def test_dispatch_does_not_downgrade_when_flag_off(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """good.yaml has downgrade_low_priority unset (default False)."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+    state.upsert_issue(project="teach-me-eng-bot", number=1, priority_label="priority:low")
+
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+    _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    assert "claude-opus-4-7" in spawner.calls[0]
+    assert "claude-sonnet-4-6" not in spawner.calls[0]
+
+
+def test_dispatch_downgrades_low_priority_when_flag_set(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    # Patch the config to enable the downgrade
+    cfg_path = project / ".fabric" / "config.yaml"
+    text = cfg_path.read_text()
+    cfg_path.write_text(
+        text.replace(
+            "daily_dispatch_cap: 30",
+            "daily_dispatch_cap: 30\n  downgrade_low_priority: true",
+        )
+    )
+    register(project)
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+    state.upsert_issue(project="teach-me-eng-bot", number=1, priority_label="priority:low")
+
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+    _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    assert "claude-sonnet-4-6" in spawner.calls[0]
+
+
+# ---------- pubsub ----------
+
+
+def test_dispatch_publishes_started_stdout_ended_events(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    d = Dispatcher(spawner=FakeSpawner(lines=["a", "b"]))
+
+    async def _run() -> list[dict[str, Any]]:
+        q = d.subscribe()
+        await d.dispatch("teach-me-eng-bot", 1, "plan-exec")
+        events: list[dict[str, Any]] = []
+        while not q.empty():
+            events.append(q.get_nowait())
+        return events
+
+    events = _aiorun(_run())
+    kinds = [e["kind"] for e in events]
+    assert kinds[0] == "dispatch_started"
+    assert kinds[-1] == "dispatch_ended"
+    stdout_events = [e for e in events if e["kind"] == "dispatch_stdout"]
+    assert [e["line"] for e in stdout_events] == ["a", "b"]
+
+
+def test_subscribe_drops_oldest_when_queue_full(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    # 5 stdout lines, queue maxsize=2 → only the last 2 stdout + dispatch_ended fit
+    d = Dispatcher(spawner=FakeSpawner(lines=["1", "2", "3", "4", "5"]))
+
+    async def _run() -> list[dict[str, Any]]:
+        q = d.subscribe(maxsize=2)
+        await d.dispatch("teach-me-eng-bot", 1, "plan-exec")
+        events: list[dict[str, Any]] = []
+        while not q.empty():
+            events.append(q.get_nowait())
+        return events
+
+    events = _aiorun(_run())
+    # exactly maxsize survive
+    assert len(events) == 2
+
+
+# ---------- single-flight ----------
+
+
+def test_dispatch_serializes_concurrent_calls(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+
+    in_flight = 0
+    max_in_flight = 0
+    enter = asyncio.Event()
+    proceed = asyncio.Event()
+
+    async def gate() -> None:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        enter.set()
+        await proceed.wait()
+        in_flight -= 1
+
+    async def _run() -> None:
+        spawner = FakeSpawner(lines=["x"], on_call=gate)
+        d = Dispatcher(spawner=spawner)
+        t1 = asyncio.create_task(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+        await enter.wait()
+        # second call should block on the semaphore
+        t2 = asyncio.create_task(d.dispatch("teach-me-eng-bot", 2, "plan-exec"))
+        await asyncio.sleep(0)
+        proceed.set()
+        await asyncio.gather(t1, t2)
+
+    _aiorun(_run())
+    assert max_in_flight == 1
+
+
+# ---------- bump_cycle (max-of-both) ----------
+
+
+def _detail_json(comments: list[dict[str, Any]] | None = None) -> str:
+    return json.dumps(
+        {
+            "number": 1,
+            "title": "x",
+            "url": "u",
+            "createdAt": "t",
+            "state": "OPEN",
+            "comments": comments or [],
+        }
+    )
+
+
+def test_bump_cycle_first_call_writes_one(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    gh_runner = FakeGhRunner()
+    gh_runner.queue(stdout=_detail_json())  # _read_cycle_from_gh
+    gh_runner.queue(stdout=json.dumps({"comments": []}))  # set_html_comment view
+    gh_runner.queue(stdout="https://example/c1\n")  # set_html_comment create
+
+    d = Dispatcher(gh_runner=gh_runner)
+    n = _aiorun(d.bump_cycle("teach-me-eng-bot", 1))
+
+    assert n == 1
+    row = state.get_issue("teach-me-eng-bot", 1)
+    assert row is not None and row.cycle_count == 1
+
+
+def test_bump_cycle_takes_max_of_db_and_gh(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    # DB says 2; GH comment says 5 → next should be 6
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+    state.upsert_issue(project="teach-me-eng-bot", number=1)
+    state.set_cycle_count("teach-me-eng-bot", 1, 2)
+
+    gh_runner = FakeGhRunner()
+    gh_runner.queue(
+        stdout=json.dumps(
+            {
+                "number": 1,
+                "title": "x",
+                "url": "u",
+                "comments": [
+                    {
+                        "body": "<!-- agent-fabric:cycle -->\n5",
+                        "url": "https://example/i/1#issuecomment-100",
+                    }
+                ],
+            }
+        )
+    )
+    # set_html_comment lookup + edit
+    gh_runner.queue(
+        stdout=json.dumps(
+            {
+                "comments": [
+                    {
+                        "body": "<!-- agent-fabric:cycle -->\n5",
+                        "url": "https://example/i/1#issuecomment-100",
+                    }
+                ]
+            }
+        )
+    )
+    gh_runner.queue(stdout="")  # PATCH
+
+    d = Dispatcher(gh_runner=gh_runner)
+    n = _aiorun(d.bump_cycle("teach-me-eng-bot", 1))
+
+    assert n == 6
+    row = state.get_issue("teach-me-eng-bot", 1)
+    assert row is not None and row.cycle_count == 6
+
+
+def test_bump_cycle_ignores_unparseable_comment(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+    state.upsert_issue(project="teach-me-eng-bot", number=1)
+    state.set_cycle_count("teach-me-eng-bot", 1, 4)
+
+    gh_runner = FakeGhRunner()
+    gh_runner.queue(
+        stdout=json.dumps(
+            {
+                "number": 1,
+                "title": "x",
+                "url": "u",
+                "comments": [
+                    {
+                        "body": "<!-- agent-fabric:cycle -->\nnot-a-number",
+                        "url": "https://example/i/1#issuecomment-100",
+                    }
+                ],
+            }
+        )
+    )
+    gh_runner.queue(stdout=json.dumps({"comments": []}))
+    gh_runner.queue(stdout="https://example/new\n")
+
+    d = Dispatcher(gh_runner=gh_runner)
+    n = _aiorun(d.bump_cycle("teach-me-eng-bot", 1))
+
+    # falls back to DB-only counter (4 + 1)
+    assert n == 5


### PR DESCRIPTION
Closes #16. Third sub-PR of Phase 1 (#2). Builds on 1A (state) + 1B (gh).

## Summary

- `fabric/dispatcher.py` (304 LOC) — `Dispatcher` class with `asyncio.Semaphore(1)`, log streaming to `\$FABRIC_HOME/logs/<project>/<issue>/<stage>-<ts>.log`, in-memory pubsub, `bump_cycle` with max-of-both cold-boot logic.
- `fabric/cli.py` — `fabric dispatch <project> <issue> <stage> [--model X]` is real, runs the dispatcher and prints `id=N exit=N duration=Ns log=…`.
- `fabric/config.py` — adds `pipeline.downgrade_low_priority: bool = False` (additive). Schema version bumped 0.0.1 → 0.1.0; example + `good.yaml` fixture re-pinned. Bad fixtures stay at 0.0.1 (the version field isn't validated, so they still cover their target failure paths).
- `tests/test_dispatcher.py` — 15 tests covering happy path, argv, quota cap, model resolution, downgrade rules, pubsub events, queue overflow drops oldest, single-flight serialization, cycle counter max-of-both, unparseable-comment fallback.

## Schema migration note

Additive change. Projects pinning `fabric_version: "0.0.1"` continue to load (the new field defaults False); they're encouraged to bump their pin at next sync.

## Design notes

- **Class, not module-level functions**, because it owns mutable state (semaphore + pubsub subscribers) for the lifetime of a server process — different from state.py/github.py/registry.py which are stateless.
- **Quota gate before semaphore** — over-cap dispatches fail fast without queueing. Inc at completion (not start) so a failed dispatch still counts (it consumed a Claude session).
- **Cycle counter mirror via `set_html_comment`** — namespaced sentinel `<!-- agent-fabric:cycle -->` matches 1B's idempotent-edit path. Cold-boot does `max(GH-comment, DB)` + 1, then DB is canonical with the comment as backup.
- **Pubsub drops oldest on overflow** — slow subscribers (e.g. a stalled WS client in 1E) don't backpressure the dispatcher.
- **Subprocess tests use injectable spawner** — argv assertions + a fake stdout async-iterator. Real `claude -p` e2e behind `RUN_DISPATCH_E2E=1` is documented in #16 but lands with 1G's SMOKE.md walkthrough.
- **Self-heals state.projects on dispatch** — registry's `projects.yaml` is the filesystem authority; state.projects gets upserted on first dispatch so the FK targets exist before record_dispatch runs.

## Test plan

- [x] `pytest -q` → 112 passed, 5 skipped (parity)
- [x] `TEACH_ME_ENG_BOT_PATH=… pytest -q tests/test_parity.py` → 5 passed (parity preserved across the schema bump)
- [x] `python -m py_compile` clean
- [x] `fabric --help` and `fabric dispatch --help` import cleanly
- [ ] CI green on this PR

## Followups (out of scope, tracked elsewhere)

- 1D (#17) — Scheduler integrates state + gh + dispatcher. Adds the retry/cycle-cap auto-block logic on top of `bump_cycle`.
- 1G (#20) — SMOKE.md documents the real `claude -p` argv (and any extra flags discovered during the live run); adds the opt-in `RUN_DISPATCH_E2E=1` test fixture.