### PR TITLE
fix: dispatcher claude argv — separate prompt, set permission mode

### DIFF
--- a/fabric/dispatcher.py
+++ b/fabric/dispatcher.py
@@ -285,13 +285,22 @@ class Dispatcher:
         )
 
     def _build_argv(self, *, model: str, project_path: str, stage: str, issue: int) -> list[str]:
+        # `--add-dir <directories...>` is variadic, so the prompt must sit
+        # behind a `--` separator — otherwise `claude` swallows it as
+        # another directory and aborts with "Input must be provided …".
+        # `bypassPermissions` is required for unattended dispatch: without
+        # it, every tool call blocks on a TTY-less permission prompt and
+        # the run produces no output.
         return [
             "claude",
             "-p",
             "--model",
             model,
+            "--permission-mode",
+            "bypassPermissions",
             "--add-dir",
             project_path,
+            "--",
             f"Run the {stage} skill on issue #{issue}.",
         ]
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -132,6 +132,51 @@ def test_dispatch_argv_uses_default_model_and_project_path(
     assert any("plan-exec" in a and "issue #7" in a for a in args)
 
 
+def test_dispatch_argv_isolates_prompt_from_variadic_add_dir(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """Regression: `--add-dir <directories...>` is variadic. The prompt
+    must sit after a `--` separator so claude does not absorb it as a
+    second directory and abort with "Input must be provided …"."""
+
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+
+    _aiorun(d.dispatch("teach-me-eng-bot", 7, "plan-exec"))
+
+    args = spawner.calls[0]
+    assert "--" in args, "prompt must follow a -- separator"
+    sep_idx = args.index("--")
+    add_dir_idx = args.index("--add-dir")
+    assert add_dir_idx < sep_idx, "--add-dir must come before -- so its argument is unambiguous"
+    prompt_idx = next(
+        i for i, a in enumerate(args) if "plan-exec" in a and "issue #7" in a
+    )
+    assert prompt_idx > sep_idx, "prompt must come after --"
+
+
+def test_dispatch_argv_sets_bypass_permission_mode(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """Unattended dispatch needs `--permission-mode bypassPermissions` —
+    the default mode prompts on every tool call, which never resolves
+    without a TTY and silently produces empty output."""
+
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+
+    _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    args = spawner.calls[0]
+    assert "--permission-mode" in args
+    mode_idx = args.index("--permission-mode")
+    assert args[mode_idx + 1] == "bypassPermissions"
+
+
 def test_dispatch_records_started_completed_and_quota(
     isolated_state_db: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

`fabric/dispatcher.py::_build_argv` produces a `claude -p` invocation
that fails on every dispatch. Two distinct bugs, both surfaced on the
first end-to-end VPC smoke against `teach-me-eng-bot`:

1. **`--add-dir` is variadic and eats the prompt.** `claude --help`
   documents `--add-dir <directories...>`. Greedy consumption of every
   following positional means the prompt is parsed as a *second*
   directory, leaving claude with no input — exit 1, stderr:
   `Error: Input must be provided either through stdin or as a prompt
   argument when using --print`.
2. **No `--permission-mode` set.** Claude's default mode prompts on
   every tool call. With no TTY (the systemd service has stdin from
   `/dev/null`), the prompt never resolves, so a dispatch silently
   succeeds (exit 0) with empty output and the issue stays in
   `state:in-progress` forever.

Together they produced three back-to-back exit-1 failures on issue #57
(no plan committed, no labels flipped) and the scheduler
auto-blocked the issue with `state:blocked` after the third strike —
correct behavior for the scheduler, but the dispatch path itself was
wrong.

The fix:

- Insert a `--` separator before the prompt so `--add-dir` cannot
  consume it.
- Set `--permission-mode bypassPermissions` for unattended dispatch.
  Safety policy is enforced elsewhere — per-project `blocked_paths`
  and the skill-side rules in `DESIGN.md` — so bypassing the *prompt*
  doesn't bypass *policy*.

## Test plan

- [x] `pytest -q` → 202 passed, 5 skipped (parity, expected)
- [x] Two regression tests added, both fail on `main` and pass with the fix:
  - `test_dispatch_argv_isolates_prompt_from_variadic_add_dir`
  - `test_dispatch_argv_sets_bypass_permission_mode`
- [x] Manual repro confirmed under exact systemd-service env
  (`User=fabric`, no TTY, stdin=/dev/null, cwd=/srv/agent-fabric):
  ```
  claude -p --model claude-opus-4-7 \
         --permission-mode bypassPermissions \
         --add-dir /srv/projects/teach-me-eng-bot \
         -- 'reply with one word: ok'
  → exit=0, stdout: "ok"
  ```
- [ ] After merge: clear `state:blocked` on teach-me-eng-bot#57 and
  watch a full plan-exec → tests-pending → in-review → merge cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)