### PR TITLE
chore: bump default Python to 3.12 across the project

### DIFF
--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: install
-description: Step-by-step procedure for installing agent-fabric on a fresh Ubuntu 24.04 (or Debian 12) VPS and registering the first managed project. Invoke when the user asks to "install", "deploy", "set up", "provision", or "bring up" agent-fabric on a server, VM, or VPS — or asks how to run it next to a managed project like teach-me-eng-bot. Project-internal; not rendered into managed projects by `fabric sync`.
-version: 1.0.0
+description: Step-by-step procedure for installing agent-fabric on a fresh Ubuntu 24.04 LTS VPS and registering the first managed project. Invoke when the user asks to "install", "deploy", "set up", "provision", or "bring up" agent-fabric on a server, VM, or VPS — or asks how to run it next to a managed project like teach-me-eng-bot. Project-internal; not rendered into managed projects by `fabric sync`.
+version: 1.1.0
 ---
 
 # install
 
-Install `agent-fabric` on a fresh Ubuntu 24.04 / Debian 12 VPS, bring up the
+Install `agent-fabric` on a fresh Ubuntu 24.04 LTS VPS, bring up the
 systemd service, and register the first managed project. Companion to
 `SMOKE.md` (the lightweight end-to-end smoke test) — this skill is the
 *detailed* install runbook with the gotchas filled in.
 
-If the user is on a different distro, stop and confirm — package names and
-service paths below assume `apt` + `systemd`. If they're trying to run
-locally for development, point them at `CLAUDE.md` ("Working in this repo")
-instead — this skill is for the deployed service path.
+If the user is on a different distro, stop and confirm — package names,
+service paths, and the Python 3.12 default below assume Ubuntu 24.04 +
+`apt` + `systemd`. Debian 12 ships Python 3.11 and won't satisfy the
+`requires-python = ">=3.12"` pin without `pyenv` or building from source —
+push back rather than improvising. If they're trying to run locally for
+development, point them at `CLAUDE.md` ("Working in this repo") instead —
+this skill is for the deployed service path.
 
 ## What you'll end up with
 
@@ -35,7 +38,7 @@ across all projects (single-flight invariant — see DESIGN.md).
 
 Before running anything, confirm with the user that they have:
 
-- A fresh Ubuntu 24.04 LTS (or Debian 12) VPS with sudo / root access.
+- A fresh Ubuntu 24.04 LTS VPS with sudo / root access.
 - A GitHub Personal Access Token with `repo` scope (and `workflow` if any
   managed project's `safety.blocked_paths` permits `.github/workflows/`
   edits — teach-me-eng-bot blocks them, so `repo` alone is enough there).
@@ -53,20 +56,18 @@ fabricate PATs.
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y python3.11 python3.11-venv git curl jq ca-certificates
+sudo apt-get install -y python3.12 python3.12-venv git curl jq ca-certificates
 ```
 
-Ubuntu 24.04 ships Python 3.12 by default but does not include 3.11. If
-`python3.11` is unavailable from the default repos, add deadsnakes:
+Ubuntu 24.04 ships Python 3.12 in the default repos, which matches the
+`requires-python = ">=3.12"` pin in `pyproject.toml` and what CI tests
+against — no PPA or deadsnakes needed.
+
+Confirm the interpreter is on `$PATH` before continuing:
 
 ```bash
-sudo add-apt-repository -y ppa:deadsnakes/ppa
-sudo apt-get update
-sudo apt-get install -y python3.11 python3.11-venv
+python3.12 --version       # e.g. Python 3.12.3
 ```
-
-Why 3.11 specifically: `pyproject.toml` pins `requires-python = ">=3.11"`
-and the parity tests are run against 3.11 in CI.
 
 ## Step 2 — install `gh` and `claude` CLIs
 
@@ -100,7 +101,7 @@ claude --version
 sudo install -d -o "$USER" /srv/agent-fabric
 git clone https://github.com/valdisd96/agent-fabric /srv/agent-fabric
 cd /srv/agent-fabric
-python3.11 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
 pip install -e .
@@ -108,8 +109,9 @@ fabric --help            # sanity check — must list 10 subcommands
 deactivate
 ```
 
-If `fabric --help` errors with `ModuleNotFoundError`, the venv isn't
-3.11 — re-create it with `python3.11 -m venv` explicitly.
+If `pip install` errors with `Package requires a different Python:
+3.x is not in '>=3.12'`, the venv was created with the wrong interpreter
+— delete `.venv/` and re-run with `python3.12 -m venv` explicitly.
 
 ## Step 4 — install the systemd unit (creates the `fabric` user)
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Use the `dev-flow` skill — branch → change → commit → PR → wait. The u
 
 ```bash
 # setup
-python3.11 -m venv .venv && source .venv/bin/activate
+python3.12 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 
 # tests

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Phase 0 (extract & generalize) — in progress. Phases tracked as GitHub issues.
 ## Install (dev)
 
 ```bash
-python3.11 -m venv .venv && source .venv/bin/activate
+python3.12 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 

--- a/SMOKE.md
+++ b/SMOKE.md
@@ -17,7 +17,7 @@ Telegram. This replaces the earlier Pi/Tailscale plan — see DESIGN.md
 
 ```bash
 # As root
-apt-get update && apt-get install -y python3.11 python3.11-venv git curl jq
+apt-get update && apt-get install -y python3.12 python3.12-venv git curl jq
 
 # Install gh and claude per their docs
 # (gh: https://cli.github.com — claude: https://docs.claude.com/en/docs/claude-code)
@@ -29,7 +29,7 @@ apt-get update && apt-get install -y python3.11 python3.11-venv git curl jq
 sudo install -d -o "$USER" /srv/agent-fabric
 git clone https://github.com/valdisd96/agent-fabric /srv/agent-fabric
 cd /srv/agent-fabric
-python3.11 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -e .
 

--- a/examples/github-actions/fabric-sync-check.yml
+++ b/examples/github-actions/fabric-sync-check.yml
@@ -33,7 +33,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: install agent-fabric
         # Pin to a commit SHA, not a tag — until agent-fabric publishes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "agent-fabric"
 version = "0.1.0"
 description = "Multi-project agent fabric — drives the plan-exec → test-writer → review-pr Claude pipeline across N repos."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Uladzislau Vauchok" }]
 dependencies = [


### PR DESCRIPTION
## Summary

- Bumps `requires-python` to `>=3.12` and aligns every install / CI / docs site with the new floor.
- Motivated by deploy ergonomics: Ubuntu 24.04 LTS ships Python 3.12 in default repos, so the install skill drops the deadsnakes PPA fallback and becomes one `apt install python3.12 python3.12-venv` line.
- Narrows the install skill's officially-supported distro list from "Ubuntu 24.04 / Debian 12" to **Ubuntu 24.04 only** — Debian 12 ships 3.11 and no longer has a turnkey install path under the new pin (would need pyenv or building from source). The skill now warns about that explicitly.

## Files touched

| File | Change |
|---|---|
| `pyproject.toml` | `requires-python = ">=3.11"` → `">=3.12"` |
| `.github/workflows/test.yml` | CI Python `3.11` → `3.12` |
| `examples/github-actions/fabric-sync-check.yml` | drift CI `3.11` → `3.12` (managed projects copying this workflow get the new floor) |
| `README.md`, `CLAUDE.md` | `python3.11 -m venv` → `python3.12 -m venv` in dev-setup snippets |
| `SMOKE.md` | apt install + venv invocations |
| `.claude/skills/install/SKILL.md` | Step 1 rewritten (no deadsnakes); scope narrowed to Ubuntu 24.04; skill version 1.0.0 → 1.1.0 |

## Compatibility note

No Python source is touched. Existing virtualenvs created against 3.11 keep working at runtime — `requires-python` is enforced by `pip install`, not by the interpreter. The new floor only bites on fresh installs and CI, which is the intent.

Existing managed projects that copied the older drift CI workflow keep working until they re-copy from `examples/`. They'll pick up 3.12 the next time they refresh that file (a no-op-equivalent change for projects that don't already block 3.12).

## Test plan

- [ ] CI on this PR runs against 3.12 and stays green (test.yml change is self-validating).
- [ ] `python3.12 -m venv .venv && pip install -e ".[dev]" && pytest -q` clean locally on 3.12.
- [ ] `grep -rn '3\.11\|python3\.11' --include='*.py' --include='*.toml' --include='*.yml' --include='*.yaml' --include='*.md' --include='*.sh' .` returns only the intentional Debian-12 explanatory note in the install skill.
- [ ] `fabric --help` still lists 10 subcommands (no CLI surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)