### PR TITLE
feat: notify on issue completion (PR-merge auto-close)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -413,6 +413,7 @@ Push notifications for human-gate states + quick actions:
 | PR opened by fabric | `Approve` `Request changes` `Open` |
 | Dispatch failed (after retries) | `Retry` `Block` `Open` |
 | Daily quota at 80% | `Pause project X` `Open settings` |
+| Issue closed (PR merged or completed) | — (informational) |
 
 Slash commands:
 - `/queue` — text-render of cross-project queue

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -57,6 +57,9 @@ _NOTIFY_STATE_KIND: dict[str, str] = {
     "state:awaiting-decompose-approval": "decompose-approval",
 }
 
+_DONE_STATE_LABEL = "state:done"
+_COMPLETED_NOTIF_KIND = "issue-completed"
+
 
 @dataclass(frozen=True)
 class TickWinner:
@@ -229,6 +232,7 @@ class Scheduler:
             return
 
         last_served = (proj_row.last_served_at if proj_row else None) or ""
+        observed_open: set[int] = {issue.number for issue in issues}
 
         for issue in issues:
             state_label = _label_with_prefix(issue.labels, "state:")
@@ -326,6 +330,51 @@ class Scheduler:
                     last_served_at=last_served,
                     created_at=issue.created_at or "",
                 )
+            )
+
+        await self._detect_completions(entry, observed_open)
+
+    async def _detect_completions(
+        self, entry: ProjectEntry, observed_open: set[int]
+    ) -> None:
+        """Find tracked issues that vanished from the open list and confirm
+        closure via `gh.get_issue`. Mark them `state:done` and fire one
+        `issue-completed` notification each. Closed issues lose their
+        `state:*` label, so this is the only place that detects pipeline
+        completion (PR-merge auto-close or manual close-as-completed).
+        """
+        tracked = await asyncio.to_thread(state.list_issues, entry.name)
+        for row in tracked:
+            if row.number in observed_open:
+                continue
+            if row.state_label in (None, _DONE_STATE_LABEL):
+                continue
+            try:
+                detail = await asyncio.to_thread(
+                    gh.get_issue, entry.repo, row.number, runner=self._gh_runner
+                )
+            except gh.GhError:
+                continue
+            if detail.state.upper() != "CLOSED":
+                continue
+            await asyncio.to_thread(
+                state.upsert_issue,
+                project=entry.name,
+                number=row.number,
+                state_label=_DONE_STATE_LABEL,
+                type_label=row.type_label,
+                priority_label=row.priority_label,
+                area_label=row.area_label,
+                title=row.title,
+                url=row.url,
+                author=row.author,
+                created_at=row.created_at,
+            )
+            await asyncio.to_thread(
+                state.add_notification,
+                kind=_COMPLETED_NOTIF_KIND,
+                project=entry.name,
+                issue=row.number,
             )
 
     def _in_backoff(

--- a/fabric/telegram_bot.py
+++ b/fabric/telegram_bot.py
@@ -137,6 +137,7 @@ _NOTIF_HEADERS = {
     "clarification": "❓ Clarification needed",
     "decompose-approval": "📋 Decompose approval",
     "quota-warning": "⚠️ Quota warning",
+    "issue-completed": "✅ Issue completed",
 }
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -404,3 +404,94 @@ def test_tick_dispatches_after_backoff_elapsed(base_setup: Path) -> None:
 
     assert res.winner is not None
     assert res.winner.issue == 1
+
+
+# ---------- closed-issue completion notification ----------
+
+
+def test_tick_fires_completion_notification_when_tracked_issue_closes(
+    base_setup: Path,
+) -> None:
+    """An issue we previously saw open (state:in-review) disappears from the
+    open list and `gh issue view` confirms CLOSED — fire `issue-completed`."""
+    # First tick: see the issue open with state:in-review.
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[_issue_payload(7, "state:in-review")]
+    )
+    _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert state.get_issue("teach-me-eng-bot", 7) is not None
+
+    # Second tick: open list no longer contains issue 7; gh issue view says CLOSED.
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[],
+        issue_view_payload={
+            "number": 7, "title": "Issue 7", "labels": [],
+            "author": {"login": "valdisd96"}, "url": "https://example/i/7",
+            "createdAt": "2026-05-01T10:00:00Z", "body": "",
+            "state": "CLOSED", "comments": [],
+        },
+    )
+    _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    notifs = state.list_unacked_notifications()
+    completed = [n for n in notifs if n.kind == "issue-completed"]
+    assert len(completed) == 1
+    assert completed[0].project == "teach-me-eng-bot"
+    assert completed[0].issue == 7
+
+    row = state.get_issue("teach-me-eng-bot", 7)
+    assert row is not None
+    assert row.state_label == "state:done"
+
+
+def test_tick_does_not_renotify_already_done_issues(base_setup: Path) -> None:
+    """An issue already marked state:done in the DB never gets re-fetched
+    nor re-notified, even if the open-list keeps omitting it."""
+    state.upsert_project(
+        name="teach-me-eng-bot", path=str(base_setup),
+        repo="valdisd96/teach-me-eng-bot",
+    )
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=9,
+        state_label="state:done", title="old", url="u",
+        author="valdisd96", created_at="2026-04-01T10:00:00Z",
+    )
+    gh_runner = FakeGhRunner(list_issues_payload=[])
+    _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    # No issue-completed notif fired and no `gh issue view` call was made.
+    assert all(
+        n.kind != "issue-completed"
+        for n in state.list_unacked_notifications()
+    )
+    assert not any(c[1:3] == ["issue", "view"] for c in gh_runner.calls)
+
+
+def test_tick_skips_notification_when_issue_still_open(
+    base_setup: Path,
+) -> None:
+    """If gh issue view reports OPEN (e.g. transient open-list pagination
+    miss), don't fire the completion notification."""
+    state.upsert_project(
+        name="teach-me-eng-bot", path=str(base_setup),
+        repo="valdisd96/teach-me-eng-bot",
+    )
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=11,
+        state_label="state:in-review", title="t", url="u",
+        author="valdisd96", created_at="2026-05-01T10:00:00Z",
+    )
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[],
+        issue_view_payload={
+            "number": 11, "title": "t", "labels": [],
+            "author": {"login": "valdisd96"}, "url": "u",
+            "createdAt": "2026-05-01T10:00:00Z", "body": "",
+            "state": "OPEN", "comments": [],
+        },
+    )
+    _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert all(
+        n.kind != "issue-completed"
+        for n in state.list_unacked_notifications()
+    )

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -231,6 +231,16 @@ def test_render_notification_for_each_kind() -> None:
     assert "p#2" in text
 
 
+def test_render_issue_completed_notification() -> None:
+    n = state.NotificationRow(
+        id=1, kind="issue-completed", project="p", issue=7,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    text = render_notification_text(n)
+    assert "Issue completed" in text
+    assert "p#7" in text
+
+
 def test_notification_buttons_dispatch_failed_has_retry_and_block() -> None:
     n = state.NotificationRow(
         id=1, kind="dispatch-failed", project="p", issue=2,


### PR DESCRIPTION
## Summary
- Detect open→closed transitions on tracked issues and fire a new `issue-completed` Telegram notification (kind `issue-completed`, header `✅ Issue completed`).
- Closed issues drop both their `state:*` label and their entry in `gh.list_issues(state="open")`, so the existing transition path in `_poll_project` never sees them finish. The new `_detect_completions` pass reconciles the open-list against the DB, calls `gh.get_issue` for any tracked issue that vanished, and confirms `state == "CLOSED"` before marking it `state:done` and queuing the notification.
- Bounded extra cost: `gh issue view` only fires for issues that disappeared since the previous tick (typically 0–1 per project per tick).

## Why
- Reported gap: PR #58 merged → issue #57 auto-closed → no Telegram ping. The existing `_NOTIFY_STATE_KIND` only covers `clarification-needed` and `awaiting-decompose-approval`; nothing fired for completion.

## DESIGN.md
- Added the new trigger row to Decision 7's notification table.

## Test plan
- [x] `pytest -q` — 224 passed, 5 skipped
- [x] New scheduler tests cover: fires on observed open→closed transition; no re-notify on already `state:done`; no notify when `gh issue view` reports OPEN (transient open-list miss).
- [x] New telegram_bot test renders the new kind.
- [x] `fabric --help` still imports cleanly.
- [ ] Live verification: after merge + deploy, manually close an in-review issue in teach-me-eng-bot and confirm the Telegram message arrives within one tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)