### PR TITLE
feat: qualify-issue triage stage + state:draft / state:epic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Conceptually identical to SCSS → CSS or `protoc` output: humans edit the sourc
 
 **Overlay mechanism.** A managed project may replace any single skill by writing its own `<project>/.fabric/skills/<name>/SKILL.md.j2`. That overlay beats the fabric default at the whole-skill level (no section-level inheritance — see DESIGN.md "Override grain"). teach-me-eng-bot has zero overlays today.
 
-**The 5 fabric-managed skills:** `plan-exec`, `test-writer`, `review-pr`, `clarify-issue`, `epic-decompose`. The list lives at `fabric/render.py::SKILL_NAMES`. `dev-flow` is intentionally project-internal — `fabric sync` does not touch it.
+**The 6 fabric-managed skills:** `plan-exec`, `test-writer`, `review-pr`, `clarify-issue`, `epic-decompose`, `qualify-issue`. The list lives at `fabric/render.py::SKILL_NAMES`. `dev-flow` is intentionally project-internal — `fabric sync` does not touch it.
 
 ## Repo layout
 
@@ -82,7 +82,7 @@ tests/
 ## Invariants
 
 - **Schema is a public contract.** `.fabric/config.yaml`'s shape is depended on by every managed project (each pins a `fabric_version`). Backwards-incompatible changes require a version bump (semver minor for additive, major for breaking), a migration note in the PR body, and an `examples/teach-me-eng-bot.config.yaml` update.
-- **Parity is byte-for-byte.** `tests/test_parity.py` renders the 5 templates against `examples/teach-me-eng-bot.config.yaml` and compares to `$TEACH_ME_ENG_BOT_PATH/.claude/skills/<name>/SKILL.md`. Any byte difference fails. Bumping a template's frontmatter `version:` is therefore a deliberate act gated by CI. Skips cleanly when `$TEACH_ME_ENG_BOT_PATH` is unset.
+- **Parity is byte-for-byte.** `tests/test_parity.py` renders the 6 templates against `examples/teach-me-eng-bot.config.yaml` and compares to `$TEACH_ME_ENG_BOT_PATH/.claude/skills/<name>/SKILL.md`. Any byte difference fails. Bumping a template's frontmatter `version:` is therefore a deliberate act gated by CI. Skips cleanly when `$TEACH_ME_ENG_BOT_PATH` is unset.
 - **Templates ship inside the package.** `fabric/skill_templates/` (NOT repo root). `default_fabric_root()` returns the package dir so editable and wheel installs behave identically. Don't move them back out.
 - **Skills are package data, not data files referenced by path.** Anything that needs to find them goes through `default_fabric_root()` or the `fabric_root` injection point — never `Path.cwd()` or repo-relative paths.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -144,7 +144,8 @@ agent-fabric/
 │   ├── test-writer.md.j2
 │   ├── review-pr.md.j2
 │   ├── clarify-issue.md.j2
-│   └── epic-decompose.md.j2
+│   ├── epic-decompose.md.j2
+│   └── qualify-issue.md.j2
 ├── examples/
 │   └── teach-me-eng-bot.config.yaml
 ├── scripts/
@@ -172,6 +173,7 @@ my-project/
 │       ├── test-writer.md
 │       ├── review-pr.md             # rendered from the project's overlay
 │       ├── clarify-issue.md
+│       ├── qualify-issue.md
 │       └── epic-decompose.md
 ```
 
@@ -300,7 +302,7 @@ CREATE TABLE dispatches (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   project TEXT NOT NULL,
   issue INTEGER NOT NULL,
-  stage TEXT NOT NULL,        -- plan-exec | test-writer | review-pr | epic-decompose
+  stage TEXT NOT NULL,        -- plan-exec | test-writer | review-pr | epic-decompose | qualify-issue
   started_at TEXT NOT NULL,
   ended_at TEXT,
   exit_code INTEGER,
@@ -362,7 +364,7 @@ When multiple projects have actionable work this tick, who goes first?
 |---|---|---|
 | D1 | Per-project round-robin within state priority | Fair; no project starves. |
 | D2 | Pure cross-project priority (any project's `priority:high in-review` beats any project's `priority:medium`) | Urgent stuff jumps repos. |
-| **D3** | **Hybrid: state priority first (in-review > rework > tests-pending > needs-planning), then `priority:*` across projects, then round-robin between projects at same level, then createdAt** | Drains in-flight; respects priority; no starvation. |
+| **D3** | **Hybrid: state priority first (in-review > rework > tests-pending > needs-planning > epic / unqualified), then `priority:*` across projects, then round-robin between projects at same level, then createdAt** | Drains in-flight; respects priority; no starvation. |
 
 **Choice: D3.** Same spirit as the in-repo plan's E3, generalized across projects. Round-robin tiebreak ensures one chatty project can't monopolise the fabric.
 

--- a/fabric/labels.py
+++ b/fabric/labels.py
@@ -26,6 +26,16 @@ class LabelSpec:
 
 # Pipeline state — every transition the scheduler/dispatcher cares about.
 STATE_LABELS: list[LabelSpec] = [
+    LabelSpec(
+        "state:draft",
+        "cccccc",
+        "Author-marked WIP — agents ignore until label is removed",
+    ),
+    LabelSpec(
+        "state:epic",
+        "8b5cf6",
+        "Complex feature; epic-decompose runs to split into children",
+    ),
     LabelSpec("state:needs-planning", "0e8a16", "Ready for plan-exec"),
     LabelSpec("state:in-progress", "fbca04", "Agent currently working"),
     LabelSpec("state:tests-pending", "1d76db", "Plan landed; tests next"),

--- a/fabric/render.py
+++ b/fabric/render.py
@@ -35,6 +35,7 @@ SKILL_NAMES: tuple[str, ...] = (
     "review-pr",
     "clarify-issue",
     "epic-decompose",
+    "qualify-issue",
 )
 
 SKILL_TEMPLATE_FILENAME = "SKILL.md.j2"

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -27,12 +27,21 @@ from fabric.dispatcher import Dispatcher, DispatchError, QuotaExceeded
 from fabric.registry import ProjectEntry, fabric_home, load_registry
 
 
+# Pseudo-state used internally when an open issue has no `state:*` label on
+# GitHub — routes the issue into the qualify-issue triage stage. Never
+# written back to GitHub; only lives in the scheduler/DB.
+_UNQUALIFIED_STATE = "state:unqualified"
+
 # Drain in-flight first → bring rework/tests back → start fresh planning.
+# Triage (unqualified, epic) sits below planning so it doesn't preempt
+# in-flight work.
 _STATE_TIER: dict[str, int] = {
     "state:in-review": 0,
     "state:needs-rework": 1,
     "state:tests-pending": 2,
     "state:needs-planning": 3,
+    "state:epic": 4,
+    _UNQUALIFIED_STATE: 4,
 }
 
 _STAGE_BY_STATE: dict[str, str] = {
@@ -40,6 +49,8 @@ _STAGE_BY_STATE: dict[str, str] = {
     "state:needs-rework": "plan-exec",
     "state:tests-pending": "test-writer",
     "state:in-review": "review-pr",
+    "state:epic": "epic-decompose",
+    _UNQUALIFIED_STATE: "qualify-issue",
 }
 
 _PRIORITY_RANK: dict[str, int] = {
@@ -304,8 +315,12 @@ class Scheduler:
 
         for issue in issues:
             state_label = _label_with_prefix(issue.labels, "state:")
+            # No state:* label → triage the issue via the qualify-issue
+            # stage. We tag it with an internal pseudo-state so the existing
+            # candidate/dispatch path handles it; the agent will set the
+            # real state label as part of qualification.
             if state_label is None:
-                continue
+                state_label = _UNQUALIFIED_STATE
             priority_label = _label_with_prefix(issue.labels, "priority:")
             type_label = _label_with_prefix(issue.labels, "type:")
             area_label = _label_with_prefix(issue.labels, "area:")

--- a/fabric/skill_templates/qualify-issue/SKILL.md.j2
+++ b/fabric/skill_templates/qualify-issue/SKILL.md.j2
@@ -1,0 +1,59 @@
+---
+name: qualify-issue
+description: Triage stage for freshly-filed open issues with no `state:*` label. Reads the issue body, decides whether it is a draft, an epic, ready to plan, or needs clarification, and applies the appropriate label set so the rest of the pipeline can take over. One dispatch = one decision; never edits code or opens PRs.
+version: 0.1.0
+---
+
+# qualify-issue
+
+The first thing the fabric does to any new issue. Reads the body and routes the issue into one of four buckets by setting labels. This skill is a skeleton — the prompt content will be tuned in a follow-up against real issues.
+
+## Hard boundaries
+
+You MAY:
+- `gh issue view`, `gh issue list`, `gh issue comment`, `gh issue edit` (labels) on the issue you were dispatched on.
+- Read code to ground your understanding when classifying scope.
+
+You MUST NOT:
+- Edit code, create branches, commit, push, or open PRs. Qualification is read-and-label only.
+- Touch any issue other than the one you were dispatched on.
+- Skip setting a state label. Every dispatch must end with the issue holding exactly one `state:*` label so the next tick knows what to do.
+
+## Inputs
+
+Dispatched on an open issue with **no** `state:*` label. The fabric tags it `state:unqualified` internally, but that label does not exist on GitHub — your job is to put a real one there.
+
+## The decision tree
+
+Walk top-down — first match wins.
+
+1. **Author marks WIP / draft.** The body says "draft", "WIP", "do not work on yet", or the title is `[WIP]…` / `[draft]…`.
+   → Set `state:draft`. Add a one-line comment: `Marked as draft — agents will skip this issue. Remove the label to start.` Stop.
+
+2. **Body is too vague to classify.** No clear ask, missing the "what" or the "why", or the request is contradictory.
+   → Set `state:clarification-needed`. Post one focused question as a comment. Stop. The TG bot will ping the user; their reply re-triggers qualification on the next tick.
+
+3. **Complex feature requiring decomposition.** The work would land as multiple PRs, touches multiple modules, or the body explicitly says "epic" / "big feature" / "multi-step".
+   → Set `state:epic` (and `type:feature` if not already set). Add a one-line comment: `Classified as epic — epic-decompose will pick it up next tick to start the Q&A.` Stop.
+
+4. **Default — ready to plan.** Single-deliverable change, body has enough detail for plan-exec to draft a plan.
+   → Set `state:needs-planning`. Also set `priority:*` and `type:*` if you can infer them confidently from the body; leave them off if you can't (plan-exec or the human will tag them later). Stop.
+
+## Required label hygiene per branch
+
+| Branch | State label set | Other labels touched |
+|---|---|---|
+| 1. Draft | `state:draft` | none |
+| 2. Vague | `state:clarification-needed` | none |
+| 3. Epic | `state:epic` | `type:feature` (if missing) |
+| 4. Plan-ready | `state:needs-planning` | `priority:*`, `type:*` if confidently inferred |
+
+Never apply more than one `state:*` label.
+
+## Output format
+
+Every dispatch ends with one of:
+1. A label edit + a short comment matching the chosen branch above, OR
+2. (Default branch) a label edit only — no comment is required for the plan-ready path.
+
+Do not post analysis, decision rationale, or trace logs. Be terse. The whole skill exists to keep new issues moving without making the human read paragraphs.

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -48,12 +48,25 @@ class FakeRunner:
 
 
 def test_state_labels_cover_all_pipeline_states() -> None:
-    """Every state the scheduler dispatches on must be in the canonical set."""
-    from fabric.scheduler import _STAGE_BY_STATE
+    """Every state the scheduler dispatches on must be in the canonical
+    set. The `_UNQUALIFIED_STATE` pseudo-label is exempt — it lives only
+    in fabric's DB and is never written to GitHub, so it doesn't need a
+    canonical spec."""
+    from fabric.scheduler import _STAGE_BY_STATE, _UNQUALIFIED_STATE
 
     spec_names = {s.name for s in STATE_LABELS}
     for state_label in _STAGE_BY_STATE:
+        if state_label == _UNQUALIFIED_STATE:
+            continue
         assert state_label in spec_names, f"missing canonical: {state_label}"
+
+
+def test_draft_and_epic_states_are_canonical() -> None:
+    """The triage states added with the qualify-issue stage must exist in
+    the canonical set so `setup-labels` provisions them on every project."""
+    spec_names = {s.name for s in STATE_LABELS}
+    assert "state:draft" in spec_names
+    assert "state:epic" in spec_names
 
 
 def test_priority_labels_cover_all_dispatcher_priorities() -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -202,12 +202,36 @@ def test_tick_per_project_paused_skips_only_that_project(
 # ---------- polling + filters ----------
 
 
-def test_tick_no_candidates_when_no_state_labels(base_setup: Path) -> None:
+def test_tick_unlabeled_issue_dispatches_qualify_stage(base_setup: Path) -> None:
+    """Open issue with no `state:*` label → qualify-issue stage dispatches.
+    The fabric uses an internal `state:unqualified` pseudo-label so the
+    issue flows through the existing candidate/dispatch machinery."""
     gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1, state_label=None)])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.winner is not None
+    assert res.winner.issue == 1
+    assert res.winner.stage == "qualify-issue"
+    # The DB row carries the pseudo-label so the next tick's transition
+    # logic can detect when qualify-issue flips it to a real state.
+    row = state.get_issue("teach-me-eng-bot", 1)
+    assert row is not None
+    assert row.state_label == "state:unqualified"
+
+
+def test_tick_state_draft_is_ignored(base_setup: Path) -> None:
+    """`state:draft` is a terminal-ignored label — never dispatched, like
+    `state:done`."""
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1, "state:draft")])
     res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
     assert res.winner is None
     assert res.candidates == 0
-    assert res.polled_projects == 1
+
+
+def test_tick_state_epic_dispatches_decompose(base_setup: Path) -> None:
+    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1, "state:epic")])
+    res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+    assert res.winner is not None
+    assert res.winner.stage == "epic-decompose"
 
 
 def test_tick_polls_and_upserts_issues(base_setup: Path) -> None:


### PR DESCRIPTION
## Summary

Adds the missing **entry pipeline** for freshly-filed issues. Today the scheduler silently skips any open issue without a `state:*` label, so unlabeled issues are invisible. This PR turns "no label" into a first-class trigger that fires the new `qualify-issue` triage stage, plus introduces `state:draft` (ignored) and `state:epic` (routed to `epic-decompose`).

## Decision tree the agent runs

\`\`\`
(no state:* label) ──► qualify-issue ──┬─► state:draft                 (terminal-ignored, like state:done)
                                       ├─► state:epic ──► epic-decompose
                                       ├─► state:needs-planning ──► plan-exec → tests → review → done
                                       └─► state:clarification-needed (TG ping)
\`\`\`

## How it's wired

- **labels.py** — adds canonical `state:draft` (gray, `cccccc`) and `state:epic` (purple, `8b5cf6`).
- **scheduler.py** — introduces `_UNQUALIFIED_STATE = "state:unqualified"` (a fabric-internal pseudo-label, never written to GitHub). When `_label_with_prefix(..., "state:")` returns None, the scheduler tags the issue with this pseudo-label so it flows through the existing candidate/dispatch path. `_STAGE_BY_STATE` maps it to `qualify-issue`. `state:epic` is added with stage `epic-decompose`. `state:draft` stays unmapped → not a candidate, like `state:done`. Both new states get tier 4 in `_STATE_TIER` so they sit below in-flight work.
- **render.py** — `qualify-issue` added to `SKILL_NAMES`.
- **skill_templates/qualify-issue/SKILL.md.j2** — new skeleton template (version 0.1.0). Encodes the four-outcome decision tree, hard boundaries (read-and-label only, never code), and required label hygiene per branch. **Prompt content is intentionally a skeleton** — tuning against real teach-me-eng-bot issues lands in a follow-up PR (per the design discussion).
- **DESIGN.md / CLAUDE.md** — pipeline references bumped from "5 skills" to "6 skills".

## What managed projects need to do after this lands

\`\`\`bash
fabric setup-labels <project>          # provisions state:draft + state:epic
fabric sync <project>                  # renders qualify-issue skill into .claude/skills/
# then commit the rendered output upstream
\`\`\`

Until that sync runs, an unlabeled issue would dispatch \`qualify-issue\` against a project that doesn't yet have the rendered skill — claude would fail to load it. The fabric's existing retry-backoff + auto-block path handles that gracefully (3 retries → blocked + TG ping), but it's a noisy first hour. Recommend running the two commands above immediately after deploy.

## Test plan
- [x] \`pytest -q\` — 234 passed, 6 skipped (was 220 / 5)
- [x] New scheduler tests: unlabeled→qualify dispatch (with pseudo-label persisted), \`state:draft\` ignored, \`state:epic\`→\`epic-decompose\`
- [x] New labels test: \`state:draft\` and \`state:epic\` are in the canonical set
- [x] Existing \`test_state_labels_cover_all_pipeline_states\` updated to exempt the \`_UNQUALIFIED_STATE\` pseudo-label
- [x] \`test_all_default_templates_render\` auto-covers the new template (renders without error)
- [x] \`fabric --help\` imports cleanly
- [ ] After deploy: open an unlabeled issue, watch the tick dispatch \`qualify-issue\`, verify it sets one of the four state labels
- [ ] Follow-up PR: tune the qualify-issue prompt against real-world examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)