### PR TITLE
feat: rich Telegram notifications for every state transition

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -414,6 +414,7 @@ Push notifications for human-gate states + quick actions:
 | Dispatch failed (after retries) | `Retry` `Block` `Open` |
 | Daily quota at 80% | `Pause project X` `Open settings` |
 | Issue closed (PR merged or completed) | — (informational) |
+| Any other observed `state:*` transition | — (informational, includes prev→new, cycle count, attribution) |
 
 Slash commands:
 - `/queue` — text-render of cross-project queue

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -49,13 +49,23 @@ _PRIORITY_RANK: dict[str, int] = {
 }
 _DEFAULT_PRIORITY_RANK = _PRIORITY_RANK["priority:medium"]
 
-# States whose entry triggers a notification for the human (1F's TG bot).
-# Notification is fired only on observed CHANGES, not on first-sight, so a
-# fabric restart re-polling in-progress state doesn't spam.
+# State→kind map for transitions that already have a dedicated notification
+# kind with custom buttons in the TG bot. Anything not in this map (and not
+# `state:blocked`, which is fired by `_block_issue`) gets the catch-all
+# `state-changed` kind. Notifications fire only on observed CHANGES, not on
+# first-sight, so a fabric restart doesn't spam the human chat.
 _NOTIFY_STATE_KIND: dict[str, str] = {
     "state:clarification-needed": "clarification",
     "state:awaiting-decompose-approval": "decompose-approval",
 }
+_GENERIC_TRANSITION_KIND = "state-changed"
+# The auto-block path (`_block_issue`) fires its own enriched `blocked` /
+# `dispatch-failed` notification, so suppress the generic transition fire.
+_SUPPRESS_GENERIC_FOR_STATE: set[str] = {"state:blocked"}
+
+# Window for attributing a state change to the most-recent completed dispatch.
+# Anything beyond this is treated as an external/manual edit.
+_ATTRIBUTION_WINDOW_SECONDS = 300
 
 _DONE_STATE_LABEL = "state:done"
 _COMPLETED_NOTIF_KIND = "issue-completed"
@@ -103,6 +113,64 @@ def _label_with_prefix(labels: Iterable[gh.Label], prefix: str) -> str | None:
         if lbl.name.startswith(prefix):
             return lbl.name
     return None
+
+
+def _format_transition_body(
+    *,
+    project: str,
+    issue: int,
+    title: str | None,
+    prev_state: str,
+    new_state: str,
+    cycle_count: int,
+    cycle_limit: int,
+    priority_label: str | None,
+    type_label: str | None,
+    actor: str,
+    url: str | None,
+) -> str:
+    """One pre-rendered text block stored in `notifications.body`. The TG
+    formatter prefers this over the legacy minimal rendering. Keeping the
+    rendering at fire-time means we capture old→new state, which gets lost
+    once the issue row is upserted with the new label.
+    """
+    head = f"{project}#{issue}"
+    if title:
+        head = f"{head} — {title}"
+    meta_bits = [f"cycle {cycle_count}/{cycle_limit}"]
+    if priority_label:
+        meta_bits.append(priority_label)
+    if type_label:
+        meta_bits.append(type_label)
+    lines = [
+        head,
+        f"{prev_state} → {new_state}",
+        " · ".join(meta_bits),
+        f"by {actor}",
+    ]
+    if url:
+        lines.append(url)
+    return "\n".join(lines)
+
+
+def _attribute_change(
+    latest: state.DispatchRow | None, now: datetime
+) -> str:
+    """Best-guess attribution: which agent stage caused this state change?
+    If a dispatch ended cleanly within the attribution window, blame it.
+    Otherwise treat the change as external (someone edited a label by hand).
+    """
+    if latest is None or not latest.ended_at:
+        return "manual"
+    try:
+        ended = _parse_iso(latest.ended_at)
+    except ValueError:
+        return "manual"
+    if (now - ended).total_seconds() > _ATTRIBUTION_WINDOW_SECONDS:
+        return "manual"
+    if latest.exit_code != 0:
+        return "manual"
+    return latest.stage
 
 
 class Scheduler:
@@ -266,13 +334,33 @@ class Scheduler:
             if (
                 prev_state is not None
                 and prev_state != state_label
-                and state_label in _NOTIFY_STATE_KIND
+                and state_label not in _SUPPRESS_GENERIC_FOR_STATE
             ):
-                await asyncio.to_thread(
-                    state.add_notification,
-                    kind=_NOTIFY_STATE_KIND[state_label],
+                kind = _NOTIFY_STATE_KIND.get(state_label, _GENERIC_TRANSITION_KIND)
+                cycle_count = prev_row.cycle_count if prev_row else 0
+                latest = await asyncio.to_thread(
+                    state.latest_dispatch, entry.name, issue.number
+                )
+                actor = _attribute_change(latest, self._now())
+                body = _format_transition_body(
                     project=entry.name,
                     issue=issue.number,
+                    title=issue.title,
+                    prev_state=prev_state,
+                    new_state=state_label,
+                    cycle_count=cycle_count,
+                    cycle_limit=config.pipeline.cycle_limit,
+                    priority_label=priority_label,
+                    type_label=type_label,
+                    actor=actor,
+                    url=issue.url,
+                )
+                await asyncio.to_thread(
+                    state.add_notification,
+                    kind=kind,
+                    project=entry.name,
+                    issue=issue.number,
+                    body=body,
                 )
 
             if author not in config.project.trusted_authors:
@@ -294,6 +382,7 @@ class Scheduler:
                         f"({issue_row.cycle_count}/{config.pipeline.cycle_limit})"
                     ),
                     kind="blocked",
+                    cycle_limit=config.pipeline.cycle_limit,
                 )
                 continue
 
@@ -307,6 +396,7 @@ class Scheduler:
                     state_label,
                     reason=f"dispatch failed {failures} times",
                     kind="dispatch-failed",
+                    cycle_limit=config.pipeline.cycle_limit,
                 )
                 continue
             if failures > 0:
@@ -412,21 +502,23 @@ class Scheduler:
         *,
         reason: str,
         kind: str,
+        cycle_limit: int,
     ) -> None:
         recent = await asyncio.to_thread(
             state.dispatches_for_issue, entry.name, issue_number, limit=5
         )
-        body_lines = [f"⚠️ Auto-blocked: {reason}", "", "Recent attempts:"]
+        gh_comment_lines = [f"⚠️ Auto-blocked: {reason}", "", "Recent attempts:"]
         for d in recent:
             tail = f" log={d.log_path}" if d.log_path else ""
-            body_lines.append(
+            gh_comment_lines.append(
                 f"- {d.started_at} stage={d.stage} exit={d.exit_code}{tail}"
             )
-        body = "\n".join(body_lines)
+        gh_comment_body = "\n".join(gh_comment_lines)
 
         try:
             await asyncio.to_thread(
-                gh.comment, entry.repo, issue_number, body, runner=self._gh_runner
+                gh.comment, entry.repo, issue_number, gh_comment_body,
+                runner=self._gh_runner,
             )
             await asyncio.to_thread(
                 gh.remove_labels,
@@ -445,14 +537,31 @@ class Scheduler:
         except gh.GhError:
             pass  # best-effort — next tick can retry
 
+        prev_row = await asyncio.to_thread(state.get_issue, entry.name, issue_number)
         await asyncio.to_thread(
             state.upsert_issue,
             project=entry.name,
             number=issue_number,
             state_label="state:blocked",
         )
+        notif_body: str | None = None
+        if prev_row is not None:
+            notif_body = _format_transition_body(
+                project=entry.name,
+                issue=issue_number,
+                title=prev_row.title,
+                prev_state=current_state,
+                new_state="state:blocked",
+                cycle_count=prev_row.cycle_count,
+                cycle_limit=cycle_limit,
+                priority_label=prev_row.priority_label,
+                type_label=prev_row.type_label,
+                actor=f"system: {reason}",
+                url=prev_row.url,
+            )
         await asyncio.to_thread(
-            state.add_notification, kind=kind, project=entry.name, issue=issue_number
+            state.add_notification,
+            kind=kind, project=entry.name, issue=issue_number, body=notif_body,
         )
 
 

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -78,6 +78,7 @@ class NotificationRow:
     acknowledged_at: str | None
     tg_chat_id: int | None = None
     tg_message_id: int | None = None
+    body: str | None = None
 
 
 def state_db_path() -> Path:
@@ -168,10 +169,16 @@ CREATE INDEX idx_notifications_tg
 """
 
 
+_SCHEMA_V4 = """
+ALTER TABLE notifications ADD COLUMN body TEXT;
+"""
+
+
 _MIGRATIONS: list[tuple[int, str]] = [
     (1, _SCHEMA_V1),
     (2, _SCHEMA_V2),
     (3, _SCHEMA_V3),
+    (4, _SCHEMA_V4),
 ]
 
 
@@ -551,11 +558,14 @@ def quota_today(project: str, *, day: str | None = None) -> int:
 # ---- notifications DAO ----
 
 
-def add_notification(*, kind: str, project: str, issue: int) -> int:
+def add_notification(
+    *, kind: str, project: str, issue: int, body: str | None = None
+) -> int:
     with connect() as conn:
         cur = conn.execute(
-            "INSERT INTO notifications (kind, project, issue, created_at) VALUES (?, ?, ?, ?)",
-            (kind, project, issue, _utc_now()),
+            "INSERT INTO notifications (kind, project, issue, created_at, body) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (kind, project, issue, _utc_now(), body),
         )
         conn.commit()
         if cur.lastrowid is None:

--- a/fabric/telegram_bot.py
+++ b/fabric/telegram_bot.py
@@ -138,11 +138,14 @@ _NOTIF_HEADERS = {
     "decompose-approval": "📋 Decompose approval",
     "quota-warning": "⚠️ Quota warning",
     "issue-completed": "✅ Issue completed",
+    "state-changed": "🔄 State changed",
 }
 
 
 def render_notification_text(n: state.NotificationRow) -> str:
     header = _NOTIF_HEADERS.get(n.kind, f"🔔 {n.kind}")
+    if n.body:
+        return f"{header}\n{n.body}"
     return f"{header}\n  {n.project}#{n.issue}"
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -495,3 +495,133 @@ def test_tick_skips_notification_when_issue_still_open(
         n.kind != "issue-completed"
         for n in state.list_unacked_notifications()
     )
+
+
+# ---------- generic transition notifications ----------
+
+
+def test_generic_state_changed_notification_fires_with_rich_body(
+    base_setup: Path,
+) -> None:
+    """Any prev_state→new_state transition outside the dedicated kinds
+    fires a `state-changed` notification with a multi-line body containing
+    project, issue#, transition arrow, cycle count, priority, and actor.
+
+    Untrusted author keeps the issue out of the candidate pool, so we can
+    seed dispatch history by hand without the real scheduler dispatch path
+    polluting it.
+    """
+    # Tick 1 (no `now` override): seed the prev state.
+    just_now = datetime(2026, 5, 5, 12, 0, 0, tzinfo=timezone.utc)
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(3, "state:tests-pending", priority="priority:high",
+                           type_="type:feat", author="randomdude"),
+        ]),
+        now=just_now - timedelta(minutes=1),
+    ).tick())
+
+    # A completed plan-exec dispatch right before the next tick.
+    did = state.record_dispatch(
+        project="teach-me-eng-bot", issue=3, stage="plan-exec",
+        started_at=(just_now - timedelta(seconds=30)).isoformat(timespec="seconds"),
+    )
+    state.complete_dispatch(
+        did,
+        ended_at=just_now.isoformat(timespec="seconds"),
+        exit_code=0,
+    )
+
+    # Tick 2: same issue now at state:in-review.
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(3, "state:in-review", priority="priority:high",
+                           type_="type:feat", author="randomdude"),
+        ]),
+        now=just_now + timedelta(seconds=10),
+    ).tick())
+
+    notifs = [n for n in state.list_unacked_notifications() if n.kind == "state-changed"]
+    assert len(notifs) == 1
+    body = notifs[0].body or ""
+    assert "teach-me-eng-bot#3" in body
+    assert "state:tests-pending → state:in-review" in body
+    assert "priority:high" in body
+    assert "type:feat" in body
+    assert "by plan-exec" in body
+    assert "cycle 0/" in body  # cycle_count starts at 0; format is N/limit
+
+
+def test_state_change_attributed_manual_when_no_recent_dispatch(
+    base_setup: Path,
+) -> None:
+    """No recent successful dispatch → attribute the change to `manual`."""
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(4, "state:needs-planning", author="randomdude"),
+        ]),
+    ).tick())
+
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(4, "state:tests-pending", author="randomdude"),
+        ]),
+    ).tick())
+
+    notifs = [n for n in state.list_unacked_notifications() if n.kind == "state-changed"]
+    assert len(notifs) == 1
+    assert "by manual" in (notifs[0].body or "")
+
+
+def test_clarification_kind_still_used_with_rich_body(
+    base_setup: Path,
+) -> None:
+    """Transitions to states with dedicated kinds (clarification,
+    decompose-approval) keep their kind, but now ship the rich body too."""
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(5, "state:in-progress", author="randomdude"),
+        ]),
+    ).tick())
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(5, "state:clarification-needed", author="randomdude"),
+        ]),
+    ).tick())
+
+    notifs = state.list_unacked_notifications()
+    clar = [n for n in notifs if n.kind == "clarification"]
+    assert len(clar) == 1
+    body = clar[0].body or ""
+    assert "state:in-progress → state:clarification-needed" in body
+    # And no duplicate state-changed kind:
+    assert not any(n.kind == "state-changed" for n in notifs)
+
+
+def test_blocked_state_does_not_double_fire(base_setup: Path) -> None:
+    """When `_block_issue` flips a label to state:blocked, the next tick
+    sees prev_state→state:blocked but must NOT fire a generic
+    state-changed on top of the dedicated `blocked` kind."""
+    # Manually seed an issue at state:in-review with cycle count over the cap.
+    state.upsert_project(
+        name="teach-me-eng-bot", path=str(base_setup),
+        repo="valdisd96/teach-me-eng-bot",
+    )
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=6,
+        state_label="state:in-review", title="t", url="u",
+        author="valdisd96", created_at="2026-05-01T10:00:00Z",
+    )
+    state.set_cycle_count("teach-me-eng-bot", 6, 999)
+
+    # Tick: gh still reports it as state:in-review; the cycle-cap path
+    # in _block_issue flips it.
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(6, "state:in-review", author="valdisd96"),
+        ]),
+    ).tick())
+
+    notifs = state.list_unacked_notifications()
+    assert any(n.kind == "blocked" for n in notifs)
+    assert not any(n.kind == "state-changed" for n in notifs)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -390,6 +390,16 @@ def test_add_notification_returns_id(isolated_state_db: Path) -> None:
     assert isinstance(nid, int) and nid > 0
 
 
+def test_notification_body_round_trips(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    add_notification(
+        kind="state-changed", project="t", issue=1,
+        body="line 1\nline 2",
+    )
+    [n] = list_unacked_notifications()
+    assert n.body == "line 1\nline 2"
+
+
 def test_list_unacked_filters_acked(isolated_state_db: Path) -> None:
     upsert_project(name="t", path="/p", repo="me/t")
     a = add_notification(kind="clarification", project="t", issue=1)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -241,6 +241,35 @@ def test_render_issue_completed_notification() -> None:
     assert "p#7" in text
 
 
+def test_render_state_changed_uses_body_when_present() -> None:
+    body = (
+        "teach-me-eng-bot#7 — Rewrite README\n"
+        "state:in-review → state:tests-pending\n"
+        "cycle 1/8 · priority:low · type:docs\n"
+        "by review-pr\n"
+        "https://example/i/7"
+    )
+    n = state.NotificationRow(
+        id=1, kind="state-changed", project="teach-me-eng-bot", issue=7,
+        created_at="t", delivered_to=None, acknowledged_at=None, body=body,
+    )
+    text = render_notification_text(n)
+    assert "🔄 State changed" in text
+    assert "state:in-review → state:tests-pending" in text
+    assert "by review-pr" in text
+    assert "cycle 1/8" in text
+
+
+def test_render_falls_back_when_body_absent() -> None:
+    n = state.NotificationRow(
+        id=1, kind="clarification", project="p", issue=2,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    text = render_notification_text(n)
+    assert "Clarification needed" in text
+    assert "p#2" in text
+
+
 def test_notification_buttons_dispatch_failed_has_retry_and_block() -> None:
     n = state.NotificationRow(
         id=1, kind="dispatch-failed", project="p", issue=2,


### PR DESCRIPTION
## Summary
Today the bot is largely silent — only `state:clarification-needed` and `state:awaiting-decompose-approval` transitions ping. Every other state advance the pipeline makes is invisible. This PR fires a notification on **every** observed `prev → new` `state:*` transition, with a rich, multi-line body.

## What ships per notification

```
🔄 State changed
teach-me-eng-bot#57 — Rewrite README
state:tests-pending → state:in-review
cycle 1/8 · priority:low · type:docs
by review-pr
https://github.com/valdisd96/teach-me-eng-bot/issues/57
```

- Project, issue #, issue title
- Old → new state (captured at fire-time so the upsert doesn't lose it)
- Cycle counter against the project's cycle cap
- Priority + type labels
- Attribution: the most recently completed dispatch if it ended within 5 min and `exit_code == 0`, else `manual` (you edited the label)
- Direct GitHub URL

## How it's wired

- `_NOTIFY_STATE_KIND` still maps the two human-gate states to their dedicated kinds (`clarification`, `decompose-approval`) so their action buttons keep working — but those notifications now also carry the rich body.
- `state:blocked` is suppressed in the generic path because `_block_issue` already fires `blocked` / `dispatch-failed` with its own enriched body.
- Everything else fires a new `state-changed` kind, no buttons (informational).
- First-sight transitions (no `prev_state` in DB) still don't fire — fabric restarts won't spam.

## Schema

Forward-only migration `_SCHEMA_V4` adds a nullable `body TEXT` column to `notifications`. Existing rows survive untouched. `render_notification_text` prefers `body` when present, falls back to the original minimal format otherwise.

## Tradeoff (flagged in conversation)

The bot will be noticeably louder. With one active issue you'll get ~3-4 messages per pipeline cycle (planning → tests → review → done). Acceptable for a single-operator dev tool. If it gets noisy across multiple projects, the next iteration can collapse the routine `planning → tests → in-review` chain into one summary message.

## Test plan
- [x] `pytest -q` — 227 passed, 5 skipped (up from 220)
- [x] New scheduler tests: rich body content; manual attribution when no recent dispatch; clarification kind preserved with body; no double-fire on `state:blocked`
- [x] New state test: notification body round-trips through SQLite
- [x] New telegram_bot tests: `state-changed` rendering uses body; fallback when body absent
- [x] `fabric --help` imports cleanly
- [ ] Live verification after deploy: open an issue, label it `state:needs-planning`, watch the full chain ping through Telegram

## Note on PR #38
Independent of #38 (closure detection). Whichever lands first, the other will rebase cleanly — they only collide on `_NOTIF_HEADERS` ordering and one DESIGN.md table line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)