### PR TITLE
chore: post-smoke docs — first-run notes + install-runs status file

### DIFF
--- a/SMOKE.md
+++ b/SMOKE.md
@@ -5,6 +5,12 @@ and watching one full `state:needs-planning → merged` cycle land via
 Telegram. This replaces the earlier Pi/Tailscale plan — see DESIGN.md
 "Decision 13 — Deployment" for the rationale.
 
+> The detailed runbook (with every gotcha called out inline) lives in
+> `.claude/skills/install/SKILL.md`. Use this file for the conceptual
+> pass; use the install skill when you're actually doing it. The first
+> real run happened 2026-05-04 — see `docs/install-runs/2026-05-04.md`
+> for the post-mortem and the bugs it surfaced.
+
 ## Prerequisites
 
 - Ubuntu 24.04 (or Debian 12) VPC VM with sudo access.
@@ -121,13 +127,32 @@ Expected progression:
 
 ## Gotchas observed
 
-(Filled in after the first real run.)
+From the first real run on 2026-05-04 (full post-mortem in
+`docs/install-runs/2026-05-04.md`):
 
-- `claude login` SSH-tunnel quirks:
-- `gh` PAT scope:
-- systemd hardening blocking writes outside `$FABRIC_HOME`:
-- Log rotation under `$FABRIC_HOME/logs/`:
-- TG bot `chat_id` discovery (vs username):
+- **`claude` binary under `$HOME` collides with `ProtectHome=true`.** The
+  official installer drops it at `~/.local/share/claude/versions/<v>` —
+  the systemd unit makes that path invisible to the service, so
+  `/usr/local/bin/claude → ~/.local/share/...` resolves to a forbidden
+  path. Relocate to `/usr/local/share/claude/claude-<v>` and re-symlink.
+  `install-systemd.sh` warns if it detects this case.
+- **`sudo -u fabric` does not load `/etc/fabric/env`.** Running
+  `fabric register` without `export FABRIC_HOME=/var/lib/fabric` writes
+  the registry to `~/.fabric/projects.yaml` while the service reads
+  `/var/lib/fabric/projects.yaml`. The CLI now prints a stderr warning
+  when this divergence is detected; always set `FABRIC_HOME` in the
+  `sudo -u fabric` block (the install skill's heredoc does this).
+- **Fine-grained PATs need `Contents: Read and write` per repo to push.**
+  Read works (api + ls-remote) but `git push` fails with `denied to
+  <user>` if the PAT doesn't grant write to the specific repo.
+- **TG bot `chat_id` is numeric, not `@username`.** Discover via
+  [@userinfobot](https://t.me/userinfobot).
+- **`claude` refuses to run as root without `IS_SANDBOX=1`.** Only
+  relevant if you deviate from the canonical `User=fabric` setup
+  (e.g. for testing). Set `IS_SANDBOX=1` in `/etc/fabric/env` if so.
+- **Per-dispatch logs land at `$FABRIC_HOME/logs/<project>/<n>/<stage>-<ts>.log`.**
+  No rotation yet; cap is informal. If a project pumps out a lot of
+  dispatches, rotate manually for now.
 
 ## Useful one-liners
 

--- a/docs/install-runs/2026-05-04.md
+++ b/docs/install-runs/2026-05-04.md
@@ -1,0 +1,140 @@
+# 2026-05-04 — first end-to-end install + smoke
+
+Status report from the first real bring-up of `agent-fabric` on a fresh
+VPS, registered against `valdisd96/teach-me-eng-bot`, smoke-tested
+through the full plan-exec → test-writer → PR cycle.
+
+## Outcome
+
+✅ **Pipeline produced a real PR end-to-end.** Issue #57 in
+`teach-me-eng-bot` (`Rewrite readme. Leave only information about this
+teach-me-eng-bot functionality`) was picked up by the scheduler,
+plan-exec posted a focused plan, test-writer made the edit + ran the
+existing test suite, and the agent opened
+[teach-me-eng-bot#58](https://github.com/valdisd96/teach-me-eng-bot/pull/58)
+("docs: trim README to bot functionality only", README.md only,
++4/−54).
+
+## Environment
+
+| | |
+|---|---|
+| OS | Ubuntu 24.04.4 LTS |
+| Python | 3.12 (system) |
+| `gh` | 2.74.1 (system-wide) |
+| `claude` | 2.1.126 (relocated to `/usr/local/share/claude/claude-2.1.126`) |
+| Fabric host:port | `127.0.0.1:7878` |
+| `$FABRIC_HOME` | `/var/lib/fabric` |
+| Service user | **`root`** (deviation — see "Operational notes") |
+| Telegram bot | `@claude_hot_guy_bot`, chat `1283394836` |
+| Managed projects | 1 — `valdisd96/teach-me-eng-bot` at `/srv/projects/teach-me-eng-bot` |
+
+## Pipeline metrics (smoke run)
+
+| Stage | Dispatch id | Exit | Duration | Outcome |
+|---|---|---|---|---|
+| `plan-exec` | 5 | 0 | ~2.5 min | plan posted as issue comment, branch created |
+| `test-writer` | 6 | 0 | ~1.5 min | edits + tests + PR opened |
+
+Per-dispatch logs live at `/var/lib/fabric/logs/teach-me-eng-bot/57/`.
+
+## Bugs found and shipped
+
+All filed and merged during the install session, in order. PRs in
+`valdisd96/agent-fabric`:
+
+| # | Title | Bug class | Found via |
+|---|---|---|---|
+| [#30](https://github.com/valdisd96/agent-fabric/pull/30) | dispatcher claude argv — separate prompt, set permission mode | dispatch-blocking | first dispatch crashed: `Error: Input must be provided …` |
+| [#31](https://github.com/valdisd96/agent-fabric/pull/31) | surface `FABRIC_HOME` divergence between CLI shell and systemd unit | silent-failure | `/api/projects` empty after register |
+| [#32](https://github.com/valdisd96/agent-fabric/pull/32) | `setup-labels --check` exits 1 on drift (was always 0) | inconsistent CI gate | `setup-labels --check` exit 0 with 24 pending changes |
+| [#33](https://github.com/valdisd96/agent-fabric/pull/33) | `install-systemd.sh` creates `/srv/projects` + warns on `$HOME` claude | install footgun | `claude` binary under `~/.local/share/...` blocked by `ProtectHome=true` |
+| [#34](https://github.com/valdisd96/agent-fabric/pull/34) | dispatcher emits journal lines on dispatch start/end | observability | `journalctl -u fabric` was silent during 3 failed dispatches |
+| [#35](https://github.com/valdisd96/agent-fabric/pull/35) | `/healthz` liveness probe + REST surface in install skill | doc gap | burned minutes on `/healthz`/`/projects` 404s |
+
+### Root cause one-liner per bug
+
+1. **#30** — `claude --add-dir <directories...>` is variadic. The
+   prompt sat after `--add-dir <project>` and got absorbed as a second
+   directory, leaving claude with no input. Fix: insert `--` separator
+   *and* set `--permission-mode bypassPermissions` for unattended dispatch.
+2. **#31** — `sudo -u` does not load `/etc/fabric/env`, so `FABRIC_HOME`
+   is unset and `fabric_home()` falls back to `~/.fabric`. CLI writes
+   to one path, service reads another. Fix: CLI emits a warning when
+   `/etc/fabric/env` declares a different `FABRIC_HOME`; install skill
+   now `export`s it explicitly inside the sudo block.
+3. **#32** — `setup-labels --check` always returned via `return`
+   regardless of drift. Now exits 1 when there is anything to create or
+   update, matching `sync --check`.
+4. **#33** — `install-systemd.sh` did not create `/srv/projects` and did
+   not detect when `claude` resolved under `$HOME` (incompatible with
+   the unit's `ProtectHome=true` hardening). Both addressed in-script.
+5. **#34** — Dispatcher had no `logging.getLogger`. Per-dispatch log
+   files captured the run, but `journalctl -u fabric` was silent.
+   Added INFO start/end and WARNING-level failure lines including the
+   per-dispatch log path.
+6. **#35** — Install skill never enumerated `/api/*`; no liveness
+   endpoint at all. `/healthz` added; cheatsheet updated.
+
+## Operational notes
+
+- **Service is currently running as `root` with `IS_SANDBOX=1`**, not
+  the canonical `User=fabric` setup. This is a deliberate testing-only
+  deviation — when the dispatcher's argv was first wired, claude still
+  refused tool calls without `--permission-mode bypassPermissions`. PR
+  #30 fixed that, but per-tool permissions are a separate hardening
+  pass. Switch back to `User=fabric` (and re-enable `ProtectHome=true`)
+  once per-project tool allow-lists are written.
+- **One known follow-up (open):** the dispatcher INFO/WARNING lines from
+  PR #34 reach the per-dispatch log files but **do not** reach
+  `journalctl -u fabric`. Python's root logger has no handler at INFO
+  level; uvicorn's logger gets through because uvicorn lazy-installs
+  its own. Fix is a one-liner — call `logging.basicConfig(level=INFO)`
+  early in `fabric.cli::server`. Will land as the next PR.
+- **First-time `gh` PAT setup matters.** Fine-grained PATs need
+  `Contents: Read and write` granted *to the specific repo* — read
+  paths (API, `ls-remote`) work without it, but `git push` doesn't.
+
+## Where things live (this VM)
+
+```
+/srv/agent-fabric/                               # checkout + venv (root-owned for now)
+/srv/projects/teach-me-eng-bot/                  # managed-project clone
+/var/lib/fabric/                                 # FABRIC_HOME — state.db, projects.yaml, logs/
+  ├── state.db
+  ├── projects.yaml
+  ├── .claude/                                   # claude auth (copied from /root/.claude)
+  ├── .config/gh/                                # gh auth (copied from /root/.config/gh)
+  └── logs/teach-me-eng-bot/<issue>/<stage>-<ts>.log
+/etc/fabric/env                                  # systemd EnvironmentFile (mode 0600)
+/etc/systemd/system/fabric.service               # the unit
+/usr/local/share/claude/claude-2.1.126           # relocated claude binary
+/usr/local/bin/claude                            # → /usr/local/share/claude/claude-2.1.126
+```
+
+## Verification snapshot
+
+```
+$ systemctl is-active fabric
+active
+
+$ curl -sS http://127.0.0.1:7878/healthz
+{"ok":true}
+
+$ curl -sS http://127.0.0.1:7878/api/status
+{"paused":false,"paused_reason":null,"projects":1,"actionable_issues":1}
+
+$ curl -sS http://127.0.0.1:7878/api/projects | jq -r '.[].name'
+teach-me-eng-bot
+```
+
+## Next steps
+
+1. Land the `logging.basicConfig` follow-up so `journalctl` actually
+   shows dispatcher activity.
+2. Review and merge `valdisd96/teach-me-eng-bot#58`.
+3. Switch the unit back to `User=fabric` after per-tool allow-lists for
+   `gh`, `Bash`, `Edit` are defined; remove `IS_SANDBOX=1` from
+   `/etc/fabric/env`.
+4. Add a second managed project to validate cross-project D3 fairness
+   (only one project today; the round-robin layer is unexercised).


### PR DESCRIPTION
## Summary

The first end-to-end install + smoke happened 2026-05-04. Capture what
it surfaced so the next install doesn't relearn it.

- `SMOKE.md`'s "Gotchas observed" was placeholder bullets — replaced
  with the actual gotchas from the run.
- `SMOKE.md` now points at `.claude/skills/install/SKILL.md` as the
  detailed runbook (it grew during this session) and at the new
  status file as the post-mortem.
- New `docs/install-runs/2026-05-04.md` is the full status report:
  - environment + pipeline metrics
  - the six PRs shipped during install (#30–#35), each with a
    root-cause one-liner
  - operational deviations (running as root with `IS_SANDBOX=1`,
    deliberate, testing-only)
  - the one open follow-up (logger `basicConfig`)
  - verification snapshot

## Test plan

- [x] `pytest -q` → 216 passed, 5 skipped (no code changes)
- [x] All inline links resolve to existing PRs / paths
- [x] `docs/install-runs/` is a new directory; layout leaves room for
  future install runs without colliding with anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)