### PR TITLE
fix: install-systemd.sh creates /srv/projects + warns on $HOME claude

### DIFF
--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -84,9 +84,27 @@ sudo apt-get update && sudo apt-get install -y gh
 
 `claude` (Anthropic Claude Code CLI): follow
 https://docs.claude.com/en/docs/claude-code — Linux install instructions
-change occasionally, so re-read rather than caching a stale command. The
-binary must end up on `$PATH` for the `fabric` system user (typically
-`/usr/local/bin/claude` works).
+change occasionally, so re-read rather than caching a stale command.
+
+**Critical** — the official curl|sh installer drops the binary at
+`~/.local/share/claude/versions/<v>` (under `$HOME`). The systemd unit
+sets `ProtectHome=true`, which makes `/root/*` and `/home/*`
+**invisible** to the service. A naive `ln -s ~/.local/share/claude/...
+/usr/local/bin/claude` resolves to a hidden path and every dispatch
+fails at exec time with no useful log.
+
+Relocate the binary outside `$HOME` and symlink:
+
+```bash
+sudo install -d -m 0755 /usr/local/share/claude
+V=$(claude --version | awk '{print $1}')        # e.g. 2.1.126
+sudo cp "$(readlink -f "$(command -v claude)")" /usr/local/share/claude/claude-$V
+sudo chmod 0755 /usr/local/share/claude/claude-$V
+sudo ln -sfn /usr/local/share/claude/claude-$V /usr/local/bin/claude
+```
+
+`scripts/install-systemd.sh` warns if it detects `claude` resolving to
+`/root/*` or `/home/*`, so you'll catch this if you skip the relocation.
 
 Verify both:
 
@@ -122,10 +140,15 @@ sudo bash /srv/agent-fabric/scripts/install-systemd.sh
 The script is idempotent. It creates:
 
 - system user `fabric` with `$HOME=/var/lib/fabric`, shell `/usr/sbin/nologin`
+- `/srv/projects` (mode 0750, owned by `fabric`) — managed-repo clones land here
 - `/etc/fabric/env` with stub values, mode 0600, owned by `fabric`
 - `/etc/systemd/system/fabric.service` with the hardening flags
   (`ProtectSystem=full`, `ProtectHome=true`, `PrivateTmp=true`,
   `NoNewPrivileges=true`, `ReadWritePaths=$FABRIC_HOME`)
+
+It also prints a warning if `claude` resolves to a path under `$HOME`
+(see Step 2 caveat) — heed it before continuing, or every dispatch
+will silently fail under the running unit.
 
 **Do not start the unit yet** — auth comes first, otherwise the service
 will boot and fail to dispatch because `gh`/`claude` aren't logged in.
@@ -220,14 +243,9 @@ Common first-boot failures:
 
 ## Step 8 — register the first managed project
 
-`/srv/projects` is **not** created by the installer; create it
-`fabric`-owned first:
-
-```bash
-sudo install -d -o fabric -g fabric -m 0750 /srv/projects
-```
-
-Then clone, configure, register, label, and sync — all as `fabric`:
+`/srv/projects` was created by `install-systemd.sh` (Step 4) — fabric
+owned, mode 0750. Clone, configure, register, label, and sync as
+`fabric`:
 
 **Critical:** `sudo -u` does *not* load `/etc/fabric/env`, so `FABRIC_HOME`
 is unset by default and the CLI falls back to `~/.fabric/projects.yaml`

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 FABRIC_USER=${FABRIC_USER:-fabric}
 FABRIC_HOME=${FABRIC_HOME:-/var/lib/fabric}
 INSTALL_PREFIX=${INSTALL_PREFIX:-/srv/agent-fabric}
+PROJECTS_DIR=${PROJECTS_DIR:-/srv/projects}
 
 UNIT_PATH=/etc/systemd/system/fabric.service
 ENV_DIR=/etc/fabric
@@ -24,6 +25,7 @@ ENV_FILE=$ENV_DIR/env
 VENV_PYTHON=$INSTALL_PREFIX/.venv/bin/fabric
 
 log() { echo "[install-systemd] $*"; }
+warn() { echo "[install-systemd] WARN: $*" >&2; }
 
 require_root() {
   if [[ $EUID -ne 0 ]]; then
@@ -40,6 +42,43 @@ ensure_user() {
     useradd --system --home "$FABRIC_HOME" --create-home --shell /usr/sbin/nologin "$FABRIC_USER"
   fi
   install -d -o "$FABRIC_USER" -g "$FABRIC_USER" -m 0750 "$FABRIC_HOME"
+}
+
+ensure_projects_dir() {
+  if [[ -d "$PROJECTS_DIR" ]]; then
+    log "$PROJECTS_DIR exists"
+  else
+    log "creating $PROJECTS_DIR ($FABRIC_USER:$FABRIC_USER 0750)"
+  fi
+  install -d -o "$FABRIC_USER" -g "$FABRIC_USER" -m 0750 "$PROJECTS_DIR"
+}
+
+# `claude` installed via the official curl|sh installer lands at
+# ~/.local/share/claude/versions/<v> — under HOME, which the unit's
+# ProtectHome=true makes invisible to the service. A naive symlink from
+# /usr/local/bin/claude resolves to that hidden path and every dispatch
+# fails at exec. Detect and tell the operator how to relocate.
+check_claude_path() {
+  local claude_path
+  claude_path=$(command -v claude 2>/dev/null) || {
+    warn "'claude' not on PATH. Install Claude Code (https://docs.claude.com) before starting the service."
+    return 0
+  }
+  local resolved
+  resolved=$(readlink -f "$claude_path")
+  case "$resolved" in
+    /root/*|/home/*)
+      warn "claude resolves to $resolved (under \$HOME)."
+      warn "ProtectHome=true in fabric.service will hide this path from the service."
+      warn "Fix: copy the binary out of \$HOME and re-symlink, e.g.:"
+      warn "  install -d /usr/local/share/claude"
+      warn "  cp $resolved /usr/local/share/claude/claude-\$(claude --version | awk '{print \$1}')"
+      warn "  ln -sfn /usr/local/share/claude/claude-* /usr/local/bin/claude"
+      ;;
+    *)
+      log "claude resolves to $resolved (OK — outside \$HOME)"
+      ;;
+  esac
 }
 
 ensure_env_file() {
@@ -94,8 +133,10 @@ EOF
 main() {
   require_root
   ensure_user
+  ensure_projects_dir
   ensure_env_file
   install_unit
+  check_claude_path
   systemctl daemon-reload
   systemctl enable fabric
   log "installed. Edit $ENV_FILE and run: systemctl start fabric"


### PR DESCRIPTION
## Summary

Two install-time footguns that bit us during the first VPC bring-up:

1. **`/srv/projects` was not created.** The skill said "create it
   first," but it's the kind of step the operator forgets. The script
   now creates it (`ensure_projects_dir` — idempotent,
   fabric:fabric, 0750).

2. **`claude` under `\$HOME` is invisible to the service.** The
   official Anthropic installer drops the binary at
   `~/.local/share/claude/versions/<v>`. The systemd unit's
   `ProtectHome=true` hardening makes `/root/*` and `/home/*` invisible
   to the service. A naive `ln -s ~/.local/share/claude/...
   /usr/local/bin/claude` resolves to a hidden path and every dispatch
   fails at exec time, with the only signal being a confusing path
   error in the per-dispatch log. The script now detects this with
   `check_claude_path` and prints the exact relocate recipe to stderr.

Install skill updated:
- Step 2 documents the relocate-out-of-`\$HOME` procedure and points
  at the script's auto-warning as a safety net.
- Step 4 lists `/srv/projects` in the "what the script creates" block
  and mentions the claude warning.
- Step 8 drops the now-redundant manual `install -d /srv/projects`.

## Test plan

- [x] `bash -n scripts/install-systemd.sh` → syntax OK
- [x] `pytest -q` → 213 passed, 5 skipped (no Python changes)
- [ ] Re-run `install-systemd.sh` on the live VPS to confirm the new
  steps don't break the existing install (both `ensure_projects_dir` and
  `check_claude_path` are idempotent and additive — `/srv/projects`
  already exists; `claude` already lives at `/usr/local/share/claude/...`
  per the manual relocate done during the first install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)