### PR TITLE
feat: /healthz liveness probe + REST surface in install skill

### DIFF
--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -328,6 +328,14 @@ sudo journalctl -u fabric -f                       # service stdout/stderr
 sudo ls /var/lib/fabric/logs/                      # per-dispatch claude -p logs
 sudo -u fabric /srv/agent-fabric/.venv/bin/fabric logs <project> <n> --follow
 
+# REST surface (all behind /api/* except liveness; OpenAPI at /docs)
+curl -sS http://127.0.0.1:7878/healthz             # {"ok": true}
+curl -sS http://127.0.0.1:7878/api/status          # paused flag + counters
+curl -sS http://127.0.0.1:7878/api/projects        # registered projects
+curl -sS http://127.0.0.1:7878/api/issues          # all tracked issues
+curl -sS http://127.0.0.1:7878/api/dispatches      # recent dispatches
+curl -sS http://127.0.0.1:7878/docs                # interactive OpenAPI UI
+
 # State (read-only is safe while running)
 sudo -u fabric sqlite3 -readonly /var/lib/fabric/state.db '.tables'
 

--- a/fabric/server.py
+++ b/fabric/server.py
@@ -136,6 +136,15 @@ def _wire_routes(
     gh_runner: gh.SubprocessRunner,
 ) -> None:
 
+    # ---- liveness ----
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, bool | str]:
+        """Liveness probe — never touches state.db / gh / claude.
+        Reverse proxies and uptime monitors hit this hot, so keep it
+        synchronous and dependency-free."""
+        return {"ok": True}
+
     # ---- read paths ----
 
     @app.get("/api/projects", response_model=list[am.ProjectOut])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -128,6 +128,17 @@ def client(setup: dict[str, Any]) -> TestClient:
         yield c
 
 
+# ---------- liveness ----------
+
+
+def test_healthz_returns_ok(client: TestClient) -> None:
+    """Liveness probe — must not depend on the DB, gh, or claude. Reverse
+    proxies and uptime monitors hit this on every poll."""
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
 # ---------- read paths ----------
 
 


### PR DESCRIPTION
## Summary

Two related papercuts from the first VPC bring-up:

1. **No liveness endpoint.** Reverse proxies and uptime checks
   probing `/healthz` got 404. `/api/status` works but it touches
   state.db every call — wrong shape for a hot probe.
2. **The install skill never enumerated the REST surface.** An
   operator debugging the running service had to guess paths or read
   `server.py`. Burned a few minutes on the first install chasing 404s
   for `/projects` and `/queue` before realizing the `/api/*` prefix.

`/healthz` returns `{"ok": true}` synchronously, dependency-free — no
DB, no gh, no claude. The install skill's Operations cheatsheet now
lists the full set: `/healthz`, `/api/status`, `/api/projects`,
`/api/issues`, `/api/dispatches`, and `/docs`.

## Test plan

- [x] `pytest -q` → 216 passed, 5 skipped (was 215, +1)
- [x] `test_healthz_returns_ok` covers the new endpoint
- [ ] After deploy, `curl -sS http://127.0.0.1:7878/healthz` → `{"ok":true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)