### PR TITLE
fix: configure root logger so fabric.* lines reach journalctl

### DIFF
--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -319,6 +319,29 @@ def setup_labels(
     )
 
 
+def _configure_root_logger(env: dict[str, str] | None = None) -> str:
+    """Install a stderr handler on the root logger so `fabric.*` INFO/WARNING
+    lines reach systemd's journal. Without this, those loggers fall back to
+    `logging.lastResort` (stderr at WARNING), and uvicorn's own handler
+    is the only thing journalctl ever sees — making dispatch activity
+    invisible.
+
+    Returns the configured level name. Honors `FABRIC_LOG_LEVEL` so
+    `FABRIC_LOG_LEVEL=DEBUG systemctl restart fabric` works for ad-hoc
+    troubleshooting."""
+    import logging
+    import os
+
+    env_map = os.environ if env is None else env
+    level = env_map.get("FABRIC_LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        force=True,
+    )
+    return level
+
+
 @app.command()
 def server(
     host: str = typer.Option("127.0.0.1", "--host", envvar="FABRIC_HOST"),
@@ -334,6 +357,7 @@ def server(
     from fabric.server import create_app
     from fabric.state import init_db
 
+    _configure_root_logger()
     init_db()
     dispatcher = Dispatcher()
     scheduler = Scheduler(dispatcher=dispatcher)

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,0 +1,46 @@
+"""`_configure_root_logger` controls whether `fabric.*` log lines ever
+reach stderr / journalctl. Cover the two things future-me would want
+preserved: default level is INFO, `FABRIC_LOG_LEVEL` overrides."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from fabric.cli import _configure_root_logger
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logger() -> None:
+    """`logging.basicConfig(force=True)` mutates the root logger globally;
+    restore default state after each test so suite ordering is irrelevant."""
+    original_level = logging.root.level
+    original_handlers = logging.root.handlers[:]
+    yield
+    logging.root.setLevel(original_level)
+    logging.root.handlers = original_handlers
+
+
+def test_default_level_is_info() -> None:
+    level = _configure_root_logger(env={})
+    assert level == "INFO"
+    assert logging.root.level == logging.INFO
+
+
+def test_fabric_log_level_env_var_wins() -> None:
+    level = _configure_root_logger(env={"FABRIC_LOG_LEVEL": "WARNING"})
+    assert level == "WARNING"
+    assert logging.root.level == logging.WARNING
+
+
+def test_lowercase_level_is_normalized() -> None:
+    _configure_root_logger(env={"FABRIC_LOG_LEVEL": "debug"})
+    assert logging.root.level == logging.DEBUG
+
+
+def test_fabric_dispatcher_logger_inherits_level() -> None:
+    """The whole point: after configure, `fabric.dispatcher` lines at INFO
+    actually emit. Without `basicConfig`, they'd be filtered out."""
+    _configure_root_logger(env={})
+    assert logging.getLogger("fabric.dispatcher").isEnabledFor(logging.INFO)


### PR DESCRIPTION
## Summary

Follow-up to PR #34. The `log.info(...)` calls landed but the lines
never showed in `journalctl -u fabric` — Python's root logger has no
handler at INFO. Uvicorn lazy-installs its own (which is why uvicorn
access lines come through), but `fabric.dispatcher`, `fabric.server`,
`fabric.telegram_bot` all fall back to `logging.lastResort` (stderr at
WARNING) and INFO lines vanish.

Add a small `_configure_root_logger()` helper called from the `server`
subcommand. It runs `logging.basicConfig(level=…, force=True)` with a
readable format and honors `FABRIC_LOG_LEVEL` so
`FABRIC_LOG_LEVEL=DEBUG systemctl restart fabric` works for ad-hoc
troubleshooting.

This was the only known follow-up from
`docs/install-runs/2026-05-04.md`.

## Test plan

- [x] `pytest -q` → 220 passed, 5 skipped (was 216, +4)
- [x] Four new tests cover: default INFO, env-var override, case
  normalization, named-logger inheritance. The autouse fixture saves
  and restores the root logger so global mutation doesn't leak.
- [ ] After deploy, restart fabric and trigger a dispatch — verify
  `journalctl -u fabric -f` shows `fabric.dispatcher: dispatch start ...`
  / `dispatch end ...` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)