### PR TITLE
fix: dispatcher emits journal lines on dispatch start/end

### DIFF
--- a/fabric/dispatcher.py
+++ b/fabric/dispatcher.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -25,6 +26,9 @@ from fabric import github as gh
 from fabric import state
 from fabric.config import FabricConfig, load_project_config
 from fabric.registry import ProjectEntry, fabric_home, find as find_project
+
+
+log = logging.getLogger("fabric.dispatcher")
 
 
 class DispatchError(Exception):
@@ -216,6 +220,16 @@ class Dispatcher:
             triggered_by=triggered_by,
         )
 
+        log.info(
+            "dispatch start id=%d project=%s issue=%d stage=%s model=%s triggered_by=%s",
+            dispatch_id,
+            entry.name,
+            issue,
+            stage,
+            model,
+            triggered_by,
+        )
+
         await self._publish(
             {
                 "kind": "dispatch_started",
@@ -265,6 +279,30 @@ class Dispatcher:
         )
         await asyncio.to_thread(state.inc_quota, entry.name)
 
+        duration_s = (ended - started).total_seconds()
+        # Bias toward log volume on failure: success at INFO, failure at
+        # WARNING with the log path so journalctl alone tells the story.
+        if exit_code == 0:
+            log.info(
+                "dispatch end id=%d project=%s issue=%d stage=%s exit=0 duration=%.1fs",
+                dispatch_id,
+                entry.name,
+                issue,
+                stage,
+                duration_s,
+            )
+        else:
+            log.warning(
+                "dispatch FAILED id=%d project=%s issue=%d stage=%s exit=%d duration=%.1fs log=%s",
+                dispatch_id,
+                entry.name,
+                issue,
+                stage,
+                exit_code,
+                duration_s,
+                log_path,
+            )
+
         await self._publish(
             {
                 "kind": "dispatch_ended",
@@ -281,7 +319,7 @@ class Dispatcher:
             dispatch_id=dispatch_id,
             exit_code=exit_code,
             log_path=log_path,
-            duration_s=(ended - started).total_seconds(),
+            duration_s=duration_s,
         )
 
     def _build_argv(self, *, model: str, project_path: str, stage: str, issue: int) -> list[str]:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -208,6 +208,50 @@ def test_dispatch_propagates_nonzero_exit(
     assert latest is not None and latest.exit_code == 2
 
 
+def test_dispatch_logs_start_and_end_at_info(
+    isolated_state_db: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """journalctl -u fabric should narrate every dispatch — silence on a
+    successful tick is fine, but a dispatch landing must produce visible
+    log lines. Otherwise the operator has no way to tell from the journal
+    alone whether anything happened."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    d = Dispatcher(spawner=FakeSpawner(lines=["ok"], exit_code=0))
+
+    with caplog.at_level("INFO", logger="fabric.dispatcher"):
+        _aiorun(d.dispatch("teach-me-eng-bot", 7, "plan-exec"))
+
+    starts = [r for r in caplog.records if "dispatch start" in r.message]
+    ends = [r for r in caplog.records if "dispatch end" in r.message]
+    assert len(starts) == 1, [r.message for r in caplog.records]
+    assert len(ends) == 1
+    assert "issue=7" in starts[0].message
+    assert "stage=plan-exec" in starts[0].message
+    assert "exit=0" in ends[0].message
+
+
+def test_dispatch_logs_failure_at_warning(
+    isolated_state_db: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Non-zero exits should hit WARNING and include the log path so the
+    operator can jump straight to the per-dispatch transcript."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    d = Dispatcher(spawner=FakeSpawner(lines=["boom"], exit_code=1))
+
+    with caplog.at_level("INFO", logger="fabric.dispatcher"):
+        _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    failures = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "dispatch FAILED" in r.message
+    ]
+    assert len(failures) == 1, [r.message for r in caplog.records]
+    assert "exit=1" in failures[0].message
+    assert "log=" in failures[0].message
+
+
 # ---------- error paths ----------
 
 


### PR DESCRIPTION
## Summary

Before this, `journalctl -u fabric` showed **nothing** on dispatch —
only uvicorn boot lines. The first end-to-end smoke ran three failing
plan-exec attempts and the journal stayed silent throughout. Diagnosis
required scraping `/api/dispatches` and `cat`-ing per-dispatch log
files. Made root-causing the variadic-flag bug far harder than it
needed to be.

Three structured lines through the existing
`logging.getLogger("fabric.dispatcher")` (matching the convention in
`fabric.server` / `fabric.telegram_bot`):

- **Start (INFO):** id, project, issue, stage, model, triggered_by
- **End, exit=0 (INFO):** id, project, issue, stage, exit, duration
- **End, exit≠0 (WARNING):** same fields **+ the per-dispatch log path**
  so the operator can jump straight to the transcript

systemd's journal already captures unit stdout/stderr, which is where
Python `logging` (default handler) writes — no config change.

## Test plan

- [x] `pytest -q` → 215 passed, 5 skipped (was 213, +2)
- [x] Two regression tests via `caplog`:
  - `test_dispatch_logs_start_and_end_at_info` (exit 0 path)
  - `test_dispatch_logs_failure_at_warning` (non-zero exit, asserts the log path is in the line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)