### PR TITLE
feat: phase 1G — VPC deploy + setup-labels + smoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,12 @@ Conceptually identical to SCSS → CSS or `protoc` output: humans edit the sourc
 ```
 fabric/
 ├── api_models.py    # Pydantic v2 request/response shapes for the FastAPI surface (shared with TG bot, future dashboard)
-├── cli.py           # typer app — every subcommand is real; only stubs left are the not-yet-existent ones
+├── cli.py           # typer app — every subcommand is real (10 in total)
 ├── config.py        # pydantic v2 models for .fabric/config.yaml + load_config (strict, extra="forbid")
 ├── dispatcher.py    # async single-flight `claude -p` runner — semaphore, log streaming, pubsub, cycle counter
 ├── registry.py      # ~/.fabric/projects.yaml reader/writer + register(repo_path)
 ├── github.py        # `gh` CLI wrapper — sync, injectable subprocess runner, pydantic models with camelCase aliases
+├── labels.py        # canonical state/priority/type label vocabulary — diff vs GH, idempotent apply
 ├── render.py        # Jinja2 env (StrictUndefined, keep_trailing_newline=True), overlay resolution, render_skill
 ├── scheduler.py     # cross-project tick — D3 selection, three-layer pause, retry-backoff, cycle-cap auto-block
 ├── server.py        # FastAPI app + lifespan tick loop — REST endpoints from Decision 5, WS /ws/live for live events
@@ -45,6 +46,9 @@ fabric/
 examples/
 ├── teach-me-eng-bot.config.yaml         # the worked example; renders to teach-me-eng-bot's current skills byte-for-byte
 └── github-actions/fabric-sync-check.yml # drift CI workflow projects copy into .github/workflows/
+
+scripts/
+└── install-systemd.sh                   # idempotent VPC VM installer — fabric system user, systemd unit, EnvironmentFile
 
 tests/
 ├── conftest.py        # shared fixtures (fabric_root, isolated_fabric_home, project, isolated_state_db)
@@ -60,6 +64,7 @@ tests/
 ├── test_scheduler.py  # tick — pause layers, D3 sort, retry-backoff, cycle-cap, consecutive-failure block
 ├── test_server.py     # FastAPI TestClient — REST endpoints, WS pubsub, lifespan tick
 ├── test_telegram_bot.py # callback codec, formatters, handler methods (mocked context.bot), state-transition notifs
+├── test_labels.py     # canonical label set, diff/apply, gh CRUD argv
 └── test_parity.py     # byte-for-byte gate against teach-me-eng-bot (see below)
 ```
 
@@ -91,8 +96,8 @@ python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
 # tests
-pytest -q                                                    # 185 tests, parity skipped
-TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 190 tests, parity active
+pytest -q                                                    # 200 tests, parity skipped
+TEACH_ME_ENG_BOT_PATH=/path/to/teach-me-eng-bot pytest -q    # 205 tests, parity active
 
 # CLI smoke
 fabric --help
@@ -108,11 +113,11 @@ fabric sync teach-me-eng-bot --check               # exit 0 / "is clean"
 ## Phase status
 
 - **Phase 0 — done.** Issue #1 closed. Renderer, CLI (`register`, `sync`), 5 templates, parity gate, drift CI workflow, package data wiring all shipped.
-- **Phase 1 — next.** Issue #2. Service + Telegram bot. Scheduler, dispatcher (subprocesses `claude -p`), SQLite state, retries, cycle counter, TG notifications + slash commands. The stubbed CLI commands (`tick`, `dispatch`, `status`, `pause`, `resume`, `logs`) become real here.
-- **Phase 2 — web dashboard.** HTMX kanban + action panel.
+- **Phase 1 — done.** Issue #2 closed via 1A–1G: SQLite state (1A), gh wrapper (1B), `claude -p` dispatcher (1C), D3 scheduler (1D), FastAPI + WS (1E), Telegram bot (1F), VPC deploy + SMOKE.md (1G).
+- **Phase 2 — next.** Issue #3. HTMX kanban + action panel against the existing REST surface.
 - **Phase 3+** — multi-project hardening, GitHub App auth, webhook receiver.
 
-All Phase-1 CLI commands are real as of 1E. `logs --follow` shells out to `tail -f` on the latest dispatch's log file; `server` runs uvicorn on `$FABRIC_HOST:$FABRIC_PORT` (default `127.0.0.1:7878`). The Telegram bot (1F) auto-starts inside `fabric server`'s lifespan if both `FABRIC_TELEGRAM_TOKEN` and `FABRIC_TELEGRAM_CHAT_ID` are set; absent either, the server logs a one-line warning and continues without the bot.
+All ten CLI commands are real. `fabric server` runs uvicorn on `$FABRIC_HOST:$FABRIC_PORT` (default `127.0.0.1:7878`); the Telegram bot auto-starts inside its lifespan when `FABRIC_TELEGRAM_TOKEN` + `FABRIC_TELEGRAM_CHAT_ID` are both set, else logs a one-line warning and continues REST-only. Production install: `sudo bash scripts/install-systemd.sh` on a VPC VM, then fill `/etc/fabric/env` and `systemctl start fabric`. End-to-end walkthrough: `SMOKE.md`.
 
 ## What's deliberately not parameterized yet
 
@@ -120,6 +125,6 @@ The schema validates many knobs (modules, blocked_paths, destructive_db_patterns
 
 ## What's intentionally out of scope for this repo
 
-- The bash agent runners in `teach-me-eng-bot/scripts/agent-*.sh` keep working untouched until Phase 1 ports them to `fabric/dispatcher.py`.
+- The bash agent runners in `teach-me-eng-bot/scripts/agent-*.sh` are now superseded by `fabric/dispatcher.py`. They remain on disk as a manual fallback during the cutover window; remove them once SMOKE.md's first end-to-end run lands.
 - Committing `.fabric/config.yaml` + the drift workflow into teach-me-eng-bot itself is a teach-me-eng-bot-side change, not an agent-fabric change.
 - Publishing to PyPI — until then, projects install via `pip install agent-fabric @ git+https://github.com/valdisd96/agent-fabric.git@<sha>`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,7 +29,7 @@ The fabric must:
 2. **Surface the queue** so you can see at a glance — on either laptop or phone — what's running, what's waiting, what needs your input.
 3. **Make human gates one-tap.** Approving a PR, answering a clarification, flipping a label, posting a comment — all from the dashboard or Telegram, without `gh` incantations.
 4. **Reuse generic skills** across projects via templates, while letting any project override any skill locally.
-5. **Stay lightweight.** Single-user. SQLite. Run on the Pi. Tailscale for remote access. No Postgres, no message queue, no Kubernetes.
+5. **Stay lightweight.** Single-user. SQLite. Runs on a small Linux VPC VM (replaces an earlier Pi-based plan; see Decision 13). No Postgres, no message queue, no Kubernetes.
 6. **Be open-source-able later.** Project-specific config is data, not code. Auth abstraction is clean enough to swap PAT for GitHub App.
 
 ## Non-goals (v1)
@@ -48,10 +48,10 @@ The fabric must:
 
 ```
                     ┌────────────────────────────────────────────────┐
-                    │              AGENT FABRIC (Pi)                 │
+                    │           AGENT FABRIC (Linux VPC VM)          │
                     │                                                │
    laptop ──HTTPS──▶│  ┌──────────────────────────────────────────┐ │
-   (Tailscale)      │  │  FastAPI  ──  REST + WebSocket           │ │
+   (Phase 2)        │  │  FastAPI  ──  REST + WebSocket           │ │
                     │  │  HTMX dashboard pages                     │ │
                     │  └──────────────────────────────────────────┘ │
                     │                     │                          │
@@ -432,7 +432,7 @@ Inline reply: replying to a notification message that's tied to an issue posts t
 
 **Choice: F1 for v1, F2 when open-sourcing.** PAT keeps setup zero-touch for a single user. GitHub App becomes worthwhile when (a) you want to share the fabric and not hand out PATs, (b) you want webhooks (Decision 9), or (c) you want fine-grained permissions per repo.
 
-Dashboard auth: HTTP basic auth over Tailscale-only HTTPS. JWT/OAuth is overkill for one user on a private network. **Never expose the dashboard to the public internet** — see Risks.
+Dashboard auth (Phase 2 only — Phase 1 has no inbound HTTP): HTTP basic auth + private-network-only ingress. The VPC VM's internal network or a Tailscale exit-node both work; **never expose the dashboard to the public internet** — see Risks.
 
 Telegram auth: bot only responds to a single hardcoded `chat_id` (yours). Anyone else gets ignored.
 
@@ -471,7 +471,14 @@ Inherited from orchestrator plan G2: 3 retries with backoff (60s, 5min, 15min), 
 
 ### Decision 13 — Deployment
 
-Single systemd unit on the Pi:
+Single systemd unit on a generic Linux VPC VM (Debian/Ubuntu). The earlier
+Pi-on-Tailscale plan is dropped: the VM runs in a private VPC with outbound
+internet for `gh` / `claude` / Telegram polling, and Phase 1 needs **no**
+inbound HTTP — the Telegram bot is long-poll. Phase 2's dashboard adds
+inbound, at which point a private ingress (VPC-internal LB or Tailscale
+exit-node) takes over. The unit is provisioned by `scripts/install-systemd.sh`
+(idempotent; creates the `fabric` system user, drops a 0600 `EnvironmentFile`,
+enables but does not auto-start the service).
 
 ```ini
 [Unit]
@@ -481,18 +488,25 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/srv/agent-fabric/.venv/bin/python -m fabric.server
-Restart=always
-RestartSec=5
 User=fabric
 WorkingDirectory=/srv/agent-fabric
-Environment="FABRIC_HOME=/var/lib/fabric"
+EnvironmentFile=/etc/fabric/env
+ExecStart=/srv/agent-fabric/.venv/bin/fabric server
+Restart=always
+RestartSec=5
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+ReadWritePaths=/var/lib/fabric
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-Tailscale provides the network — both dashboard (HTTPS via `tailscale serve`) and the fabric's outbound `gh`/`claude` calls share the host's network namespace. No port-forwarding to the public internet.
+`/etc/fabric/env` carries `FABRIC_HOME`, `FABRIC_HOST`, `FABRIC_PORT`,
+`FABRIC_TELEGRAM_TOKEN`, `FABRIC_TELEGRAM_CHAT_ID`. See SMOKE.md for the
+full bring-up walkthrough on a fresh VM.
 
 ### Decision 14 — CLI modes
 
@@ -567,7 +581,7 @@ The current plan in `orchestrator-plan.md` was never fully built (only the agent
 
 ### Risks
 
-1. **Dashboard-as-RCE.** The dashboard can dispatch agents, merge PRs, and edit labels across N repos. If exposed beyond Tailscale or auth fails, it's effectively a remote-code-execution surface. Mitigations: Tailscale-only, basic auth, action audit log in DB, rate limit on destructive endpoints.
+1. **Dashboard-as-RCE.** The dashboard can dispatch agents, merge PRs, and edit labels across N repos. If exposed publicly or auth fails, it's effectively a remote-code-execution surface. Mitigations (Phase 2): private-VPC ingress only, basic auth, action audit log in DB, rate limit on destructive endpoints. (Phase 1 has no inbound HTTP at all — Telegram is long-poll outbound.)
 2. **Single point of failure.** Fabric crashes → no project ships. Mitigations: systemd restart, SQLite state survives restart, health endpoint pinged by external uptime monitor.
 3. **Skill-template drift across projects.** Updating a template ripples to all 6–8 projects. A bad template change ships bad PRs everywhere. Mitigations: `fabric sync --dry-run` shows diff per project; `fabric_version` in config pins compatibility; CI drift check fails the build on stale skills.
 4. **Quota explosion.** 6–8 projects × pipeline activity can burn weekly Pro/Max budget faster than you notice. Mitigations: per-project daily cap, Telegram alert at 80% of cap, optional Sonnet downgrade for low-priority work.

--- a/SMOKE.md
+++ b/SMOKE.md
@@ -1,0 +1,144 @@
+# SMOKE — first end-to-end run on a VPC VM
+
+End-to-end walkthrough for bringing up `agent-fabric` on a fresh Linux VM
+and watching one full `state:needs-planning → merged` cycle land via
+Telegram. This replaces the earlier Pi/Tailscale plan — see DESIGN.md
+"Decision 13 — Deployment" for the rationale.
+
+## Prerequisites
+
+- Ubuntu 24.04 (or Debian 12) VPC VM with sudo access.
+- `gh` CLI installed and a Personal Access Token with `repo` scope.
+- `claude` CLI installed (Anthropic's Claude Code).
+- A Telegram bot token from `@BotFather` and your numeric `chat_id`
+  (easiest: message [@userinfobot](https://t.me/userinfobot)).
+
+## 1. Provision the VM
+
+```bash
+# As root
+apt-get update && apt-get install -y python3.11 python3.11-venv git curl jq
+
+# Install gh and claude per their docs
+# (gh: https://cli.github.com — claude: https://docs.claude.com/en/docs/claude-code)
+```
+
+## 2. Check out + install agent-fabric
+
+```bash
+sudo install -d -o "$USER" /srv/agent-fabric
+git clone https://github.com/valdisd96/agent-fabric /srv/agent-fabric
+cd /srv/agent-fabric
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+
+# Confirm CLI imports
+fabric --help
+```
+
+## 3. Authenticate
+
+```bash
+gh auth login          # paste the PAT
+claude login           # see "Headless claude login" below if no browser
+```
+
+### Headless `claude login`
+
+If the VM has no browser:
+
+1. Run `claude login` and copy the OAuth URL it prints.
+2. From your laptop: `ssh -L 8000:localhost:8000 vm-host` (or whichever
+   port `claude` waits on — printed in its log).
+3. Open the URL on your laptop. The OAuth callback hits `localhost:8000`
+   on the laptop, which the SSH tunnel forwards to the VM's local
+   listener.
+4. `claude` prints "logged in"; the SSH tunnel can close.
+
+## 4. Install the systemd unit
+
+```bash
+sudo bash scripts/install-systemd.sh
+```
+
+Edit `/etc/fabric/env`:
+
+```bash
+FABRIC_HOME=/var/lib/fabric
+FABRIC_HOST=127.0.0.1
+FABRIC_PORT=7878
+FABRIC_TELEGRAM_TOKEN=<from BotFather>
+FABRIC_TELEGRAM_CHAT_ID=<your numeric chat_id>
+```
+
+```bash
+sudo systemctl start fabric
+sudo systemctl status fabric    # should be "active (running)"
+```
+
+## 5. Register your first project
+
+```bash
+sudo -u fabric -i bash -lc '
+  cd /srv/projects
+  git clone https://github.com/valdisd96/teach-me-eng-bot
+  cp /srv/agent-fabric/examples/teach-me-eng-bot.config.yaml \
+     teach-me-eng-bot/.fabric/config.yaml
+  /srv/agent-fabric/.venv/bin/fabric register /srv/projects/teach-me-eng-bot
+  /srv/agent-fabric/.venv/bin/fabric setup-labels teach-me-eng-bot --check
+  /srv/agent-fabric/.venv/bin/fabric setup-labels teach-me-eng-bot
+  /srv/agent-fabric/.venv/bin/fabric sync teach-me-eng-bot
+'
+```
+
+## 6. File a smoke issue
+
+On GitHub, create an issue in `valdisd96/teach-me-eng-bot`:
+
+- Title: `smoke: rename README heading`
+- Body: ``Change `# Teach me eng bot` to `# Teach Me — English Bot` in `README.md`.``
+- Labels: `state:needs-planning`, `priority:low`, `type:docs`, `area:bot`
+
+Within 60 seconds the scheduler picks it up.
+
+## 7. Watch the cycle
+
+| Where | What you see |
+|---|---|
+| `journalctl -u fabric -f` | scheduler tick + dispatch lifecycle |
+| `fabric logs teach-me-eng-bot <n> --follow` | streaming `claude -p` stdout |
+| `/queue` in Telegram | the cross-project queue |
+| `/status` in Telegram | paused?, project counts |
+
+Expected progression:
+
+1. **`state:needs-planning` → `state:in-progress`** — `plan-exec` dispatches.
+2. **`state:in-progress` → `state:tests-pending`** — plan committed, branch pushed.
+3. **`state:tests-pending` → `state:in-review`** — `test-writer` runs, PR opens.
+4. Telegram: notification with `Approve` / `Request changes` buttons.
+5. Tap `Approve` → PR merges via squash, branch deletes, issue auto-closes.
+
+## Gotchas observed
+
+(Filled in after the first real run.)
+
+- `claude login` SSH-tunnel quirks:
+- `gh` PAT scope:
+- systemd hardening blocking writes outside `$FABRIC_HOME`:
+- Log rotation under `$FABRIC_HOME/logs/`:
+- TG bot `chat_id` discovery (vs username):
+
+## Useful one-liners
+
+```bash
+# Tail the active dispatch's logs from your laptop
+ssh vm "journalctl -u fabric -f"
+
+# Force-dispatch a specific stage (debug)
+sudo -u fabric /srv/agent-fabric/.venv/bin/fabric dispatch \
+    teach-me-eng-bot 42 plan-exec
+
+# Pause the fabric without stopping the unit
+sudo -u fabric /srv/agent-fabric/.venv/bin/fabric pause --reason "demo"
+```

--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -243,6 +243,59 @@ def logs(
     typer.echo(log_path.read_text(), nl=False)
 
 
+@app.command(name="setup-labels")
+def setup_labels(
+    project: str = typer.Argument(..., help="Project name (must be registered)"),
+    check: bool = typer.Option(
+        False, "--check", help="Print planned changes without writing"
+    ),
+) -> None:
+    """Idempotently provision the canonical label set in a project's repo."""
+    from fabric import github as gh
+    from fabric.config import ConfigError, load_project_config
+    from fabric.labels import all_labels, apply_label_diff, diff_labels
+    from fabric.registry import find as find_project
+
+    entry = find_project(project)
+    if entry is None:
+        typer.echo(f"setup-labels: project {project!r} not registered", err=True)
+        raise typer.Exit(1)
+    try:
+        config = load_project_config(entry.path)
+    except ConfigError as e:
+        typer.echo(f"setup-labels: {e}", err=True)
+        raise typer.Exit(1) from e
+
+    target = all_labels(config.labels.area_labels)
+    try:
+        existing = gh.list_labels(entry.repo)
+    except gh.GhError as e:
+        typer.echo(f"setup-labels: {e}", err=True)
+        raise typer.Exit(2) from e
+
+    diff = diff_labels(target, existing)
+
+    for spec in diff.to_create:
+        typer.echo(f"  create: {spec.name} ({spec.color})")
+    for spec in diff.to_update:
+        typer.echo(f"  update: {spec.name} ({spec.color})")
+    typer.echo(f"  ({len(diff.unchanged)} unchanged)")
+
+    if check:
+        return
+
+    try:
+        apply_label_diff(entry.repo, diff)
+    except gh.GhError as e:
+        typer.echo(f"setup-labels: {e}", err=True)
+        raise typer.Exit(2) from e
+
+    typer.echo(
+        f"setup-labels: created {len(diff.to_create)}, "
+        f"updated {len(diff.to_update)}, unchanged {len(diff.unchanged)}"
+    )
+
+
 @app.command()
 def server(
     host: str = typer.Option("127.0.0.1", "--host", envvar="FABRIC_HOST"),

--- a/fabric/github.py
+++ b/fabric/github.py
@@ -84,6 +84,14 @@ class Label(_GhModel):
     name: str
 
 
+class LabelDetail(_GhModel):
+    """Fuller `gh label list --json` row — used by `fabric setup-labels`."""
+
+    name: str
+    color: str = ""
+    description: str = ""
+
+
 class IssueComment(_GhModel):
     body: str = ""
     author: Author | None = None
@@ -287,6 +295,60 @@ def merge_pr(
     _run_gh(args, runner=runner)
 
 
+def list_labels(
+    repo: str,
+    *,
+    runner: SubprocessRunner = _default_runner,
+) -> list[LabelDetail]:
+    """All labels currently defined in `repo` with their color + description."""
+    args = [
+        "label",
+        "list",
+        "--repo",
+        repo,
+        "--limit",
+        "200",
+        "--json",
+        "name,color,description",
+    ]
+    raw = _run_gh_json(args, runner=runner)
+    if not isinstance(raw, list):
+        raise GhError(f"expected list from `gh label list`, got {type(raw).__name__}")
+    return [LabelDetail.model_validate(item) for item in raw]
+
+
+def create_label(
+    repo: str,
+    name: str,
+    *,
+    color: str,
+    description: str = "",
+    runner: SubprocessRunner = _default_runner,
+) -> None:
+    args = ["label", "create", name, "--repo", repo, "--color", color]
+    if description:
+        args += ["--description", description]
+    _run_gh(args, runner=runner)
+
+
+def edit_label(
+    repo: str,
+    name: str,
+    *,
+    color: str | None = None,
+    description: str | None = None,
+    runner: SubprocessRunner = _default_runner,
+) -> None:
+    if color is None and description is None:
+        return
+    args = ["label", "edit", name, "--repo", repo]
+    if color is not None:
+        args += ["--color", color]
+    if description is not None:
+        args += ["--description", description]
+    _run_gh(args, runner=runner)
+
+
 _HTML_COMMENT_NS = "agent-fabric"
 _COMMENT_ID_RE = re.compile(r"#issuecomment-(\d+)\b")
 
@@ -358,13 +420,17 @@ __all__ = [
     "IssueDetail",
     "IssueSummary",
     "Label",
+    "LabelDetail",
     "PRSummary",
     "SubprocessRunner",
     "add_labels",
     "comment",
+    "create_label",
+    "edit_label",
     "find_pr_for_issue",
     "get_issue",
     "list_issues",
+    "list_labels",
     "merge_pr",
     "remove_labels",
     "review_pr",

--- a/fabric/labels.py
+++ b/fabric/labels.py
@@ -1,0 +1,145 @@
+"""Canonical label vocabulary the pipeline expects.
+
+`state:*` labels drive the dispatcher: scheduler.py's `_STAGE_BY_STATE`
+keys are this module's state-label names. `priority:*` feeds the D3
+sort. `type:*` is informational. Per-project `area:*` labels come from
+`<project>/.fabric/config.yaml::labels.area_labels` — the fabric ships
+the prefix only, the values are project-specific.
+
+Used by `fabric setup-labels <project>` (Phase 1G) to converge a repo's
+GitHub labels to this vocabulary idempotently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fabric import github as gh
+
+
+@dataclass(frozen=True)
+class LabelSpec:
+    name: str
+    color: str  # 6-char hex, no leading '#'
+    description: str = ""
+
+
+# Pipeline state — every transition the scheduler/dispatcher cares about.
+STATE_LABELS: list[LabelSpec] = [
+    LabelSpec("state:needs-planning", "0e8a16", "Ready for plan-exec"),
+    LabelSpec("state:in-progress", "fbca04", "Agent currently working"),
+    LabelSpec("state:tests-pending", "1d76db", "Plan landed; tests next"),
+    LabelSpec("state:in-review", "5319e7", "PR ready; review-pr will run"),
+    LabelSpec("state:needs-rework", "d93f0b", "Review found issues; back to plan-exec"),
+    LabelSpec(
+        "state:clarification-needed",
+        "ff9800",
+        "Waiting on human input — reply to the TG notification",
+    ),
+    LabelSpec(
+        "state:awaiting-decompose-approval",
+        "9c27b0",
+        "Decomposition awaits human approval",
+    ),
+    LabelSpec(
+        "state:blocked",
+        "b60205",
+        "Cycle cap or repeated failure; human intervention required",
+    ),
+    LabelSpec("state:done", "0e8a16", "Closed; pipeline complete"),
+]
+
+# Priority — D3 sort tier inside a state group.
+PRIORITY_LABELS: list[LabelSpec] = [
+    LabelSpec("priority:high", "b60205", "Drains the queue first"),
+    LabelSpec("priority:medium", "fbca04", "Default priority"),
+    LabelSpec("priority:low", "0e8a16", "Eligible for sonnet downgrade"),
+]
+
+# Type — informational; not pipeline-load-bearing.
+TYPE_LABELS: list[LabelSpec] = [
+    LabelSpec("type:feature", "1d76db", ""),
+    LabelSpec("type:bug", "d93f0b", ""),
+    LabelSpec("type:refactor", "5319e7", ""),
+    LabelSpec("type:test", "0e8a16", ""),
+    LabelSpec("type:docs", "fef2c0", ""),
+]
+
+
+def area_labels(area_names: list[str]) -> list[LabelSpec]:
+    """Build `area:<name>` specs from a project's `labels.area_labels` list."""
+    return [
+        LabelSpec(f"area:{name}", "c5def5", "")
+        for name in area_names
+    ]
+
+
+def all_labels(area_names: list[str]) -> list[LabelSpec]:
+    """The full label set for a project."""
+    return [*STATE_LABELS, *PRIORITY_LABELS, *TYPE_LABELS, *area_labels(area_names)]
+
+
+@dataclass(frozen=True)
+class LabelDiff:
+    to_create: list[LabelSpec]
+    to_update: list[LabelSpec]
+    unchanged: list[str]
+
+
+def diff_labels(
+    target: list[LabelSpec], existing: list[gh.LabelDetail]
+) -> LabelDiff:
+    """Compute the create/update/unchanged buckets given current + target."""
+    by_name = {lbl.name: lbl for lbl in existing}
+    to_create: list[LabelSpec] = []
+    to_update: list[LabelSpec] = []
+    unchanged: list[str] = []
+
+    for spec in target:
+        cur = by_name.get(spec.name)
+        if cur is None:
+            to_create.append(spec)
+        elif cur.color.lower() != spec.color.lower() or cur.description != spec.description:
+            to_update.append(spec)
+        else:
+            unchanged.append(spec.name)
+    return LabelDiff(to_create=to_create, to_update=to_update, unchanged=unchanged)
+
+
+def apply_label_diff(
+    repo: str,
+    diff: LabelDiff,
+    *,
+    runner: gh.SubprocessRunner | None = None,
+) -> None:
+    """Apply create/update calls via `gh label create|edit`."""
+    runner = runner or gh._default_runner
+    for spec in diff.to_create:
+        gh.create_label(
+            repo,
+            spec.name,
+            color=spec.color,
+            description=spec.description,
+            runner=runner,
+        )
+    for spec in diff.to_update:
+        gh.edit_label(
+            repo,
+            spec.name,
+            color=spec.color,
+            description=spec.description,
+            runner=runner,
+        )
+
+
+__all__ = [
+    "LabelDiff",
+    "LabelSpec",
+    "PRIORITY_LABELS",
+    "STATE_LABELS",
+    "TYPE_LABELS",
+    "all_labels",
+    "apply_label_diff",
+    "area_labels",
+    "diff_labels",
+]

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# install-systemd.sh — idempotent installer for the agent-fabric systemd unit.
+# Targets a generic Linux VPC VM (Debian/Ubuntu tested). Replaces the earlier
+# Pi-on-Tailscale plan; see DESIGN.md "Decision 13 — Deployment".
+#
+# Usage:
+#   sudo bash scripts/install-systemd.sh
+#
+# Environment overrides (optional):
+#   FABRIC_USER         system user to run the service as           [fabric]
+#   FABRIC_HOME         FABRIC_HOME / state.db location             [/var/lib/fabric]
+#   INSTALL_PREFIX      where the agent-fabric checkout lives       [/srv/agent-fabric]
+
+set -euo pipefail
+
+FABRIC_USER=${FABRIC_USER:-fabric}
+FABRIC_HOME=${FABRIC_HOME:-/var/lib/fabric}
+INSTALL_PREFIX=${INSTALL_PREFIX:-/srv/agent-fabric}
+
+UNIT_PATH=/etc/systemd/system/fabric.service
+ENV_DIR=/etc/fabric
+ENV_FILE=$ENV_DIR/env
+VENV_PYTHON=$INSTALL_PREFIX/.venv/bin/fabric
+
+log() { echo "[install-systemd] $*"; }
+
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo "must run as root (sudo bash $0)" >&2
+    exit 1
+  fi
+}
+
+ensure_user() {
+  if id -u "$FABRIC_USER" >/dev/null 2>&1; then
+    log "user $FABRIC_USER exists"
+  else
+    log "creating system user $FABRIC_USER"
+    useradd --system --home "$FABRIC_HOME" --create-home --shell /usr/sbin/nologin "$FABRIC_USER"
+  fi
+  install -d -o "$FABRIC_USER" -g "$FABRIC_USER" -m 0750 "$FABRIC_HOME"
+}
+
+ensure_env_file() {
+  install -d -m 0755 "$ENV_DIR"
+  if [[ ! -f "$ENV_FILE" ]]; then
+    cat > "$ENV_FILE" <<EOF
+# /etc/fabric/env — sourced by systemd. Mode 0600, owner $FABRIC_USER.
+FABRIC_HOME=$FABRIC_HOME
+FABRIC_HOST=127.0.0.1
+FABRIC_PORT=7878
+
+# Telegram bot — fill both to enable. Comment out for REST-only.
+# FABRIC_TELEGRAM_TOKEN=
+# FABRIC_TELEGRAM_CHAT_ID=
+EOF
+    log "created $ENV_FILE — fill TG creds then: systemctl restart fabric"
+  else
+    log "env file $ENV_FILE present, leaving as-is"
+  fi
+  chown "$FABRIC_USER:$FABRIC_USER" "$ENV_FILE"
+  chmod 0600 "$ENV_FILE"
+}
+
+install_unit() {
+  cat > "$UNIT_PATH" <<EOF
+[Unit]
+Description=Agent Fabric
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$FABRIC_USER
+WorkingDirectory=$INSTALL_PREFIX
+EnvironmentFile=$ENV_FILE
+ExecStart=$VENV_PYTHON server
+Restart=always
+RestartSec=5
+# Hardening: read-only filesystem except FABRIC_HOME and the temp dir.
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+ReadWritePaths=$FABRIC_HOME
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  log "wrote $UNIT_PATH"
+}
+
+main() {
+  require_root
+  ensure_user
+  ensure_env_file
+  install_unit
+  systemctl daemon-reload
+  systemctl enable fabric
+  log "installed. Edit $ENV_FILE and run: systemctl start fabric"
+}
+
+main "$@"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from fabric import github as gh
+from fabric.labels import (
+    LabelSpec,
+    PRIORITY_LABELS,
+    STATE_LABELS,
+    TYPE_LABELS,
+    all_labels,
+    apply_label_diff,
+    area_labels,
+    diff_labels,
+)
+
+
+# ---------- helpers ----------
+
+
+@dataclass
+class _GhRunResult:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class FakeRunner:
+    responses: list[_GhRunResult] = field(default_factory=list)
+    calls: list[list[str]] = field(default_factory=list)
+
+    def __call__(self, args: list[str], **kwargs: Any) -> _GhRunResult:
+        self.calls.append(list(args))
+        if not self.responses:
+            return _GhRunResult()
+        return self.responses.pop(0)
+
+    def queue(self, stdout: str = "", returncode: int = 0) -> None:
+        self.responses.append(_GhRunResult(returncode=returncode, stdout=stdout))
+
+
+# ---------- shape ----------
+
+
+def test_state_labels_cover_all_pipeline_states() -> None:
+    """Every state the scheduler dispatches on must be in the canonical set."""
+    from fabric.scheduler import _STAGE_BY_STATE
+
+    spec_names = {s.name for s in STATE_LABELS}
+    for state_label in _STAGE_BY_STATE:
+        assert state_label in spec_names, f"missing canonical: {state_label}"
+
+
+def test_priority_labels_cover_all_dispatcher_priorities() -> None:
+    from fabric.scheduler import _PRIORITY_RANK
+
+    spec_names = {s.name for s in PRIORITY_LABELS}
+    for priority in _PRIORITY_RANK:
+        assert priority in spec_names
+
+
+def test_all_labels_includes_areas() -> None:
+    target = all_labels(["bot", "vocab"])
+    names = {s.name for s in target}
+    assert "area:bot" in names
+    assert "area:vocab" in names
+    assert "state:needs-planning" in names
+    assert "priority:high" in names
+
+
+def test_area_labels_emits_prefix() -> None:
+    specs = area_labels(["a", "b"])
+    assert [s.name for s in specs] == ["area:a", "area:b"]
+
+
+# ---------- diff ----------
+
+
+def _detail(name: str, color: str = "", description: str = "") -> gh.LabelDetail:
+    return gh.LabelDetail(name=name, color=color, description=description)
+
+
+def test_diff_creates_when_missing() -> None:
+    target = [LabelSpec("priority:high", "b60205", "")]
+    diff = diff_labels(target, [])
+    assert [s.name for s in diff.to_create] == ["priority:high"]
+    assert diff.to_update == []
+
+
+def test_diff_updates_when_color_differs() -> None:
+    target = [LabelSpec("priority:high", "b60205", "")]
+    existing = [_detail("priority:high", color="ffffff")]
+    diff = diff_labels(target, existing)
+    assert diff.to_create == []
+    assert [s.name for s in diff.to_update] == ["priority:high"]
+
+
+def test_diff_updates_when_description_differs() -> None:
+    target = [LabelSpec("priority:high", "b60205", "drains first")]
+    existing = [_detail("priority:high", color="b60205", description="old")]
+    diff = diff_labels(target, existing)
+    assert [s.name for s in diff.to_update] == ["priority:high"]
+
+
+def test_diff_unchanged_when_match() -> None:
+    target = [LabelSpec("priority:high", "b60205", "drains first")]
+    existing = [_detail("priority:high", color="b60205", description="drains first")]
+    diff = diff_labels(target, existing)
+    assert diff.to_create == []
+    assert diff.to_update == []
+    assert diff.unchanged == ["priority:high"]
+
+
+def test_diff_color_compare_is_case_insensitive() -> None:
+    """Match colors regardless of hex casing."""
+    target = [LabelSpec("priority:high", "B60205", "")]
+    existing = [_detail("priority:high", color="b60205")]
+    diff = diff_labels(target, existing)
+    assert diff.unchanged == ["priority:high"]
+
+
+# ---------- apply ----------
+
+
+def test_apply_label_diff_creates_and_edits() -> None:
+    target = [
+        LabelSpec("state:new", "0e8a16", "fresh"),
+        LabelSpec("state:old", "fbca04", "updated desc"),
+    ]
+    existing = [_detail("state:old", color="fbca04", description="stale desc")]
+
+    diff = diff_labels(target, existing)
+    assert [s.name for s in diff.to_create] == ["state:new"]
+    assert [s.name for s in diff.to_update] == ["state:old"]
+
+    runner = FakeRunner()
+    apply_label_diff("me/r", diff, runner=runner)
+
+    create_calls = [c for c in runner.calls if c[1:3] == ["label", "create"]]
+    edit_calls = [c for c in runner.calls if c[1:3] == ["label", "edit"]]
+    assert len(create_calls) == 1
+    assert len(edit_calls) == 1
+    assert "state:new" in create_calls[0]
+    assert "state:old" in edit_calls[0]
+
+
+def test_apply_label_diff_no_calls_when_clean() -> None:
+    runner = FakeRunner()
+    apply_label_diff(
+        "me/r",
+        diff_labels(
+            [LabelSpec("state:done", "0e8a16", "")],
+            [_detail("state:done", color="0e8a16")],
+        ),
+        runner=runner,
+    )
+    assert runner.calls == []
+
+
+# ---------- gh client surface ----------
+
+
+def test_list_labels_invokes_correct_argv() -> None:
+    runner = FakeRunner()
+    runner.queue(stdout="[]")
+    gh.list_labels("me/r", runner=runner)
+    assert runner.calls[0][:5] == ["gh", "label", "list", "--repo", "me/r"]
+
+
+def test_create_label_emits_color_and_description() -> None:
+    runner = FakeRunner()
+    runner.queue()
+    gh.create_label("me/r", "x", color="abcdef", description="hi", runner=runner)
+    args = runner.calls[0]
+    assert "--color" in args and "abcdef" in args
+    assert "--description" in args and "hi" in args
+
+
+def test_edit_label_skips_when_nothing_changed() -> None:
+    runner = FakeRunner()
+    gh.edit_label("me/r", "x", runner=runner)  # color=None, description=None
+    assert runner.calls == []
+
+
+def test_list_labels_parses_camelcase() -> None:
+    payload = [{"name": "n", "color": "abcdef", "description": "d"}]
+    runner = FakeRunner()
+    runner.queue(stdout=json.dumps(payload))
+    rows = gh.list_labels("me/r", runner=runner)
+    assert len(rows) == 1
+    assert rows[0].name == "n"
+    assert rows[0].color == "abcdef"


### PR DESCRIPTION
Closes #20. **Final sub-PR of Phase 1** (#2). Closes the parent issue.

## Summary

- **DESIGN.md**: Pi/Tailscale framing replaced with Linux VPC VM. Tailscale stays mentioned as one option for Phase 2 private-ingress; Phase 1 has zero inbound HTTP.
- **`scripts/install-systemd.sh`** — idempotent installer with systemd hardening (`ProtectSystem=full`, `ProtectHome=true`, `PrivateTmp=true`, `ReadWritePaths=$FABRIC_HOME`). Creates the `fabric` system user, 0600 EnvironmentFile, enables (but doesn't auto-start) the unit.
- **`fabric/labels.py`** — canonical state/priority/type vocabulary with hex colors + descriptions. A unit test asserts `STATE_LABELS` is a superset of `scheduler._STAGE_BY_STATE` keys, so future divergence trips CI instead of a production silent-skip.
- **`fabric setup-labels <project>`** (10th CLI command) — reads project's area labels, merges with canonical, diffs vs. `gh label list`, `--check` prints the plan, otherwise applies. Color comparison is case-insensitive.
- **gh wrapper extensions** — `LabelDetail` model + `list_labels` / `create_label` / `edit_label`.
- **SMOKE.md** — provisioning, headless `claude login` via SSH port-forward, register + setup-labels + sync, first test issue, watching the cycle through TG.

## Why no Pi anymore

User decided to move teach-me-eng-bot into a VPC VM. The Pi-specific concerns (ARM/x86, Tailscale ingress, headless OAuth) collapse into "generic Linux VM with outbound internet" since:

1. Phase 1 has zero inbound HTTP — the Telegram bot is long-poll. So no public IP / port forwarding needed.
2. The dashboard (Phase 2) gains an inbound surface; that's where private-ingress comes back. Tailscale stays as an option there, alongside VPC-internal LBs.

DESIGN.md "Decision 13" now reflects this — the unit file is the same shape but the prose around it drops the Pi/Tailscale specifics.

## CLI surface — final Phase-1 state

```
fabric register       fabric tick           fabric pause
fabric sync           fabric dispatch       fabric resume
fabric setup-labels   fabric status         fabric server
fabric logs
```

10 commands. All real.

## Test plan

- [x] `pytest -q` → 200 passed, 5 skipped (parity)
- [x] `TEACH_ME_ENG_BOT_PATH=… pytest -q` → 205 passed (parity holds across the whole phase)
- [x] `python -m py_compile` clean
- [x] `bash -n scripts/install-systemd.sh` syntax-clean
- [x] `fabric --help` lists all 10 commands; `fabric setup-labels --help` shows `--check`
- [x] Unit-tested invariant: `STATE_LABELS` ⊇ `scheduler._STAGE_BY_STATE`
- [ ] CI green on this PR
- [ ] Manual: real bring-up on a VPC VM per SMOKE.md (gotchas section gets filled afterward)

## What ships in Phase 1, all-up

```
fabric/api_models.py    fabric/labels.py        fabric/state.py
fabric/cli.py           fabric/registry.py      fabric/sync.py
fabric/config.py        fabric/render.py        fabric/telegram_bot.py
fabric/dispatcher.py    fabric/scheduler.py
fabric/github.py        fabric/server.py
scripts/install-systemd.sh                      SMOKE.md
DESIGN.md updated                               .github/workflows/test.yml
```

Schema reached `v3` (3 forward-only migrations). 205 tests + parity gate.

## Followups (Phase 2 / Phase 3 territory)

- Magic-resume label flip on `clarification` reply (deferred from 1F).
- Real e2e test behind `RUN_DISPATCH_E2E=1` (currently a placeholder).
- `find_pr_for_issue` heuristic refinement if 1G's smoke surfaces flakiness.
- The gotchas section of SMOKE.md fills in after the first real VM run.