### PR TITLE
feat: tune qualify-issue prompt (v1.0.0)

### DIFF
--- a/fabric/skill_templates/qualify-issue/SKILL.md.j2
+++ b/fabric/skill_templates/qualify-issue/SKILL.md.j2
@@ -1,59 +1,164 @@
 ---
 name: qualify-issue
-description: Triage stage for freshly-filed open issues with no `state:*` label. Reads the issue body, decides whether it is a draft, an epic, ready to plan, or needs clarification, and applies the appropriate label set so the rest of the pipeline can take over. One dispatch = one decision; never edits code or opens PRs.
-version: 0.1.0
+description: Triage stage for freshly-filed open issues that have no `state:*` label. Reads the body and routes the issue into one of four buckets — `state:draft` (ignored), `state:epic` (decompose), `state:clarification-needed` (ask the human), or `state:needs-planning` (ready for plan-exec) — by setting labels and, where appropriate, a single short comment. Read-and-label only; never edits code, never opens PRs, never touches more than one issue per dispatch.
+version: 1.0.0
 ---
 
 # qualify-issue
 
-The first thing the fabric does to any new issue. Reads the body and routes the issue into one of four buckets by setting labels. This skill is a skeleton — the prompt content will be tuned in a follow-up against real issues.
+The first thing the fabric does to any new issue. One dispatch = one classification = one terminal `state:*` label set on the issue.
 
 ## Hard boundaries
 
 You MAY:
-- `gh issue view`, `gh issue list`, `gh issue comment`, `gh issue edit` (labels) on the issue you were dispatched on.
-- Read code to ground your understanding when classifying scope.
+- `gh issue view`, `gh issue list` (read-only on other issues for cross-reference resolution).
+- `gh issue comment`, `gh issue edit` (labels) **on the issue you were dispatched on**.
+- Read code with the `Read` / `Grep` tools to ground a scope estimate.
 
 You MUST NOT:
-- Edit code, create branches, commit, push, or open PRs. Qualification is read-and-label only.
+- Edit code, create branches, commit, push, or open PRs. Triage is read-and-label only.
 - Touch any issue other than the one you were dispatched on.
-- Skip setting a state label. Every dispatch must end with the issue holding exactly one `state:*` label so the next tick knows what to do.
+- Apply more than one `state:*` label.
+- Skip applying a state label. Every dispatch must end with the issue holding exactly one `state:*` label so the next tick knows what to do.
+- Apply `priority:*` or `type:*` you cannot defend from the body. When in doubt, leave them off — the next stage or the human will tag them.
 
 ## Inputs
 
-Dispatched on an open issue with **no** `state:*` label. The fabric tags it `state:unqualified` internally, but that label does not exist on GitHub — your job is to put a real one there.
+You're dispatched on an open issue with **no** `state:*` label on GitHub. The fabric tags it `state:unqualified` internally — that label is not on GitHub, you don't need to remove anything before applying the real one.
 
 ## The decision tree
 
-Walk top-down — first match wins.
+Walk top-down. **First match wins** — once a branch fires, set its labels and stop.
 
-1. **Author marks WIP / draft.** The body says "draft", "WIP", "do not work on yet", or the title is `[WIP]…` / `[draft]…`.
-   → Set `state:draft`. Add a one-line comment: `Marked as draft — agents will skip this issue. Remove the label to start.` Stop.
+### Branch 1 — Draft / WIP
 
-2. **Body is too vague to classify.** No clear ask, missing the "what" or the "why", or the request is contradictory.
-   → Set `state:clarification-needed`. Post one focused question as a comment. Stop. The TG bot will ping the user; their reply re-triggers qualification on the next tick.
+Match if **any**:
+- The body or title contains "WIP", "draft", "not ready", "do not work on", "ignore for now", "[WIP]", "[draft]", or equivalent.
+- The body explicitly says the author is still drafting / thinking out loud.
 
-3. **Complex feature requiring decomposition.** The work would land as multiple PRs, touches multiple modules, or the body explicitly says "epic" / "big feature" / "multi-step".
-   → Set `state:epic` (and `type:feature` if not already set). Add a one-line comment: `Classified as epic — epic-decompose will pick it up next tick to start the Q&A.` Stop.
+```bash
+gh issue edit <N> --add-label "state:draft"
+gh issue comment <N> --body "Marked as \`state:draft\` — agents will skip this issue. Remove the label when it's ready to work."
+```
 
-4. **Default — ready to plan.** Single-deliverable change, body has enough detail for plan-exec to draft a plan.
-   → Set `state:needs-planning`. Also set `priority:*` and `type:*` if you can infer them confidently from the body; leave them off if you can't (plan-exec or the human will tag them later). Stop.
+Stop.
 
-## Required label hygiene per branch
+### Branch 2 — Vague / unanswerable
 
-| Branch | State label set | Other labels touched |
-|---|---|---|
-| 1. Draft | `state:draft` | none |
-| 2. Vague | `state:clarification-needed` | none |
-| 3. Epic | `state:epic` | `type:feature` (if missing) |
-| 4. Plan-ready | `state:needs-planning` | `priority:*`, `type:*` if confidently inferred |
+Match if **all** of these hold even after re-reading the body and skimming related code:
+- You cannot state in one sentence what the change is supposed to *do*.
+- Two reasonable interpretations of the body would lead to different module changes.
+- The issue contradicts itself, or asks for two unrelated things in the same body.
 
-Never apply more than one `state:*` label.
+If yes, ask **one focused question** and park.
 
-## Output format
+```bash
+gh issue comment <N> --body "$(cat <<'EOF'
+<!-- agent-qualify v1 -->
+**Quick triage question before I queue this for planning:**
 
-Every dispatch ends with one of:
-1. A label edit + a short comment matching the chosen branch above, OR
-2. (Default branch) a label edit only — no comment is required for the plan-ready path.
+<the precise question — one paragraph, one decision>
 
-Do not post analysis, decision rationale, or trace logs. Be terse. The whole skill exists to keep new issues moving without making the human read paragraphs.
+Context: <one sentence — the load-bearing ambiguity, in your own words>.
+
+Reply on the issue or via Telegram. Once you answer, remove `state:clarification-needed` and the next tick will re-triage.
+EOF
+)"
+gh issue edit <N> --add-label "state:clarification-needed"
+```
+
+Stop. Do not also set `priority:*` or `type:*` — they may change after the answer.
+
+The bar for asking is high. **You are not the planner.** Plan-exec will ask its own clarification later if needed. Ask only when the issue body is so under-specified that *any* attempt at a plan would be guesswork.
+
+### Branch 3 — Epic
+
+Match if **any** of these are clearly true from the body:
+- The author explicitly calls it an "epic", "big feature", "multi-step initiative", or asks to "split into smaller issues".
+- Implementation would obviously require **3+ separate PRs** to ship safely (e.g. new module + new schema + new UI + migration; multi-stage rollout with feature flags).
+- The body lists 4+ acceptance criteria across **different concerns** (not 4 sub-checks of one thing — the test for "different concerns" is whether each criterion lives in a different module).
+
+Most issues are **not epics.** A single feature, a bug fix, a refactor, a docs update, even a moderate cross-module change — these are plan-ready, not epics. Bias toward Branch 4. Reach for "epic" only when splitting it would be obviously wrong to do in a single PR.
+
+```bash
+gh issue edit <N> --add-label "state:epic" --add-label "type:feature"
+gh issue comment <N> --body "Classified as \`state:epic\` — \`epic-decompose\` will pick this up to start the Q&A and propose a child-issue list."
+```
+
+Stop. Skip `type:feature` if a different `type:*` is already set.
+
+### Branch 4 — Plan-ready (default)
+
+This is the **default branch** if 1–3 didn't fire. Use it whenever the issue is a single-deliverable change with enough detail for plan-exec to draft a plan, even if some details are fuzzy.
+
+```bash
+gh issue edit <N> --add-label "state:needs-planning"
+# Add priority + type only if you can defend the choice from the body.
+# When unsure, leave them off — plan-exec or the human will set them.
+```
+
+No comment is required for this branch. Quietness on the plan-ready path keeps the issue thread clean for the actual planning work.
+
+#### Inferring `priority:*` (optional)
+
+| Body signal | Label |
+|---|---|
+| "ASAP", "urgent", security risk, broken feature blocking other work | `priority:high` |
+| Quality-of-life, tech debt, "nice to have", small UX, docs | `priority:low` |
+| Anything else | `priority:medium` (or leave unset) |
+
+Don't infer `priority:high` from author tone alone — look for a concrete reason.
+
+#### Inferring `type:*` (optional)
+
+| Body signal | Label |
+|---|---|
+| "fix", "broken", "doesn't work", reproducible defect | `type:bug` |
+| "add", "support for", new capability | `type:feature` |
+| "rename", "move", "clean up", "extract" with no behavior change | `type:refactor` |
+| README, docstring, /help text, `*.md` | `type:docs` |
+| Test coverage, fixtures | `type:test` |
+
+#### Inferring `area:*` (optional)
+
+If the issue body or title clearly references one of the project's `area:*` labels (each project's `.fabric/config.yaml` lists the valid set), apply it. Cross-cutting issues may take 2+ area labels. Skip if uncertain.
+
+## Worked examples
+
+These are sketches based on real issue shapes — actual classification will vary with the full body.
+
+**Title: "Rewrite README. Leave only information about this bot's functionality"**
+→ Branch 4. `state:needs-planning` + `priority:low` + `type:docs`. Single deliverable, scope is clear.
+
+**Title: "Need ability to upload words by batches"** (body: use case, mentions import/export as a stretch)
+→ Branch 4. `state:needs-planning` + `type:feature`. Borderline epic? No — one user-facing capability with one input format. Plan-exec can scope import/export as a follow-up if needed.
+
+**Title: "Update /help command descriptions"** (body: "we just completed #49 but /help wasn't updated; please fix")
+→ Branch 4. `state:needs-planning` + `priority:medium` + `type:docs`. Cross-references another issue but is itself a single small change.
+
+**Title: "Potential security risk"** (body: notes that `ALLOWED_USER_IDS` is empty in some tested branch, suggests this might let anyone use the bot)
+→ Branch 4. `state:needs-planning` + `priority:high` + `type:bug`. A defect with a concrete reproducer and a real consequence.
+
+**Title: "Migrate auth + storage + UI to multi-tenant"** (body: lists 6 ACs spanning DB schema, OAuth, frontend, new admin pages, billing, docs)
+→ Branch 3. `state:epic` + `type:feature`. 3+ PRs, different concerns. epic-decompose takes it from here.
+
+**Title: "Refactor"** (body: empty)
+→ Branch 2. Ask: "What part of the codebase, and what's wrong with the current shape that motivates the refactor?" Cannot reasonably plan from this.
+
+**Title: "[WIP] Thinking about a new vocab review mode"**
+→ Branch 1. `state:draft`. The `[WIP]` tag is the signal.
+
+## Output discipline
+
+Every dispatch ends with **one** of:
+
+- A label edit + a short comment (Branches 1, 2, 3).
+- A label edit only (Branch 4).
+
+That's it. Do not post your reasoning, do not narrate the decision tree you walked, do not summarize the issue back at the user. The whole skill exists to keep new issues moving without making the human read your scratch work.
+
+## Failure handling
+
+- If the issue was closed between dispatch and your read: silently exit. The fabric's closure-detection path will handle the bookkeeping on the next tick.
+- If `gh issue edit` fails for a label that doesn't exist on the project: the project hasn't yet run `fabric setup-labels`. Comment the label name + this fact, and exit. The fabric will retry on the next tick.
+- If you genuinely cannot decide between two branches after re-reading: prefer Branch 2 (ask one question) over guessing. The cost of one Q&A round is one tick.


### PR DESCRIPTION
## Summary

Follow-up to #40 (which scaffolded the qualify-issue stage). Promotes the skill prompt from a skeleton (0.1.0) to a tuned v1.0.0 ready to triage real issues.

## What changed

- **Concrete gh commands per branch.** Every classification branch lists the exact \`gh issue edit\` / \`gh issue comment\` invocation. No more "set the appropriate label" hand-waving.
- **Worked examples from teach-me-eng-bot's own issue history.** README rewrite, batch upload feature, /help fix, security observation, multi-tenant migration (epic), bare "Refactor" (vague), [WIP] draft. These show the agent the *texture* of input it'll see, not just the rules.
- **Sharpened heuristics:**
  - Strong bias toward Branch 4 (\`state:needs-planning\`) — most issues are not epics.
  - Epic threshold: explicit author signal *or* 3+ PRs to ship safely *or* 4+ ACs across different concerns.
  - Vague threshold: cannot state the change in one sentence + two reasonable interpretations exist + body is self-contradictory.
- **Inference tables** for \`priority:*\`, \`type:*\`, \`area:*\` with explicit guidance to leave labels off when uncertain rather than guess.
- **Hidden marker** \`<!-- agent-qualify v1 -->\` on the clarification comment, matching epic-decompose's pattern, so future tooling can distinguish triage-asks from worker-stage clarifications.
- **Failure handling:** closed-during-dispatch (silent exit), missing label on the project (comment + exit, retry next tick).
- **Output discipline section** keeps the agent from narrating its decision tree back at the human.

## What didn't change

- The schema, the scheduler, the label set, the skill list. This is pure prompt content.
- Other skill templates — voice and structure of qualify-issue now match clarify-issue / epic-decompose.

## Test plan
- [x] \`pytest -q\` — 234 passed, 6 skipped (unchanged)
- [x] \`test_all_default_templates_render\` — qualify-issue still renders without error
- [ ] After merge + sync + first real triage on teach-me-eng-bot: confirm at least one of each branch fires correctly. Iterate from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)