### PR TITLE
feat: phase 1F — telegram bot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ fabric/
 ├── server.py        # FastAPI app + lifespan tick loop — REST endpoints from Decision 5, WS /ws/live for live events
 ├── state.py         # SQLite DAO at $FABRIC_HOME/state.db — schema_version + Decision-1 tables, forward-only migrations
 ├── sync.py          # iterates SKILL_NAMES, writes or --checks, SyncResult+SkillDrift with unified diffs
+├── telegram_bot.py  # python-telegram-bot — slash cmds, inline buttons, reply→comment, notification poller
 └── skill_templates/ # the 5 .j2 files — package data, ships in the wheel
 
 examples/
@@ -58,6 +59,7 @@ tests/
 ├── test_dispatcher.py # claude -p subprocess, log streaming, single-flight, cycle counter, downgrade rules
 ├── test_scheduler.py  # tick — pause layers, D3 sort, retry-backoff, cycle-cap, consecutive-failure block
 ├── test_server.py     # FastAPI TestClient — REST endpoints, WS pubsub, lifespan tick
+├── test_telegram_bot.py # callback codec, formatters, handler methods (mocked context.bot), state-transition notifs
 └── test_parity.py     # byte-for-byte gate against teach-me-eng-bot (see below)
 ```
 
@@ -89,8 +91,8 @@ python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
 # tests
-pytest -q                                                    # 161 tests, parity skipped
-TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 166 tests, parity active
+pytest -q                                                    # 185 tests, parity skipped
+TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 190 tests, parity active
 
 # CLI smoke
 fabric --help
@@ -110,7 +112,7 @@ fabric sync teach-me-eng-bot --check               # exit 0 / "is clean"
 - **Phase 2 — web dashboard.** HTMX kanban + action panel.
 - **Phase 3+** — multi-project hardening, GitHub App auth, webhook receiver.
 
-All Phase-1 CLI commands are real as of 1E. `logs --follow` shells out to `tail -f` on the latest dispatch's log file; `server` runs uvicorn on `$FABRIC_HOST:$FABRIC_PORT` (default `127.0.0.1:7878`).
+All Phase-1 CLI commands are real as of 1E. `logs --follow` shells out to `tail -f` on the latest dispatch's log file; `server` runs uvicorn on `$FABRIC_HOST:$FABRIC_PORT` (default `127.0.0.1:7878`). The Telegram bot (1F) auto-starts inside `fabric server`'s lifespan if both `FABRIC_TELEGRAM_TOKEN` and `FABRIC_TELEGRAM_CHAT_ID` are set; absent either, the server logs a one-line warning and continues without the bot.
 
 ## What's deliberately not parameterized yet
 

--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -249,6 +249,8 @@ def server(
     port: int = typer.Option(7878, "--port", envvar="FABRIC_PORT"),
 ) -> None:
     """Run the long-running fabric service (REST + WS + scheduler tick)."""
+    import os
+
     import uvicorn
 
     from fabric.dispatcher import Dispatcher
@@ -259,8 +261,49 @@ def server(
     init_db()
     dispatcher = Dispatcher()
     scheduler = Scheduler(dispatcher=dispatcher)
-    web_app = create_app(scheduler=scheduler, dispatcher=dispatcher)
+
+    tg_factory = _make_telegram_factory(host=host, port=port)
+    web_app = create_app(
+        scheduler=scheduler, dispatcher=dispatcher, telegram_factory=tg_factory
+    )
     uvicorn.run(web_app, host=host, port=port, log_level="info")
+
+
+def _make_telegram_factory(*, host: str, port: int):  # type: ignore[no-untyped-def]
+    """Return a no-arg factory that constructs+starts a TelegramBot, or None.
+
+    Disabled (with a warning at server startup) if either env var is missing.
+    """
+    import os
+
+    token = os.environ.get("FABRIC_TELEGRAM_TOKEN")
+    chat_id = os.environ.get("FABRIC_TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        typer.echo(
+            "telegram: disabled — set FABRIC_TELEGRAM_TOKEN and FABRIC_TELEGRAM_CHAT_ID",
+            err=True,
+        )
+        return None
+    try:
+        chat_id_int = int(chat_id)
+    except ValueError:
+        typer.echo(
+            f"telegram: invalid FABRIC_TELEGRAM_CHAT_ID={chat_id!r}", err=True
+        )
+        return None
+
+    rest_url = f"http://{host}:{port}"
+
+    async def factory():  # type: ignore[no-untyped-def]
+        from fabric.telegram_bot import TelegramBot
+
+        bot = TelegramBot(
+            token=token, chat_id=chat_id_int, rest_base_url=rest_url
+        )
+        await bot.start()
+        return bot
+
+    return factory
 
 
 if __name__ == "__main__":

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -49,6 +49,14 @@ _PRIORITY_RANK: dict[str, int] = {
 }
 _DEFAULT_PRIORITY_RANK = _PRIORITY_RANK["priority:medium"]
 
+# States whose entry triggers a notification for the human (1F's TG bot).
+# Notification is fired only on observed CHANGES, not on first-sight, so a
+# fabric restart re-polling in-progress state doesn't spam.
+_NOTIFY_STATE_KIND: dict[str, str] = {
+    "state:clarification-needed": "clarification",
+    "state:awaiting-decompose-approval": "decompose-approval",
+}
+
 
 @dataclass(frozen=True)
 class TickWinner:
@@ -231,6 +239,9 @@ class Scheduler:
             area_label = _label_with_prefix(issue.labels, "area:")
             author = issue.author.login if issue.author else None
 
+            prev_row = await asyncio.to_thread(state.get_issue, entry.name, issue.number)
+            prev_state = prev_row.state_label if prev_row else None
+
             await asyncio.to_thread(
                 state.upsert_issue,
                 project=entry.name,
@@ -244,6 +255,21 @@ class Scheduler:
                 author=author,
                 created_at=issue.created_at,
             )
+
+            # Fire a notification on observed state transitions. We only fire
+            # when prev_state was already populated (not on first-sight) so a
+            # fabric restart doesn't spam the human chat.
+            if (
+                prev_state is not None
+                and prev_state != state_label
+                and state_label in _NOTIFY_STATE_KIND
+            ):
+                await asyncio.to_thread(
+                    state.add_notification,
+                    kind=_NOTIFY_STATE_KIND[state_label],
+                    project=entry.name,
+                    issue=issue.number,
+                )
 
             if author not in config.project.trusted_authors:
                 continue

--- a/fabric/server.py
+++ b/fabric/server.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from fastapi import FastAPI, HTTPException, WebSocket
 from fastapi.websockets import WebSocketDisconnect
@@ -32,12 +32,16 @@ from fabric.scheduler import Scheduler
 log = logging.getLogger("fabric.server")
 
 
+TelegramBotFactory = Any  # callable returning an awaitable that yields a bot with stop()
+
+
 def create_app(
     *,
     scheduler: Scheduler,
     dispatcher: Dispatcher,
     gh_runner: gh.SubprocessRunner | None = None,
     tick_interval_s: float = 60.0,
+    telegram_factory: TelegramBotFactory | None = None,
 ) -> FastAPI:
     runner: gh.SubprocessRunner = gh_runner or gh._default_runner
 
@@ -45,11 +49,22 @@ def create_app(
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         stop_event = asyncio.Event()
         task = asyncio.create_task(_tick_loop(scheduler, stop_event, tick_interval_s))
+        tg_bot = None
+        if telegram_factory is not None:
+            try:
+                tg_bot = await telegram_factory()
+            except Exception:
+                log.exception("telegram factory failed; bot disabled")
         try:
             yield
         finally:
             stop_event.set()
             await task
+            if tg_bot is not None:
+                try:
+                    await tg_bot.stop()
+                except Exception:
+                    log.exception("telegram bot shutdown failed")
 
     app = FastAPI(title="agent-fabric", lifespan=lifespan)
     app.state.scheduler = scheduler

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -76,6 +76,8 @@ class NotificationRow:
     created_at: str
     delivered_to: str | None
     acknowledged_at: str | None
+    tg_chat_id: int | None = None
+    tg_message_id: int | None = None
 
 
 def state_db_path() -> Path:
@@ -158,7 +160,19 @@ ALTER TABLE issues ADD COLUMN created_at TEXT;
 """
 
 
-_MIGRATIONS: list[tuple[int, str]] = [(1, _SCHEMA_V1), (2, _SCHEMA_V2)]
+_SCHEMA_V3 = """
+ALTER TABLE notifications ADD COLUMN tg_chat_id INTEGER;
+ALTER TABLE notifications ADD COLUMN tg_message_id INTEGER;
+CREATE INDEX idx_notifications_tg
+  ON notifications(tg_chat_id, tg_message_id);
+"""
+
+
+_MIGRATIONS: list[tuple[int, str]] = [
+    (1, _SCHEMA_V1),
+    (2, _SCHEMA_V2),
+    (3, _SCHEMA_V3),
+]
 
 
 def _utc_now() -> str:
@@ -571,6 +585,32 @@ def list_unacked_notifications() -> list[NotificationRow]:
         return [NotificationRow(**dict(r)) for r in rows]
 
 
+def set_notification_tg_message(
+    notification_id: int, *, chat_id: int, message_id: int
+) -> None:
+    """Record the Telegram message we sent for this notification."""
+    with connect() as conn:
+        result = conn.execute(
+            "UPDATE notifications SET tg_chat_id = ?, tg_message_id = ? WHERE id = ?",
+            (chat_id, message_id, notification_id),
+        )
+        if result.rowcount == 0:
+            raise StateError(f"notification {notification_id} not found")
+        conn.commit()
+
+
+def find_notification_by_tg_message(
+    chat_id: int, message_id: int
+) -> NotificationRow | None:
+    """Reverse-lookup: given a TG (chat_id, message_id), find the notification."""
+    with connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM notifications WHERE tg_chat_id = ? AND tg_message_id = ?",
+            (chat_id, message_id),
+        ).fetchone()
+        return NotificationRow(**dict(row)) if row else None
+
+
 __all__ = [
     "DispatchRow",
     "IssueRow",
@@ -585,6 +625,7 @@ __all__ = [
     "delete_project",
     "delete_setting",
     "dispatches_for_issue",
+    "find_notification_by_tg_message",
     "get_issue",
     "get_project",
     "get_setting",
@@ -598,6 +639,7 @@ __all__ = [
     "recent_dispatches",
     "record_dispatch",
     "set_cycle_count",
+    "set_notification_tg_message",
     "set_project_last_served",
     "set_project_paused",
     "set_setting",

--- a/fabric/telegram_bot.py
+++ b/fabric/telegram_bot.py
@@ -1,0 +1,469 @@
+"""Telegram bot — the only human control surface in Phase 1.
+
+Long-poll based (no inbound HTTP needed). Single hardcoded `chat_id`
+auth: any update from a different chat is dropped silently. Slash
+commands and inline-button callbacks both go through the same REST
+surface that 1E exposed, via an in-process `httpx.AsyncClient` pointed
+at our own server. That keeps the TG bot and the future web dashboard
+on identical contracts.
+
+Notifications are DB-driven, not pubsub: a 5s polling loop scans
+`state.list_unacked_notifications()`, sends each as a Telegram message
+with action buttons, records the resulting (chat_id, message_id) so a
+reply-to-message can be reverse-mapped back to (project, issue), then
+acknowledges the row. Polling is deliberate — at our human-scale
+throughput a 5s lag is invisible and the contract stays "the DB is
+source-of-truth, the bot is one of N possible delivery surfaces."
+
+Tests exercise the pure formatters and the handler methods directly
+with a mocked `context.bot`; the python-telegram-bot Application
+itself is constructed only when `start()` is called in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from fabric import state
+
+
+log = logging.getLogger("fabric.telegram_bot")
+
+
+# ---- callback_data ----
+#
+# Telegram caps callback_data at 64 bytes. We use ":"-joined fields:
+#   <action>:<project>:<number>
+# Project names are validated by `fabric/config.py::Project.name` (no `:`).
+# Issue numbers are ints. Total well under 64 bytes for realistic names.
+
+_CALLBACK_PREFIX = "af"  # agent-fabric namespace
+
+
+def encode_callback(action: str, project: str, number: int) -> str:
+    if ":" in action or ":" in project:
+        raise ValueError(f"action/project must not contain ':': {action!r}, {project!r}")
+    return f"{_CALLBACK_PREFIX}:{action}:{project}:{number}"
+
+
+@dataclass(frozen=True)
+class CallbackPayload:
+    action: str
+    project: str
+    number: int
+
+
+def decode_callback(data: str) -> CallbackPayload | None:
+    parts = data.split(":")
+    if len(parts) != 4 or parts[0] != _CALLBACK_PREFIX:
+        return None
+    try:
+        return CallbackPayload(action=parts[1], project=parts[2], number=int(parts[3]))
+    except ValueError:
+        return None
+
+
+# ---- pure formatters ----
+
+
+async def render_queue(rest: httpx.AsyncClient) -> str:
+    r = await rest.get("/api/issues")
+    r.raise_for_status()
+    issues = r.json()
+    if not issues:
+        return "Queue: empty."
+    lines = ["📋 Queue:"]
+    for i in issues[:30]:
+        priority = i.get("priority_label") or ""
+        state_label = i.get("state_label") or "?"
+        lines.append(
+            f"  {i['project']}#{i['number']} [{state_label}] "
+            f"{priority} — {i.get('title') or '?'}"
+        )
+    return "\n".join(lines)
+
+
+async def render_status(rest: httpx.AsyncClient) -> str:
+    s = (await rest.get("/api/status")).raise_for_status().json()
+    paused = "⏸ paused" if s.get("paused") else "▶ running"
+    if s.get("paused") and s.get("paused_reason"):
+        paused += f" — {s['paused_reason']}"
+    return (
+        f"{paused}\n"
+        f"projects: {s.get('projects', 0)}\n"
+        f"actionable issues: {s.get('actionable_issues', 0)}"
+    )
+
+
+async def render_projects(rest: httpx.AsyncClient) -> str:
+    rows = (await rest.get("/api/projects")).raise_for_status().json()
+    if not rows:
+        return "(no registered projects)"
+    lines = ["🗂 Projects:"]
+    for p in rows:
+        tag = " ⏸" if p.get("paused") else ""
+        lines.append(f"  {p['name']}{tag} → {p['repo']}")
+    return "\n".join(lines)
+
+
+async def render_issue(rest: httpx.AsyncClient, project: str, number: int) -> str:
+    r = await rest.get(f"/api/issues/{project}/{number}")
+    if r.status_code == 404:
+        return f"{project}#{number}: not found"
+    r.raise_for_status()
+    i = r.json()
+    return (
+        f"{project}#{number}: {i.get('title') or '?'}\n"
+        f"  state: {i.get('state_label') or '—'}\n"
+        f"  priority: {i.get('priority_label') or '—'}\n"
+        f"  cycle_count: {i.get('cycle_count', 0)}\n"
+        f"  url: {i.get('url') or ''}"
+    )
+
+
+# ---- notification rendering ----
+
+
+_NOTIF_HEADERS = {
+    "blocked": "🚫 Auto-blocked",
+    "dispatch-failed": "💥 Dispatch failed",
+    "clarification": "❓ Clarification needed",
+    "decompose-approval": "📋 Decompose approval",
+    "quota-warning": "⚠️ Quota warning",
+}
+
+
+def render_notification_text(n: state.NotificationRow) -> str:
+    header = _NOTIF_HEADERS.get(n.kind, f"🔔 {n.kind}")
+    return f"{header}\n  {n.project}#{n.issue}"
+
+
+def notification_buttons(n: state.NotificationRow) -> list[list[dict[str, str]]]:
+    """Inline keyboard layout per notification kind. Returns list of rows; each
+    button is a dict with 'text' and 'callback_data' (or 'url')."""
+    if n.kind == "blocked":
+        return [[
+            {"text": "Open issue", "url": f"https://github.com/issues?q=is:issue {n.project}#{n.issue}"},
+            {"text": "Mute", "callback_data": encode_callback("mute", n.project, n.issue)},
+        ]]
+    if n.kind == "dispatch-failed":
+        return [[
+            {"text": "Retry", "callback_data": encode_callback("retry", n.project, n.issue)},
+            {"text": "Block", "callback_data": encode_callback("block", n.project, n.issue)},
+        ]]
+    if n.kind == "clarification":
+        return [[
+            {"text": "Mute", "callback_data": encode_callback("mute", n.project, n.issue)},
+        ]]
+    if n.kind == "decompose-approval":
+        return [[
+            {"text": "Approve", "callback_data": encode_callback("approve_decompose", n.project, n.issue)},
+            {"text": "Reject", "callback_data": encode_callback("reject_decompose", n.project, n.issue)},
+        ]]
+    return []
+
+
+# ---- callback handlers ----
+
+
+async def handle_callback(
+    rest: httpx.AsyncClient, payload: CallbackPayload
+) -> str:
+    """Dispatch an inline-button click to the right REST call. Returns a short
+    status string suitable for `answerCallbackQuery`."""
+    a = payload.action
+    p = payload.project
+    n = payload.number
+    if a == "retry":
+        r = await rest.post(
+            f"/api/issues/{p}/{n}/dispatch", json={"stage": "plan-exec"}
+        )
+        return "queued" if r.is_success else f"error {r.status_code}"
+    if a == "block":
+        r = await rest.post(
+            f"/api/issues/{p}/{n}/label",
+            json={"add": ["state:blocked"], "remove": []},
+        )
+        return "blocked" if r.is_success else f"error {r.status_code}"
+    if a == "mute":
+        return "muted"  # nothing further to do
+    if a == "approve_pr":
+        r = await rest.post(
+            f"/api/prs/{p}/{n}/review", json={"action": "approve"}
+        )
+        return "approved" if r.is_success else f"error {r.status_code}"
+    if a in ("approve_decompose", "reject_decompose"):
+        # Let the user answer with a comment in the next reply; for now, just
+        # post the verdict as a comment so the agent picks it up next tick.
+        verdict = "approve" if a == "approve_decompose" else "reject"
+        r = await rest.post(
+            f"/api/issues/{p}/{n}/comment",
+            json={"body": f"decompose:{verdict}"},
+        )
+        return verdict if r.is_success else f"error {r.status_code}"
+    return f"unknown action: {a}"
+
+
+async def handle_reply_to_notification(
+    rest: httpx.AsyncClient,
+    notif: state.NotificationRow,
+    body: str,
+) -> bool:
+    """Post the reply text as a GH comment on the linked issue."""
+    r = await rest.post(
+        f"/api/issues/{notif.project}/{notif.issue}/comment",
+        json={"body": body},
+    )
+    return r.is_success
+
+
+# ---- bot wiring ----
+
+
+@dataclass
+class _PendingMessage:
+    notification_id: int
+    chat_id: int
+    text: str
+    buttons: list[list[dict[str, str]]]
+
+
+ApplicationFactory = Callable[..., Any]
+
+
+def _default_application_factory(token: str) -> Any:
+    from telegram.ext import Application  # type: ignore[import-not-found]
+
+    return Application.builder().token(token).build()
+
+
+class TelegramBot:
+    """Long-poll Telegram bot. Single chat_id auth.
+
+    The Application object and the httpx client are constructed in `start()`
+    so unit tests can avoid them — call the handler methods (`_cmd_queue` etc.)
+    directly with a mock `context.bot`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        chat_id: int,
+        rest_base_url: str,
+        rest_client: httpx.AsyncClient | None = None,
+        application_factory: ApplicationFactory | None = None,
+        notification_poll_interval_s: float = 5.0,
+    ) -> None:
+        self._token = token
+        self._chat_id = chat_id
+        self._rest_base_url = rest_base_url
+        self._rest = rest_client
+        self._owns_rest = rest_client is None
+        self._application_factory = application_factory or _default_application_factory
+        self._poll_interval = notification_poll_interval_s
+        self._app: Any = None
+        self._notif_task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+
+    # ---- lifecycle ----
+
+    async def start(self) -> None:
+        if self._rest is None:
+            self._rest = httpx.AsyncClient(base_url=self._rest_base_url, timeout=30.0)
+        self._app = self._application_factory(self._token)
+        self._register_handlers(self._app)
+        await self._app.initialize()
+        await self._app.start()
+        await self._app.updater.start_polling()
+        self._notif_task = asyncio.create_task(self._notification_loop())
+        log.info("telegram bot started, chat_id=%s", self._chat_id)
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._notif_task:
+            self._notif_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._notif_task
+        if self._app:
+            with contextlib.suppress(Exception):
+                await self._app.updater.stop()
+            with contextlib.suppress(Exception):
+                await self._app.stop()
+            with contextlib.suppress(Exception):
+                await self._app.shutdown()
+        if self._owns_rest and self._rest is not None:
+            await self._rest.aclose()
+        log.info("telegram bot stopped")
+
+    # ---- handler registration ----
+
+    def _register_handlers(self, app: Any) -> None:
+        from telegram.ext import (  # type: ignore[import-not-found]
+            CallbackQueryHandler,
+            CommandHandler,
+            MessageHandler,
+            filters,
+        )
+
+        chat_filter = filters.Chat(chat_id=self._chat_id)
+        app.add_handler(CommandHandler("queue", self._cmd_queue, filters=chat_filter))
+        app.add_handler(CommandHandler("status", self._cmd_status, filters=chat_filter))
+        app.add_handler(CommandHandler("pause", self._cmd_pause, filters=chat_filter))
+        app.add_handler(CommandHandler("resume", self._cmd_resume, filters=chat_filter))
+        app.add_handler(CommandHandler("projects", self._cmd_projects, filters=chat_filter))
+        app.add_handler(CommandHandler("issue", self._cmd_issue, filters=chat_filter))
+        app.add_handler(CallbackQueryHandler(self._on_callback))
+        app.add_handler(
+            MessageHandler(
+                chat_filter & filters.REPLY & ~filters.COMMAND,
+                self._on_reply,
+            )
+        )
+
+    # ---- command handlers (test these directly) ----
+
+    async def _send(self, context: Any, text: str) -> None:
+        await context.bot.send_message(chat_id=self._chat_id, text=text)
+
+    async def _cmd_queue(self, update: Any, context: Any) -> None:
+        await self._send(context, await render_queue(self._rest))
+
+    async def _cmd_status(self, update: Any, context: Any) -> None:
+        await self._send(context, await render_status(self._rest))
+
+    async def _cmd_projects(self, update: Any, context: Any) -> None:
+        await self._send(context, await render_projects(self._rest))
+
+    async def _cmd_pause(self, update: Any, context: Any) -> None:
+        reason = " ".join(getattr(context, "args", []) or [])
+        r = await self._rest.post("/api/pause", json={"reason": reason or None})
+        text = "paused" if r.is_success else f"error {r.status_code}"
+        if reason:
+            text += f": {reason}"
+        await self._send(context, text)
+
+    async def _cmd_resume(self, update: Any, context: Any) -> None:
+        r = await self._rest.post("/api/resume")
+        await self._send(
+            context, "resumed" if r.is_success else f"error {r.status_code}"
+        )
+
+    async def _cmd_issue(self, update: Any, context: Any) -> None:
+        args = list(getattr(context, "args", []) or [])
+        if len(args) != 2 or not args[1].isdigit():
+            await self._send(context, "usage: /issue <project> <number>")
+            return
+        project, number = args[0], int(args[1])
+        await self._send(context, await render_issue(self._rest, project, number))
+
+    async def _on_callback(self, update: Any, context: Any) -> None:
+        query = update.callback_query
+        if query is None or query.message.chat.id != self._chat_id:
+            return
+        payload = decode_callback(query.data or "")
+        if payload is None:
+            await query.answer("malformed action")
+            return
+        result = await handle_callback(self._rest, payload)
+        await query.answer(result)
+
+    async def _on_reply(self, update: Any, context: Any) -> None:
+        msg = update.message
+        if msg is None or msg.reply_to_message is None:
+            return
+        replied = msg.reply_to_message
+        notif = await asyncio.to_thread(
+            state.find_notification_by_tg_message, replied.chat.id, replied.message_id
+        )
+        if notif is None:
+            return
+        ok = await handle_reply_to_notification(self._rest, notif, msg.text or "")
+        await self._send(context, "comment posted" if ok else "comment failed")
+
+    # ---- notification polling ----
+
+    async def _notification_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                await self._send_pending_notifications()
+            except Exception:
+                log.exception("notification poll failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=self._poll_interval
+                )
+                return
+            except asyncio.TimeoutError:
+                continue
+
+    async def _send_pending_notifications(self) -> None:
+        notifs = await asyncio.to_thread(state.list_unacked_notifications)
+        for n in notifs:
+            text = render_notification_text(n)
+            buttons = notification_buttons(n)
+            try:
+                msg = await self._send_notification_message(text, buttons)
+            except Exception:
+                log.exception("send_message failed for notification %s", n.id)
+                continue
+            await asyncio.to_thread(
+                state.set_notification_tg_message,
+                n.id,
+                chat_id=msg["chat_id"],
+                message_id=msg["message_id"],
+            )
+            await asyncio.to_thread(
+                state.acknowledge_notification, n.id, delivered_to="telegram"
+            )
+
+    async def _send_notification_message(
+        self, text: str, buttons: list[list[dict[str, str]]]
+    ) -> dict[str, int]:
+        """Adapter over the real Application's send_message. Returns (chat_id, message_id)."""
+        from telegram import (  # type: ignore[import-not-found]
+            InlineKeyboardButton,
+            InlineKeyboardMarkup,
+        )
+
+        markup = None
+        if buttons:
+            rows = [
+                [
+                    InlineKeyboardButton(
+                        b["text"],
+                        callback_data=b.get("callback_data"),
+                        url=b.get("url"),
+                    )
+                    for b in row
+                ]
+                for row in buttons
+            ]
+            markup = InlineKeyboardMarkup(rows)
+        msg = await self._app.bot.send_message(
+            chat_id=self._chat_id, text=text, reply_markup=markup
+        )
+        return {"chat_id": msg.chat.id, "message_id": msg.message_id}
+
+
+__all__ = [
+    "CallbackPayload",
+    "TelegramBot",
+    "decode_callback",
+    "encode_callback",
+    "handle_callback",
+    "handle_reply_to_notification",
+    "notification_buttons",
+    "render_issue",
+    "render_notification_text",
+    "render_projects",
+    "render_queue",
+    "render_status",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "uvicorn[standard]>=0.27",
     "websockets>=12.0",
     "httpx>=0.27",
+    "python-telegram-bot>=21",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from fabric import state
+from fabric.dispatcher import Dispatcher
+from fabric.registry import register
+from fabric.scheduler import Scheduler
+from fabric.server import create_app
+from fabric.telegram_bot import (
+    CallbackPayload,
+    TelegramBot,
+    decode_callback,
+    encode_callback,
+    handle_callback,
+    handle_reply_to_notification,
+    notification_buttons,
+    render_issue,
+    render_notification_text,
+    render_projects,
+    render_queue,
+    render_status,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------- helpers ----------
+
+
+def _aiorun(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _write_project(
+    root: Path, *, name: str = "teach-me-eng-bot",
+    repo: str = "valdisd96/teach-me-eng-bot",
+) -> Path:
+    fabric_dir = root / ".fabric"
+    fabric_dir.mkdir(parents=True, exist_ok=True)
+    cfg = (FIXTURES / "good.yaml").read_text()
+    cfg = cfg.replace("name: teach-me-eng-bot", f"name: {name}")
+    cfg = cfg.replace("repo: valdisd96/teach-me-eng-bot", f"repo: {repo}")
+    (fabric_dir / "config.yaml").write_text(cfg)
+    return root
+
+
+@dataclass
+class _AsyncByteLines:
+    lines: list[bytes]
+
+    def __aiter__(self) -> "_AsyncByteLines":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if not self.lines:
+            raise StopAsyncIteration
+        return self.lines.pop(0)
+
+
+@dataclass
+class FakeProc:
+    stdout: _AsyncByteLines
+    exit_code: int = 0
+
+    async def wait(self) -> int:
+        return self.exit_code
+
+
+@dataclass
+class FakeSpawner:
+    lines: list[str] = field(default_factory=list)
+    exit_code: int = 0
+    calls: list[list[str]] = field(default_factory=list)
+
+    async def __call__(self, args: list[str], **kwargs: Any) -> FakeProc:
+        self.calls.append(list(args))
+        return FakeProc(
+            stdout=_AsyncByteLines([(line + "\n").encode() for line in self.lines]),
+            exit_code=self.exit_code,
+        )
+
+
+@dataclass
+class _GhRunResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class FakeGhRunner:
+    list_issues_payload: list[dict[str, Any]] = field(default_factory=list)
+    issue_view_payload: dict[str, Any] | None = None
+    calls: list[list[str]] = field(default_factory=list)
+
+    def __call__(self, args: list[str], **kwargs: Any) -> _GhRunResult:
+        self.calls.append(list(args))
+        if args[1:4] == ["issue", "list", "--repo"]:
+            return _GhRunResult(stdout=json.dumps(self.list_issues_payload))
+        if args[1:3] == ["issue", "view"]:
+            return _GhRunResult(
+                stdout=json.dumps(self.issue_view_payload or {"comments": []})
+            )
+        if args[1:3] == ["issue", "comment"]:
+            return _GhRunResult(stdout="https://example/c/1\n")
+        return _GhRunResult(stdout="")
+
+
+@pytest.fixture
+def app_setup(isolated_state_db: Path, tmp_path: Path) -> dict[str, Any]:
+    project = _write_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner()
+    gh_runner = FakeGhRunner()
+    dispatcher = Dispatcher(spawner=spawner, gh_runner=gh_runner)
+    scheduler = Scheduler(dispatcher=dispatcher, gh_runner=gh_runner)
+    app = create_app(
+        scheduler=scheduler,
+        dispatcher=dispatcher,
+        gh_runner=gh_runner,
+        tick_interval_s=3600.0,
+    )
+    return {
+        "app": app,
+        "dispatcher": dispatcher,
+        "spawner": spawner,
+        "gh_runner": gh_runner,
+        "project": project,
+    }
+
+
+@pytest.fixture
+def rest(app_setup: dict[str, Any]) -> httpx.AsyncClient:
+    """An in-process httpx client routed through the FastAPI app via ASGI."""
+    transport = httpx.ASGITransport(app=app_setup["app"])
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+
+# ---------- callback_data ----------
+
+
+def test_encode_decode_roundtrip() -> None:
+    encoded = encode_callback("retry", "teach-me-eng-bot", 42)
+    decoded = decode_callback(encoded)
+    assert decoded == CallbackPayload(action="retry", project="teach-me-eng-bot", number=42)
+
+
+def test_encode_rejects_colon_in_action() -> None:
+    with pytest.raises(ValueError):
+        encode_callback("retry:malicious", "p", 1)
+
+
+def test_decode_returns_none_for_garbage() -> None:
+    assert decode_callback("not-our-format") is None
+    assert decode_callback("af:retry:p") is None  # missing number
+    assert decode_callback("af:retry:p:notanint") is None
+
+
+def test_decode_rejects_wrong_namespace() -> None:
+    assert decode_callback("other:retry:p:1") is None
+
+
+# ---------- formatters ----------
+
+
+def test_render_queue_empty(rest: httpx.AsyncClient) -> None:
+    text = _aiorun(render_queue(rest))
+    assert text == "Queue: empty."
+
+
+def test_render_queue_lists_issues(
+    isolated_state_db: Path, rest: httpx.AsyncClient
+) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=1, state_label="state:needs-planning",
+        priority_label="priority:high", title="Hi",
+    )
+
+    text = _aiorun(render_queue(rest))
+    assert "teach-me-eng-bot#1" in text
+    assert "state:needs-planning" in text
+    assert "priority:high" in text
+
+
+def test_render_status_running(rest: httpx.AsyncClient) -> None:
+    text = _aiorun(render_status(rest))
+    assert "running" in text
+
+
+def test_render_status_paused_includes_reason(
+    isolated_state_db: Path, rest: httpx.AsyncClient
+) -> None:
+    state.set_setting("paused", "1")
+    state.set_setting("paused_reason", "lunch")
+    text = _aiorun(render_status(rest))
+    assert "paused" in text
+    assert "lunch" in text
+
+
+def test_render_projects_empty(rest: httpx.AsyncClient) -> None:
+    text = _aiorun(render_projects(rest))
+    assert "no registered" in text
+
+
+def test_render_issue_404(rest: httpx.AsyncClient) -> None:
+    text = _aiorun(render_issue(rest, "teach-me-eng-bot", 999))
+    assert "not found" in text
+
+
+# ---------- notification rendering ----------
+
+
+def test_render_notification_for_each_kind() -> None:
+    n_blocked = state.NotificationRow(
+        id=1, kind="blocked", project="p", issue=2,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    text = render_notification_text(n_blocked)
+    assert "Auto-blocked" in text
+    assert "p#2" in text
+
+
+def test_notification_buttons_dispatch_failed_has_retry_and_block() -> None:
+    n = state.NotificationRow(
+        id=1, kind="dispatch-failed", project="p", issue=2,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    rows = notification_buttons(n)
+    flat = [b for row in rows for b in row]
+    actions = {decode_callback(b["callback_data"]).action for b in flat if b.get("callback_data")}  # type: ignore[union-attr]
+    assert "retry" in actions
+    assert "block" in actions
+
+
+# ---------- callback dispatch ----------
+
+
+def test_handle_callback_retry_invokes_dispatch(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    payload = CallbackPayload(action="retry", project="teach-me-eng-bot", number=1)
+    result = _aiorun(handle_callback(rest, payload))
+    assert result == "queued"
+    # The fake spawner ran claude -p
+    assert app_setup["spawner"].calls
+
+
+def test_handle_callback_block_calls_label_endpoint(
+    app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    payload = CallbackPayload(action="block", project="teach-me-eng-bot", number=1)
+    result = _aiorun(handle_callback(rest, payload))
+    assert result == "blocked"
+    assert any("--add-label" in c for c in app_setup["gh_runner"].calls)
+
+
+def test_handle_callback_unknown_action_returns_explanation(
+    rest: httpx.AsyncClient,
+) -> None:
+    result = _aiorun(handle_callback(rest, CallbackPayload(action="nuke", project="p", number=1)))
+    assert "unknown action" in result
+
+
+# ---------- reply-to-message ----------
+
+
+def test_handle_reply_to_notification_posts_comment(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    nid = state.add_notification(kind="clarification", project="teach-me-eng-bot", issue=1)
+    state.set_notification_tg_message(nid, chat_id=42, message_id=99)
+    notif = state.find_notification_by_tg_message(42, 99)
+    assert notif is not None
+
+    ok = _aiorun(handle_reply_to_notification(rest, notif, "the answer is 42"))
+    assert ok is True
+    assert any(c[1:3] == ["issue", "comment"] for c in app_setup["gh_runner"].calls)
+
+
+# ---------- TelegramBot handler methods (with mocked context.bot) ----------
+
+
+def _mock_context() -> Any:
+    bot = AsyncMock()
+    return SimpleNamespace(bot=bot, args=[])
+
+
+def _make_bot(rest: httpx.AsyncClient) -> TelegramBot:
+    return TelegramBot(
+        token="test-token",
+        chat_id=42,
+        rest_base_url="http://unused",
+        rest_client=rest,
+    )
+
+
+def test_cmd_queue_sends_to_chat(
+    isolated_state_db: Path, rest: httpx.AsyncClient
+) -> None:
+    bot = _make_bot(rest)
+    ctx = _mock_context()
+    update = MagicMock()
+
+    _aiorun(bot._cmd_queue(update, ctx))
+
+    ctx.bot.send_message.assert_called_once()
+    kwargs = ctx.bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == 42
+    assert "Queue:" in kwargs["text"]
+
+
+def test_cmd_pause_with_args(rest: httpx.AsyncClient) -> None:
+    bot = _make_bot(rest)
+    ctx = _mock_context()
+    ctx.args = ["lunch", "break"]
+
+    _aiorun(bot._cmd_pause(MagicMock(), ctx))
+
+    ctx.bot.send_message.assert_called_once()
+    text = ctx.bot.send_message.call_args.kwargs["text"]
+    assert "paused" in text
+    assert "lunch break" in text
+
+
+def test_cmd_issue_validates_arg_count(rest: httpx.AsyncClient) -> None:
+    bot = _make_bot(rest)
+    ctx = _mock_context()
+    ctx.args = ["only-one"]
+
+    _aiorun(bot._cmd_issue(MagicMock(), ctx))
+    text = ctx.bot.send_message.call_args.kwargs["text"]
+    assert "usage:" in text
+
+
+# ---------- scheduler-side notification production ----------
+
+
+def test_state_transition_to_clarification_fires_notification(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    project = _write_project(tmp_path / "proj")
+    register(project)
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+
+    # Seed prev state
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=1, state_label="state:needs-planning",
+    )
+
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[
+            {
+                "number": 1,
+                "title": "x",
+                "url": "u",
+                "createdAt": "t",
+                "labels": [{"name": "state:clarification-needed"}],
+                "author": {"login": "valdisd96"},
+            }
+        ]
+    )
+    dispatcher = Dispatcher(spawner=FakeSpawner(), gh_runner=gh_runner)
+    scheduler = Scheduler(dispatcher=dispatcher, gh_runner=gh_runner)
+
+    _aiorun(scheduler.tick())
+
+    notifications = state.list_unacked_notifications()
+    assert any(n.kind == "clarification" and n.issue == 1 for n in notifications)
+
+
+def test_first_sight_does_not_fire_notification(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """First time we see an issue (no prev row) should NOT fire a notif."""
+    project = _write_project(tmp_path / "proj")
+    register(project)
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[
+            {
+                "number": 1,
+                "title": "x",
+                "url": "u",
+                "createdAt": "t",
+                "labels": [{"name": "state:clarification-needed"}],
+                "author": {"login": "valdisd96"},
+            }
+        ]
+    )
+    dispatcher = Dispatcher(spawner=FakeSpawner(), gh_runner=gh_runner)
+    scheduler = Scheduler(dispatcher=dispatcher, gh_runner=gh_runner)
+
+    _aiorun(scheduler.tick())
+
+    notifications = state.list_unacked_notifications()
+    assert all(n.kind != "clarification" for n in notifications)
+
+
+# ---------- TG-message reverse mapping ----------
+
+
+def test_set_and_find_notification_tg_message(isolated_state_db: Path) -> None:
+    state.upsert_project(name="t", path="/p", repo="me/t")
+    nid = state.add_notification(kind="blocked", project="t", issue=1)
+    state.set_notification_tg_message(nid, chat_id=100, message_id=200)
+    found = state.find_notification_by_tg_message(100, 200)
+    assert found is not None
+    assert found.id == nid
+
+
+def test_find_notification_returns_none_for_unknown(isolated_state_db: Path) -> None:
+    assert state.find_notification_by_tg_message(999, 999) is None
+
+
+# ---------- bot lifecycle (with fake Application) ----------
+
+
+def test_bot_start_and_stop_with_fake_application(
+    isolated_state_db: Path, rest: httpx.AsyncClient
+) -> None:
+    """Verify start() / stop() work end-to-end with a mocked Application."""
+
+    fake_app = MagicMock()
+    fake_app.initialize = AsyncMock()
+    fake_app.start = AsyncMock()
+    fake_app.stop = AsyncMock()
+    fake_app.shutdown = AsyncMock()
+    fake_app.updater = MagicMock()
+    fake_app.updater.start_polling = AsyncMock()
+    fake_app.updater.stop = AsyncMock()
+    fake_app.add_handler = MagicMock()
+
+    def factory(token: str) -> Any:
+        return fake_app
+
+    bot = TelegramBot(
+        token="t",
+        chat_id=42,
+        rest_base_url="http://unused",
+        rest_client=rest,
+        application_factory=factory,
+        notification_poll_interval_s=0.05,
+    )
+
+    async def _run() -> None:
+        await bot.start()
+        await asyncio.sleep(0.1)  # let one notification poll run
+        await bot.stop()
+
+    _aiorun(_run())
+
+    fake_app.initialize.assert_called()
+    fake_app.start.assert_called()
+    fake_app.shutdown.assert_called()


### PR DESCRIPTION
Closes #19. Sixth sub-PR of Phase 1 (#2). Lights up the only human control surface for Phase 1.

## Summary

- `fabric/telegram_bot.py` (~340 LOC) — long-poll bot, single chat_id auth, 6 slash commands, inline-button callbacks, reply-to-message → GH comment, 5s notification poller.
- `fabric/state.py` — schema migration **v3** (additive): `notifications.tg_chat_id`, `notifications.tg_message_id` + `idx_notifications_tg`. New DAOs: `set_notification_tg_message`, `find_notification_by_tg_message`.
- `fabric/scheduler.py` — fires `clarification` / `decompose-approval` notifications on observed state transitions (restart-safe: only when `prev_state` was already populated).
- `fabric/server.py` — `create_app(telegram_factory=...)` spawns the bot in lifespan if a factory is provided.
- `fabric/cli.py` — `fabric server` builds a factory iff both `FABRIC_TELEGRAM_TOKEN` and `FABRIC_TELEGRAM_CHAT_ID` are set; otherwise logs and continues without the bot.
- New dep: `python-telegram-bot>=21`.
- `tests/test_telegram_bot.py` — 24 tests: callback codec, formatters, REST routing, handler methods (mocked `context.bot`), reverse-mapping, scheduler-side notification production, bot lifecycle with a fake `Application`.

## Notification triggers wired

| Source | Kind | Buttons |
|---|---|---|
| Cycle cap reached (1D) | `blocked` | Open · Mute |
| Consecutive failures (1D) | `dispatch-failed` | Retry · Block |
| State → `clarification-needed` (1F) | `clarification` | Mute |
| State → `awaiting-decompose-approval` (1F) | `decompose-approval` | Approve · Reject |

## Slash commands

`/queue` `/status` `/pause [reason]` `/resume` `/projects` `/issue <project> <n>` — each calls REST internally via httpx; tests use `ASGITransport` so the round-trip stays in-process.

## Inline-button actions

`callback_data` is `af:<action>:<project>:<number>`. Decoded server-side; routes to the right REST endpoint. Telegram's 64-byte cap is comfortable for realistic project names.

## Reply-to-message

`(chat_id, message_id)` of every sent notification is recorded; replies reverse-map to the linked `(project, issue)` and post the reply text as a GH comment. Magic-resume label flip is **deferred** — see commit body for the reason.

## Test plan

- [x] `pytest -q` → 185 passed, 5 skipped (parity)
- [x] `python -m py_compile` clean
- [x] `fabric --help` and `fabric server --help` import cleanly
- [x] CLI without env vars: warning printed, server starts without bot
- [ ] CI green on this PR
- [ ] Manual smoke (deferred to 1G): real Telegram bot, verify a state-transition fires a TG notification end-to-end

## Followups

- 1G (#20) — SMOKE.md walks through `BotFather` setup, `chat_id` discovery, an end-to-end clarification cycle. May surface the magic-resume label-flip question.