### PR TITLE
feat: phase 1D — scheduler (D3 selection + retry/pause/cycle gating)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,13 @@ Conceptually identical to SCSS → CSS or `protoc` output: humans edit the sourc
 
 ```
 fabric/
-├── cli.py           # typer app — register, sync, dispatch (real); tick/status/pause/resume/logs (still stubs)
+├── cli.py           # typer app — register, sync, dispatch, tick, pause, resume, status (real); logs (stub)
 ├── config.py        # pydantic v2 models for .fabric/config.yaml + load_config (strict, extra="forbid")
 ├── dispatcher.py    # async single-flight `claude -p` runner — semaphore, log streaming, pubsub, cycle counter
 ├── registry.py      # ~/.fabric/projects.yaml reader/writer + register(repo_path)
 ├── github.py        # `gh` CLI wrapper — sync, injectable subprocess runner, pydantic models with camelCase aliases
 ├── render.py        # Jinja2 env (StrictUndefined, keep_trailing_newline=True), overlay resolution, render_skill
+├── scheduler.py     # cross-project tick — D3 selection, three-layer pause, retry-backoff, cycle-cap auto-block
 ├── state.py         # SQLite DAO at $FABRIC_HOME/state.db — schema_version + Decision-1 tables, forward-only migrations
 ├── sync.py          # iterates SKILL_NAMES, writes or --checks, SyncResult+SkillDrift with unified diffs
 └── skill_templates/ # the 5 .j2 files — package data, ships in the wheel
@@ -53,6 +54,7 @@ tests/
 ├── test_state.py      # SQLite schema, migrations, DAO, FK cascade
 ├── test_github.py     # gh CLI wrapper — argv, JSON parsing, set_html_comment idempotency
 ├── test_dispatcher.py # claude -p subprocess, log streaming, single-flight, cycle counter, downgrade rules
+├── test_scheduler.py  # tick — pause layers, D3 sort, retry-backoff, cycle-cap, consecutive-failure block
 └── test_parity.py     # byte-for-byte gate against teach-me-eng-bot (see below)
 ```
 
@@ -84,8 +86,8 @@ python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
 # tests
-pytest -q                                                    # 112 tests, parity skipped
-TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 117 tests, parity active
+pytest -q                                                    # 141 tests, parity skipped
+TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 146 tests, parity active
 
 # CLI smoke
 fabric --help
@@ -105,7 +107,7 @@ fabric sync teach-me-eng-bot --check               # exit 0 / "is clean"
 - **Phase 2 — web dashboard.** HTMX kanban + action panel.
 - **Phase 3+** — multi-project hardening, GitHub App auth, webhook receiver.
 
-Phase-1 CLI commands today are mixed: `dispatch` is real (1C); `tick`, `status`, `pause`, `resume`, `logs` still exit code 2 with "not implemented in phase 0". This is deliberate — the surface is discoverable and accidental invocations fail loudly.
+Phase-1 CLI commands today: `dispatch` (1C), `tick`, `pause`, `resume`, `status` (1D) are real. Only `logs` still exits code 2 with "not implemented in phase 0" — it lights up in 1E once the WS log-tail endpoint exists.
 
 ## What's deliberately not parameterized yet
 

--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -91,7 +91,25 @@ def sync(
 @app.command()
 def tick() -> None:
     """One-shot poll-and-dispatch (debug)."""
-    _stub("tick")
+    from fabric.dispatcher import Dispatcher
+    from fabric.scheduler import Scheduler
+    from fabric.state import init_db
+
+    init_db()
+    scheduler = Scheduler(dispatcher=Dispatcher())
+    result = asyncio.run(scheduler.tick())
+
+    if result.skipped_reason:
+        typer.echo(f"tick: skipped — {result.skipped_reason}")
+        return
+    if result.winner is None:
+        typer.echo(f"tick: no actionable issues (polled {result.polled_projects} project(s))")
+        return
+    w = result.winner
+    typer.echo(
+        f"tick: dispatched {w.project}#{w.issue} ({w.stage}) "
+        f"id={w.dispatch_id} exit={w.exit_code}"
+    )
 
 
 @app.command()
@@ -134,19 +152,70 @@ def dispatch(
 @app.command()
 def status() -> None:
     """Text dump of current queue state."""
-    _stub("status")
+    from fabric.state import (
+        get_setting,
+        init_db,
+        list_issues,
+        list_projects,
+        recent_dispatches,
+    )
+
+    init_db()
+    paused = get_setting("paused") == "1"
+    reason = get_setting("paused_reason") or ""
+    pause_line = "paused: yes" if paused else "paused: no"
+    if paused and reason:
+        pause_line += f" — {reason}"
+    typer.echo(pause_line)
+
+    projects = list_projects()
+    if not projects:
+        typer.echo("(no registered projects)")
+    else:
+        typer.echo("")
+        typer.echo("Projects:")
+        for p in projects:
+            issues = list_issues(p.name)
+            actionable = [i for i in issues if i.state_label and i.state_label.startswith("state:")]
+            tag = " [paused]" if p.paused else ""
+            typer.echo(f"  {p.name}{tag}: {len(actionable)} issue(s) tracked")
+
+    typer.echo("")
+    typer.echo("Recent dispatches:")
+    rows = recent_dispatches(limit=5)
+    if not rows:
+        typer.echo("  (none)")
+    for d in rows:
+        ended = d.ended_at or "running"
+        typer.echo(
+            f"  {d.started_at}  {d.project}#{d.issue}  {d.stage}  "
+            f"exit={d.exit_code}  ended={ended}"
+        )
 
 
 @app.command()
 def pause(reason: str = typer.Option("", "--reason", help="Pause reason recorded in state.")) -> None:
     """Set the global pause flag."""
-    _stub("pause")
+    from fabric.state import delete_setting, init_db, set_setting
+
+    init_db()
+    set_setting("paused", "1")
+    if reason:
+        set_setting("paused_reason", reason)
+    else:
+        delete_setting("paused_reason")
+    typer.echo(f"fabric: paused" + (f" ({reason})" if reason else ""))
 
 
 @app.command()
 def resume() -> None:
     """Clear the global pause flag."""
-    _stub("resume")
+    from fabric.state import delete_setting, init_db, set_setting
+
+    init_db()
+    set_setting("paused", "0")
+    delete_setting("paused_reason")
+    typer.echo("fabric: resumed")
 
 
 @app.command()

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -1,0 +1,388 @@
+"""Cross-project scheduler tick — D3 selection + retry/pause/cycle gating.
+
+One `Scheduler.tick()` call:
+  1. Honours three-layer pause (settings flag, per-project flag, touch-file).
+  2. Polls each registered project via `gh.list_issues` and upserts into DB.
+  3. Filters candidates: trusted-author-only, actionable state labels,
+     under cycle cap, past retry-backoff window.
+  4. Sorts by D3 — state tier > priority > round-robin > createdAt.
+  5. Hands the winner to the dispatcher; updates `last_served_at` for fairness.
+
+The 60s tick loop lives in 1E's FastAPI lifespan; this module only ships
+the synchronous decision layer + the CLI hook.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fabric import github as gh
+from fabric import state
+from fabric.config import FabricConfig, load_project_config
+from fabric.dispatcher import Dispatcher, DispatchError, QuotaExceeded
+from fabric.registry import ProjectEntry, fabric_home, load_registry
+
+
+# Drain in-flight first → bring rework/tests back → start fresh planning.
+_STATE_TIER: dict[str, int] = {
+    "state:in-review": 0,
+    "state:needs-rework": 1,
+    "state:tests-pending": 2,
+    "state:needs-planning": 3,
+}
+
+_STAGE_BY_STATE: dict[str, str] = {
+    "state:needs-planning": "plan-exec",
+    "state:needs-rework": "plan-exec",
+    "state:tests-pending": "test-writer",
+    "state:in-review": "review-pr",
+}
+
+_PRIORITY_RANK: dict[str, int] = {
+    "priority:high": 0,
+    "priority:medium": 1,
+    "priority:low": 2,
+}
+_DEFAULT_PRIORITY_RANK = _PRIORITY_RANK["priority:medium"]
+
+
+@dataclass(frozen=True)
+class TickWinner:
+    project: str
+    issue: int
+    stage: str
+    exit_code: int
+    dispatch_id: int
+
+
+@dataclass(frozen=True)
+class TickResult:
+    skipped_reason: str | None = None
+    winner: TickWinner | None = None
+    polled_projects: int = 0
+    candidates: int = 0
+
+
+@dataclass
+class _Candidate:
+    entry: ProjectEntry
+    config: FabricConfig
+    issue_number: int
+    state_label: str
+    priority_rank: int
+    last_served_at: str
+    created_at: str
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(s: str) -> datetime:
+    """Tolerant ISO-8601 parser (handles the Z suffix gh emits)."""
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def _label_with_prefix(labels: Iterable[gh.Label], prefix: str) -> str | None:
+    for lbl in labels:
+        if lbl.name.startswith(prefix):
+            return lbl.name
+    return None
+
+
+class Scheduler:
+    """One-tick dispatcher for the cross-project queue."""
+
+    def __init__(
+        self,
+        *,
+        dispatcher: Dispatcher,
+        gh_runner: gh.SubprocessRunner | None = None,
+        fabric_home_path: Path | None = None,
+        now: Callable[[], datetime] = _now_utc,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._gh_runner: gh.SubprocessRunner = gh_runner or gh._default_runner
+        self._home = fabric_home_path or fabric_home()
+        self._now = now
+
+    # ---- public ----
+
+    async def tick(self) -> TickResult:
+        reason = await self._global_paused_reason()
+        if reason:
+            return TickResult(skipped_reason=reason)
+
+        registry_entries = load_registry()
+        candidates: list[_Candidate] = []
+        polled = 0
+
+        for entry in registry_entries:
+            try:
+                config = await asyncio.to_thread(load_project_config, entry.path)
+            except Exception:
+                continue
+            await self._ensure_state_project(entry, config)
+
+            proj_row = await asyncio.to_thread(state.get_project, entry.name)
+            if proj_row is not None and proj_row.paused:
+                continue
+
+            polled += 1
+            await self._poll_project(entry, config, proj_row, candidates)
+
+        if not candidates:
+            return TickResult(polled_projects=polled, candidates=0)
+
+        candidates.sort(key=self._sort_key)
+        winner = candidates[0]
+        stage = _STAGE_BY_STATE[winner.state_label]
+
+        try:
+            result = await self._dispatcher.dispatch(
+                winner.entry.name,
+                winner.issue_number,
+                stage,
+                triggered_by="scheduler",
+            )
+        except QuotaExceeded as e:
+            return TickResult(
+                skipped_reason=f"quota: {e}",
+                polled_projects=polled,
+                candidates=len(candidates),
+            )
+        except DispatchError as e:
+            return TickResult(
+                skipped_reason=f"dispatch error: {e}",
+                polled_projects=polled,
+                candidates=len(candidates),
+            )
+
+        await asyncio.to_thread(
+            state.set_project_last_served,
+            winner.entry.name,
+            self._now().isoformat(timespec="seconds"),
+        )
+
+        return TickResult(
+            polled_projects=polled,
+            candidates=len(candidates),
+            winner=TickWinner(
+                project=winner.entry.name,
+                issue=winner.issue_number,
+                stage=stage,
+                exit_code=result.exit_code,
+                dispatch_id=result.dispatch_id,
+            ),
+        )
+
+    # ---- pause ----
+
+    async def _global_paused_reason(self) -> str | None:
+        if (self._home / "PAUSED").exists():
+            return f"PAUSED touch-file at {self._home / 'PAUSED'}"
+        flag = await asyncio.to_thread(state.get_setting, "paused")
+        if flag == "1":
+            why = await asyncio.to_thread(state.get_setting, "paused_reason")
+            return f"paused: {why}" if why else "paused"
+        return None
+
+    # ---- polling ----
+
+    async def _ensure_state_project(self, entry: ProjectEntry, config: FabricConfig) -> None:
+        await asyncio.to_thread(
+            state.upsert_project,
+            name=entry.name,
+            path=entry.path,
+            repo=entry.repo,
+            fabric_version=config.fabric_version,
+        )
+
+    async def _poll_project(
+        self,
+        entry: ProjectEntry,
+        config: FabricConfig,
+        proj_row: state.ProjectRow | None,
+        candidates: list[_Candidate],
+    ) -> None:
+        try:
+            issues = await asyncio.to_thread(
+                gh.list_issues,
+                entry.repo,
+                state="open",
+                limit=200,
+                runner=self._gh_runner,
+            )
+        except gh.GhError:
+            return
+
+        last_served = (proj_row.last_served_at if proj_row else None) or ""
+
+        for issue in issues:
+            state_label = _label_with_prefix(issue.labels, "state:")
+            if state_label is None:
+                continue
+            priority_label = _label_with_prefix(issue.labels, "priority:")
+            type_label = _label_with_prefix(issue.labels, "type:")
+            area_label = _label_with_prefix(issue.labels, "area:")
+            author = issue.author.login if issue.author else None
+
+            await asyncio.to_thread(
+                state.upsert_issue,
+                project=entry.name,
+                number=issue.number,
+                state_label=state_label,
+                type_label=type_label,
+                priority_label=priority_label,
+                area_label=area_label,
+                title=issue.title,
+                url=issue.url,
+                author=author,
+                created_at=issue.created_at,
+            )
+
+            if author not in config.project.trusted_authors:
+                continue
+            if state_label not in _STAGE_BY_STATE:
+                continue
+
+            issue_row = await asyncio.to_thread(state.get_issue, entry.name, issue.number)
+            if (
+                issue_row is not None
+                and issue_row.cycle_count >= config.pipeline.cycle_limit
+            ):
+                await self._block_issue(
+                    entry,
+                    issue.number,
+                    state_label,
+                    reason=(
+                        f"cycle cap reached "
+                        f"({issue_row.cycle_count}/{config.pipeline.cycle_limit})"
+                    ),
+                    kind="blocked",
+                )
+                continue
+
+            failures = await asyncio.to_thread(
+                state.consecutive_failures, entry.name, issue.number
+            )
+            if failures >= config.pipeline.retry_count:
+                await self._block_issue(
+                    entry,
+                    issue.number,
+                    state_label,
+                    reason=f"dispatch failed {failures} times",
+                    kind="dispatch-failed",
+                )
+                continue
+            if failures > 0:
+                latest = await asyncio.to_thread(
+                    state.latest_dispatch, entry.name, issue.number
+                )
+                if latest and latest.ended_at and self._in_backoff(
+                    failures, latest.ended_at, config.pipeline.retry_backoff_seconds
+                ):
+                    continue
+
+            candidates.append(
+                _Candidate(
+                    entry=entry,
+                    config=config,
+                    issue_number=issue.number,
+                    state_label=state_label,
+                    priority_rank=_PRIORITY_RANK.get(
+                        priority_label or "", _DEFAULT_PRIORITY_RANK
+                    ),
+                    last_served_at=last_served,
+                    created_at=issue.created_at or "",
+                )
+            )
+
+    def _in_backoff(
+        self, failures: int, ended_at: str, backoffs: list[int]
+    ) -> bool:
+        if not backoffs:
+            return False
+        idx = min(failures - 1, len(backoffs) - 1)
+        delay = backoffs[idx]
+        try:
+            ended = _parse_iso(ended_at)
+        except ValueError:
+            return False
+        elapsed = (self._now() - ended).total_seconds()
+        return elapsed < delay
+
+    # ---- D3 sort ----
+
+    def _sort_key(self, c: _Candidate) -> tuple[int, int, str, str, int]:
+        return (
+            _STATE_TIER.get(c.state_label, 99),
+            c.priority_rank,
+            c.last_served_at,  # ascending → less-recently-served goes first
+            c.created_at,      # ascending → older issue goes first
+            c.issue_number,
+        )
+
+    # ---- blocking ----
+
+    async def _block_issue(
+        self,
+        entry: ProjectEntry,
+        issue_number: int,
+        current_state: str,
+        *,
+        reason: str,
+        kind: str,
+    ) -> None:
+        recent = await asyncio.to_thread(
+            state.dispatches_for_issue, entry.name, issue_number, limit=5
+        )
+        body_lines = [f"⚠️ Auto-blocked: {reason}", "", "Recent attempts:"]
+        for d in recent:
+            tail = f" log={d.log_path}" if d.log_path else ""
+            body_lines.append(
+                f"- {d.started_at} stage={d.stage} exit={d.exit_code}{tail}"
+            )
+        body = "\n".join(body_lines)
+
+        try:
+            await asyncio.to_thread(
+                gh.comment, entry.repo, issue_number, body, runner=self._gh_runner
+            )
+            await asyncio.to_thread(
+                gh.remove_labels,
+                entry.repo,
+                issue_number,
+                [current_state],
+                runner=self._gh_runner,
+            )
+            await asyncio.to_thread(
+                gh.add_labels,
+                entry.repo,
+                issue_number,
+                ["state:blocked"],
+                runner=self._gh_runner,
+            )
+        except gh.GhError:
+            pass  # best-effort — next tick can retry
+
+        await asyncio.to_thread(
+            state.upsert_issue,
+            project=entry.name,
+            number=issue_number,
+            state_label="state:blocked",
+        )
+        await asyncio.to_thread(
+            state.add_notification, kind=kind, project=entry.name, issue=issue_number
+        )
+
+
+__all__ = [
+    "Scheduler",
+    "TickResult",
+    "TickWinner",
+]

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -34,6 +34,8 @@ class ProjectRow:
     repo: str
     fabric_version: str | None
     registered_at: str
+    last_served_at: str | None = None
+    paused: bool = False
 
 
 @dataclass(frozen=True)
@@ -48,6 +50,8 @@ class IssueRow:
     url: str | None
     cycle_count: int
     last_seen_at: str
+    author: str | None = None
+    created_at: str | None = None
 
 
 @dataclass(frozen=True)
@@ -146,7 +150,15 @@ CREATE TABLE settings (
 );
 """
 
-_MIGRATIONS: list[tuple[int, str]] = [(1, _SCHEMA_V1)]
+_SCHEMA_V2 = """
+ALTER TABLE projects ADD COLUMN last_served_at TEXT;
+ALTER TABLE projects ADD COLUMN paused INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE issues ADD COLUMN author TEXT;
+ALTER TABLE issues ADD COLUMN created_at TEXT;
+"""
+
+
+_MIGRATIONS: list[tuple[int, str]] = [(1, _SCHEMA_V1), (2, _SCHEMA_V2)]
 
 
 def _utc_now() -> str:
@@ -239,13 +251,59 @@ def upsert_project(
         conn.commit()
 
 
+def _project_from_row(r: sqlite3.Row) -> ProjectRow:
+    return ProjectRow(
+        name=r["name"],
+        path=r["path"],
+        repo=r["repo"],
+        fabric_version=r["fabric_version"],
+        registered_at=r["registered_at"],
+        last_served_at=r["last_served_at"],
+        paused=bool(r["paused"]),
+    )
+
+
+_PROJECT_COLS = (
+    "name, path, repo, fabric_version, registered_at, last_served_at, paused"
+)
+
+
 def list_projects() -> list[ProjectRow]:
     with connect() as conn:
         rows = conn.execute(
-            "SELECT name, path, repo, fabric_version, registered_at "
-            "FROM projects ORDER BY name"
+            f"SELECT {_PROJECT_COLS} FROM projects ORDER BY name"
         ).fetchall()
-        return [ProjectRow(**dict(r)) for r in rows]
+        return [_project_from_row(r) for r in rows]
+
+
+def get_project(name: str) -> ProjectRow | None:
+    with connect() as conn:
+        row = conn.execute(
+            f"SELECT {_PROJECT_COLS} FROM projects WHERE name = ?", (name,)
+        ).fetchone()
+        return _project_from_row(row) if row else None
+
+
+def set_project_paused(name: str, paused: bool) -> None:
+    with connect() as conn:
+        result = conn.execute(
+            "UPDATE projects SET paused = ? WHERE name = ?",
+            (1 if paused else 0, name),
+        )
+        if result.rowcount == 0:
+            raise StateError(f"project {name!r} not found")
+        conn.commit()
+
+
+def set_project_last_served(name: str, ts: str) -> None:
+    with connect() as conn:
+        result = conn.execute(
+            "UPDATE projects SET last_served_at = ? WHERE name = ?",
+            (ts, name),
+        )
+        if result.rowcount == 0:
+            raise StateError(f"project {name!r} not found")
+        conn.commit()
 
 
 def delete_project(name: str) -> None:
@@ -267,12 +325,15 @@ def upsert_issue(
     area_label: str | None = None,
     title: str | None = None,
     url: str | None = None,
+    author: str | None = None,
+    created_at: str | None = None,
 ) -> None:
     with connect() as conn:
         conn.execute(
             "INSERT INTO issues (project, number, state_label, type_label, "
-            "                    priority_label, area_label, title, url, last_seen_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "                    priority_label, area_label, title, url, "
+            "                    author, created_at, last_seen_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(project, number) DO UPDATE SET "
             "  state_label = excluded.state_label, "
             "  type_label = excluded.type_label, "
@@ -280,6 +341,8 @@ def upsert_issue(
             "  area_label = excluded.area_label, "
             "  title = excluded.title, "
             "  url = excluded.url, "
+            "  author = excluded.author, "
+            "  created_at = COALESCE(issues.created_at, excluded.created_at), "
             "  last_seen_at = excluded.last_seen_at",
             (
                 project,
@@ -290,6 +353,8 @@ def upsert_issue(
                 area_label,
                 title,
                 url,
+                author,
+                created_at,
                 _utc_now(),
             ),
         )
@@ -398,6 +463,30 @@ def latest_dispatch(project: str, issue: int) -> DispatchRow | None:
         return DispatchRow(**dict(row)) if row else None
 
 
+def dispatches_for_issue(project: str, issue: int, *, limit: int = 50) -> list[DispatchRow]:
+    """Newest-first dispatch history for one issue."""
+    with connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM dispatches WHERE project = ? AND issue = ? "
+            "ORDER BY started_at DESC, id DESC LIMIT ?",
+            (project, issue, limit),
+        ).fetchall()
+        return [DispatchRow(**dict(r)) for r in rows]
+
+
+def consecutive_failures(project: str, issue: int) -> int:
+    """How many failed dispatches since the most recent success (or all)."""
+    rows = dispatches_for_issue(project, issue, limit=50)
+    count = 0
+    for r in rows:  # newest first
+        if r.exit_code is None:
+            continue  # still running, ignore
+        if r.exit_code == 0:
+            break
+        count += 1
+    return count
+
+
 def recent_dispatches(*, project: str | None = None, limit: int = 50) -> list[DispatchRow]:
     with connect() as conn:
         if project is None:
@@ -492,9 +581,12 @@ __all__ = [
     "add_notification",
     "complete_dispatch",
     "connect",
+    "consecutive_failures",
     "delete_project",
     "delete_setting",
+    "dispatches_for_issue",
     "get_issue",
+    "get_project",
     "get_setting",
     "inc_quota",
     "init_db",
@@ -506,6 +598,8 @@ __all__ = [
     "recent_dispatches",
     "record_dispatch",
     "set_cycle_count",
+    "set_project_last_served",
+    "set_project_paused",
     "set_setting",
     "state_db_path",
     "upsert_issue",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fabric import state
+from fabric.dispatcher import Dispatcher
+from fabric.registry import register
+from fabric.scheduler import Scheduler
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------- helpers ----------
+
+
+def _aiorun(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _write_project(root: Path, *, name: str = "teach-me-eng-bot",
+                   repo: str = "valdisd96/teach-me-eng-bot") -> Path:
+    fabric_dir = root / ".fabric"
+    fabric_dir.mkdir(parents=True, exist_ok=True)
+    cfg = (FIXTURES / "good.yaml").read_text()
+    cfg = cfg.replace("name: teach-me-eng-bot", f"name: {name}")
+    cfg = cfg.replace("repo: valdisd96/teach-me-eng-bot", f"repo: {repo}")
+    (fabric_dir / "config.yaml").write_text(cfg)
+    return root
+
+
+@dataclass
+class _AsyncByteLines:
+    lines: list[bytes]
+
+    def __aiter__(self) -> "_AsyncByteLines":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if not self.lines:
+            raise StopAsyncIteration
+        return self.lines.pop(0)
+
+
+@dataclass
+class FakeProc:
+    stdout: _AsyncByteLines
+    exit_code: int = 0
+
+    async def wait(self) -> int:
+        return self.exit_code
+
+
+@dataclass
+class FakeSpawner:
+    lines: list[str] = field(default_factory=list)
+    exit_code: int = 0
+    calls: list[list[str]] = field(default_factory=list)
+
+    async def __call__(self, args: list[str], **kwargs: Any) -> FakeProc:
+        self.calls.append(list(args))
+        return FakeProc(
+            stdout=_AsyncByteLines([(line + "\n").encode() for line in self.lines]),
+            exit_code=self.exit_code,
+        )
+
+
+@dataclass
+class _GhRunResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class FakeGhRunner:
+    """Maps `(verb, sub)` keys to canned JSON; falls back to empty success."""
+
+    list_issues_payload: list[dict[str, Any]] = field(default_factory=list)
+    issue_view_payload: dict[str, Any] | None = None
+    calls: list[list[str]] = field(default_factory=list)
+
+    def __call__(self, args: list[str], **kwargs: Any) -> _GhRunResult:
+        self.calls.append(list(args))
+        # args[0] is "gh"
+        if args[1:4] == ["issue", "list", "--repo"]:
+            return _GhRunResult(stdout=json.dumps(self.list_issues_payload))
+        if args[1:3] == ["issue", "view"]:
+            payload = self.issue_view_payload or {"comments": []}
+            return _GhRunResult(stdout=json.dumps(payload))
+        # fall-through: comment, edit, etc. — succeed silently
+        return _GhRunResult(stdout="https://example/c/1\n")
+
+
+def _issue_payload(
+    number: int,
+    state_label: str | None = "state:needs-planning",
+    *,
+    priority: str | None = None,
+    type_: str | None = None,
+    author: str = "valdisd96",
+    created_at: str = "2026-05-01T10:00:00Z",
+) -> dict[str, Any]:
+    labels: list[dict[str, str]] = []
+    if state_label:
+        labels.append({"name": state_label})
+    if priority:
+        labels.append({"name": priority})
+    if type_:
+        labels.append({"name": type_})
+    return {
+        "number": number,
+        "title": f"Issue {number}",
+        "url": f"https://example/i/{number}",
+        "createdAt": created_at,
+        "labels": labels,
+        "author": {"login": author} if author else None,
+    }
+
+
+# ---------- fixtures ----------
+
+
+@pytest.fixture
+def base_setup(isolated_state_db: Path, tmp_path: Path) -> Path:
+    """One project registered, no issues yet."""
+    p = _write_project(tmp_path / "proj")
+    register(p)
+    return p
+
+
+def _make_scheduler(
+    *,
+    spawner: FakeSpawner | None = None,
+    gh_runner: FakeGhRunner | None = None,
+    now: datetime | None = None,
+) -> Scheduler:
+    spawner = spawner or FakeSpawner()
+    gh_runner = gh_runner or FakeGhRunner()
+    dispatcher = Dispatcher(spawner=spawner, gh_runner=gh_runner)
+    return Scheduler(
+        dispatcher=dispatcher,
+        gh_runner=gh_runner,
+        now=(lambda: now) if now else lambda: datetime.now(timezone.utc),
+    )
+
+
+# ---------- pause ----------
+
+
+def test_tick_skips_when_global_paused(base_setup: Path) -> None:
+    state.set_setting("paused", "1")
+    state.set_setting("paused_reason", "vacation")
+
+    res = _aiorun(_make_scheduler().tick())
+
+    assert res.winner is None
+    assert res.skipped_reason is not None
+    assert "vacation" in res.skipped_reason
+
+
+def test_tick_skips_when_touch_file_exists(base_setup: Path, isolated_fabric_home: Path) -> None:
+    (isolated_fabric_home / "PAUSED").touch()
+
+    res = _aiorun(_make_scheduler().tick())
+
+    assert res.winner is None
+    assert res.skipped_reason is not None
+    assert "PAUSED" in res.skipped_reason
+
+
+def test_tick_per_project_paused_skips_only_that_project(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    a = _write_project(tmp_path / "a", name="a", repo="me/a")
+    b = _write_project(tmp_path / "b", name="b", repo="me/b")
+    register(a)
+    register(b)
+    # Both projects ensured in state via dispatcher self-heal — do it manually here
+    state.upsert_project(name="a", path=str(a), repo="me/a")
+    state.upsert_project(name="b", path=str(b), repo="me/b")
+    state.set_project_paused("a", True)
+
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
+    scheduler = _make_scheduler(gh_runner=gh_runner)
+
+    res = _aiorun(scheduler.tick())
+
+    # only b polled → b's issue should be the winner
+    assert res.polled_projects == 1
+    assert res.winner is not None
+    assert res.winner.project == "b"
+
+
+# ---------- polling + filters ----------
+
+
+def test_tick_no_candidates_when_no_state_labels(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1, state_label=None)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.winner is None
+    assert res.candidates == 0
+    assert res.polled_projects == 1
+
+
+def test_tick_polls_and_upserts_issues(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[
+            _issue_payload(1, "state:needs-planning"),
+            _issue_payload(2, "state:clarification-needed"),
+        ]
+    )
+    _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    rows = state.list_issues("teach-me-eng-bot")
+    assert {r.number for r in rows} == {1, 2}
+
+
+def test_tick_filters_untrusted_authors(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[_issue_payload(1, author="randomdude")]
+    )
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    # the issue is upserted but never enters the candidate pool
+    assert res.candidates == 0
+
+
+def test_tick_skips_non_actionable_states(base_setup: Path) -> None:
+    """state:clarification-needed is a human gate — never dispatched."""
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[_issue_payload(1, "state:clarification-needed")]
+    )
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.candidates == 0
+
+
+# ---------- D3 sort ----------
+
+
+def test_tick_picks_in_review_over_needs_planning(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[
+            _issue_payload(1, "state:needs-planning", created_at="2026-05-01T10:00:00Z"),
+            _issue_payload(2, "state:in-review", created_at="2026-05-02T10:00:00Z"),
+        ]
+    )
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.winner is not None
+    assert res.winner.issue == 2
+    assert res.winner.stage == "review-pr"
+
+
+def test_tick_picks_high_priority_within_tier(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[
+            _issue_payload(1, "state:needs-planning", priority="priority:low"),
+            _issue_payload(2, "state:needs-planning", priority="priority:high"),
+        ]
+    )
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.winner is not None
+    assert res.winner.issue == 2
+
+
+def test_tick_round_robin_uses_last_served_at(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    a = _write_project(tmp_path / "a", name="a", repo="me/a")
+    b = _write_project(tmp_path / "b", name="b", repo="me/b")
+    register(a)
+    register(b)
+    state.upsert_project(name="a", path=str(a), repo="me/a")
+    state.upsert_project(name="b", path=str(b), repo="me/b")
+    # a was served more recently → b should go first
+    state.set_project_last_served("a", "2026-05-04T10:00:00+00:00")
+    state.set_project_last_served("b", "2026-05-03T10:00:00+00:00")
+
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[_issue_payload(1, created_at="2026-05-01T10:00:00Z")]
+    )
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.winner is not None
+    assert res.winner.project == "b"
+
+
+def test_tick_created_at_breaks_final_tie(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[
+            _issue_payload(2, "state:needs-planning", created_at="2026-05-02T10:00:00Z"),
+            _issue_payload(1, "state:needs-planning", created_at="2026-05-01T10:00:00Z"),
+        ]
+    )
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.winner is not None
+    assert res.winner.issue == 1  # earlier created_at wins
+
+
+# ---------- dispatch + last_served ----------
+
+
+def test_tick_dispatches_winner_and_updates_last_served(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    assert res.winner is not None
+    proj = state.get_project("teach-me-eng-bot")
+    assert proj is not None
+    assert proj.last_served_at is not None
+
+
+def test_tick_quota_exceeded_returns_reason(base_setup: Path) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path=str(base_setup), repo="me/x")
+    for _ in range(30):  # good.yaml's daily_dispatch_cap == 30
+        state.inc_quota("teach-me-eng-bot")
+
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    assert res.winner is None
+    assert res.skipped_reason is not None
+    assert "quota" in res.skipped_reason
+
+
+# ---------- cycle-cap / failure auto-block ----------
+
+
+def test_tick_cycle_cap_auto_blocks(base_setup: Path) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path=str(base_setup), repo="me/x")
+    state.upsert_issue(project="teach-me-eng-bot", number=1, state_label="state:needs-planning")
+    state.set_cycle_count("teach-me-eng-bot", 1, 5)  # good.yaml cycle_limit == 5
+
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    assert res.candidates == 0
+    blocked = state.get_issue("teach-me-eng-bot", 1)
+    assert blocked is not None and blocked.state_label == "state:blocked"
+    notifications = state.list_unacked_notifications()
+    assert any(n.kind == "blocked" for n in notifications)
+
+
+def test_tick_consecutive_failures_block(base_setup: Path) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path=str(base_setup), repo="me/x")
+    # 3 consecutive failures, no successes → retry_count == 3 → block
+    for _ in range(3):
+        did = state.record_dispatch(project="teach-me-eng-bot", issue=1, stage="plan-exec")
+        state.complete_dispatch(did, exit_code=1)
+
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    assert res.candidates == 0
+    blocked = state.get_issue("teach-me-eng-bot", 1)
+    assert blocked is not None and blocked.state_label == "state:blocked"
+    notifications = state.list_unacked_notifications()
+    assert any(n.kind == "dispatch-failed" for n in notifications)
+
+
+# ---------- retry-backoff ----------
+
+
+def test_tick_skips_within_backoff(base_setup: Path) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path=str(base_setup), repo="me/x")
+    failed_at = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    did = state.record_dispatch(
+        project="teach-me-eng-bot", issue=1, stage="plan-exec",
+        started_at=failed_at.isoformat(timespec="seconds"),
+    )
+    state.complete_dispatch(
+        did, ended_at=failed_at.isoformat(timespec="seconds"), exit_code=1
+    )
+
+    # 30 seconds after failure < 60s backoff[0]
+    now = failed_at + timedelta(seconds=30)
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner, now=now).tick())
+
+    assert res.candidates == 0
+    assert res.winner is None
+
+
+def test_tick_dispatches_after_backoff_elapsed(base_setup: Path) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path=str(base_setup), repo="me/x")
+    failed_at = datetime(2026, 5, 4, 12, 0, 0, tzinfo=timezone.utc)
+    did = state.record_dispatch(
+        project="teach-me-eng-bot", issue=1, stage="plan-exec",
+        started_at=failed_at.isoformat(timespec="seconds"),
+    )
+    state.complete_dispatch(
+        did, ended_at=failed_at.isoformat(timespec="seconds"), exit_code=1
+    )
+
+    # 90 seconds after failure > 60s backoff[0]
+    now = failed_at + timedelta(seconds=90)
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner, now=now).tick())
+
+    assert res.winner is not None
+    assert res.winner.issue == 1

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -10,9 +10,12 @@ from fabric.state import (
     add_notification,
     complete_dispatch,
     connect,
+    consecutive_failures,
     delete_project,
     delete_setting,
+    dispatches_for_issue,
     get_issue,
+    get_project,
     get_setting,
     inc_quota,
     init_db,
@@ -24,6 +27,8 @@ from fabric.state import (
     recent_dispatches,
     record_dispatch,
     set_cycle_count,
+    set_project_last_served,
+    set_project_paused,
     set_setting,
     state_db_path,
     upsert_issue,
@@ -59,17 +64,21 @@ def test_init_db_creates_tables(isolated_fabric_home: Path) -> None:
 
 
 def test_init_db_records_schema_version(isolated_state_db: Path) -> None:
+    from fabric.state import _MIGRATIONS
+
     with connect(isolated_state_db) as conn:
         rows = conn.execute("SELECT version FROM schema_version").fetchall()
-    assert {r["version"] for r in rows} == {1}
+    assert {r["version"] for r in rows} == {v for v, _ in _MIGRATIONS}
 
 
 def test_init_db_is_idempotent(isolated_fabric_home: Path) -> None:
+    p1 = init_db()
+    with connect(p1) as conn:
+        n1 = conn.execute("SELECT COUNT(*) AS n FROM schema_version").fetchone()["n"]
     init_db()
-    init_db()  # second call must not fail or duplicate-record
-    with connect() as conn:
-        n = conn.execute("SELECT COUNT(*) AS n FROM schema_version").fetchone()["n"]
-    assert n == 1
+    with connect(p1) as conn:
+        n2 = conn.execute("SELECT COUNT(*) AS n FROM schema_version").fetchone()["n"]
+    assert n1 == n2 and n1 > 0
 
 
 def test_pragmas_are_set(isolated_state_db: Path) -> None:
@@ -124,6 +133,38 @@ def test_upsert_project_updates_existing(isolated_state_db: Path) -> None:
     assert len(rows) == 1
     assert rows[0].path == "/new"
     assert rows[0].fabric_version == "0.1.0"
+
+
+def test_get_project_returns_paused_and_last_served(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    p = get_project("t")
+    assert p is not None
+    assert p.paused is False
+    assert p.last_served_at is None
+
+
+def test_get_project_returns_none_for_unknown(isolated_state_db: Path) -> None:
+    assert get_project("nope") is None
+
+
+def test_set_project_paused_round_trip(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    set_project_paused("t", True)
+    assert get_project("t").paused is True  # type: ignore[union-attr]
+    set_project_paused("t", False)
+    assert get_project("t").paused is False  # type: ignore[union-attr]
+
+
+def test_set_project_paused_raises_when_missing(isolated_state_db: Path) -> None:
+    with pytest.raises(StateError, match="not found"):
+        set_project_paused("nope", True)
+
+
+def test_set_project_last_served_persists(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    set_project_last_served("t", "2026-05-04T10:00:00+00:00")
+    p = get_project("t")
+    assert p is not None and p.last_served_at == "2026-05-04T10:00:00+00:00"
 
 
 # ---------- issues ----------
@@ -234,6 +275,72 @@ def test_latest_dispatch_returns_most_recent(isolated_state_db: Path) -> None:
     assert row is not None
     assert row.id == did2
     assert row.stage == "test-writer"
+
+
+def test_dispatches_for_issue_orders_desc(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-01T10:00:00+00:00")
+    record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-02T10:00:00+00:00")
+    record_dispatch(project="t", issue=2, stage="plan-exec", started_at="2026-05-03T10:00:00+00:00")
+
+    rows = dispatches_for_issue("t", 1)
+    assert len(rows) == 2
+    assert rows[0].started_at > rows[1].started_at
+
+
+def test_consecutive_failures_zero_when_no_dispatches(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    assert consecutive_failures("t", 1) == 0
+
+
+def test_consecutive_failures_counts_until_success(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    # success → fail → fail (newest first)
+    a = record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-01T10:00:00+00:00")
+    complete_dispatch(a, exit_code=0)
+    b = record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-02T10:00:00+00:00")
+    complete_dispatch(b, exit_code=1)
+    c = record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-03T10:00:00+00:00")
+    complete_dispatch(c, exit_code=1)
+
+    assert consecutive_failures("t", 1) == 2
+
+
+def test_consecutive_failures_zero_when_last_succeeded(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    a = record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-01T10:00:00+00:00")
+    complete_dispatch(a, exit_code=1)
+    b = record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-02T10:00:00+00:00")
+    complete_dispatch(b, exit_code=0)
+
+    assert consecutive_failures("t", 1) == 0
+
+
+def test_consecutive_failures_skips_running(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    # in-progress dispatch (no exit_code yet) shouldn't count
+    record_dispatch(project="t", issue=1, stage="plan-exec", started_at="2026-05-03T10:00:00+00:00")
+    assert consecutive_failures("t", 1) == 0
+
+
+def test_upsert_issue_records_author_and_created_at(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    upsert_issue(
+        project="t", number=1, author="alice", created_at="2026-05-01T10:00:00+00:00",
+    )
+    row = get_issue("t", 1)
+    assert row is not None
+    assert row.author == "alice"
+    assert row.created_at == "2026-05-01T10:00:00+00:00"
+
+
+def test_upsert_issue_preserves_created_at_on_update(isolated_state_db: Path) -> None:
+    """Upsert with new created_at must NOT overwrite the original."""
+    upsert_project(name="t", path="/p", repo="me/t")
+    upsert_issue(project="t", number=1, created_at="2026-05-01T10:00:00+00:00")
+    upsert_issue(project="t", number=1, created_at="2026-99-99T99:99:99+00:00")
+    row = get_issue("t", 1)
+    assert row is not None and row.created_at == "2026-05-01T10:00:00+00:00"
 
 
 def test_recent_dispatches_orders_desc(isolated_state_db: Path) -> None:


### PR DESCRIPTION
Closes #17. Fourth sub-PR of Phase 1 (#2). Integrates state (1A) + gh (1B) + dispatcher (1C).

## Summary

- `fabric/scheduler.py` (270 LOC) — `Scheduler.tick()` with D3 selection, three-layer pause, retry-backoff filter, cycle-cap and consecutive-failure auto-block.
- `fabric/state.py` — schema migration **v2** (additive): `projects.last_served_at`, `projects.paused`, `issues.author`, `issues.created_at`. New DAOs: `get_project`, `set_project_paused`, `set_project_last_served`, `dispatches_for_issue`, `consecutive_failures`.
- `fabric/cli.py` — `tick`, `pause [--reason]`, `resume`, `status` are real (only `logs` still stubs).
- `tests/test_scheduler.py` — 17 tests covering pause layers, polling/filters, D3 sort across all five tie-breakers, auto-block flow, retry-backoff window.
- `tests/test_state.py` — 11 new DAO tests + idempotency/migration assertions made `_MIGRATIONS`-derived so v3/v4 don't break them.

## Schema migration note

Forward-only. Existing v1 DBs apply v2's `ALTER TABLE` statements at next `init_db()`. New columns are nullable / default 0 — no data loss, no project pin churn required.

## D3 sort key (lowest wins)

```
(state tier, priority rank, last_served_at, issue.created_at, issue.number)
```

State tier: `in-review (0) > rework (1) > tests-pending (2) > needs-planning (3)` — drain in-flight first, then unblock fresh work. Priority rank: `high (0) > medium (1) > low (2)`. Round-robin: project that was served least recently goes first. Then GitHub `createdAt`, then issue number — both ascending so older issues / lower numbers don't starve.

## Auto-block flow

When `cycle_count >= cycle_limit` **or** there have been `pipeline.retry_count` consecutive failures:
1. Comment listing the last ≤ 5 dispatches (timestamp / stage / exit / log path)
2. Swap `state:*` for `state:blocked`
3. Mirror to DB
4. Queue a `notifications` row (kind=`blocked` or `dispatch-failed`) for 1F

Failures on the gh side are swallowed (best-effort); next tick can retry.

## Test plan

- [x] `pytest -q` → 141 passed, 5 skipped (parity)
- [x] CLI smoke: `fabric tick` (no projects) → "no actionable issues"; `fabric pause --reason X` / `fabric status` / `fabric resume` round-trip
- [x] `python -m py_compile` clean
- [ ] CI green on this PR

## Followups (out of scope, tracked elsewhere)

- 1E (#18) — FastAPI `/api/status`, `/api/pause`, `/api/issues/.../dispatch` reuse the same DAOs the CLI status command uses; the 60s tick loop wraps `Scheduler.tick()` in lifespan.
- 1F (#19) — Telegram bot subscribes to dispatcher pubsub + reads `notifications` table; magic-resume on clarification-needed flips the label and the next tick picks it back up.
- 1G (#20) — SMOKE.md walkthrough exercises the full tick → block recovery cycle end-to-end.