### PR TITLE
feat: stream-json verbose agent logs + --pretty viewer

### DIFF
--- a/fabric/cli.py
+++ b/fabric/cli.py
@@ -237,10 +237,23 @@ def logs(
     project: str = typer.Argument(...),
     issue: int = typer.Argument(...),
     follow: bool = typer.Option(False, "--follow", "-f"),
+    pretty: bool = typer.Option(
+        False,
+        "--pretty",
+        help="Format the JSONL stream as a human-readable transcript "
+        "(tool calls, assistant text, results). Default: raw JSONL.",
+    ),
 ) -> None:
-    """Tail the latest agent log for an issue."""
+    """Tail the latest agent log for an issue.
+
+    The log is JSONL emitted by `claude -p --output-format stream-json
+    --verbose` — one event per tool call / assistant message / tool
+    result. Default output is the raw stream (greppable, parseable);
+    pass `--pretty` for a transcript view.
+    """
     import os
 
+    from fabric.log_format import format_stream
     from fabric.state import init_db, latest_dispatch
 
     init_db()
@@ -253,8 +266,13 @@ def logs(
         typer.echo(f"logs: log file missing: {d.log_path}", err=True)
         raise typer.Exit(1)
     if follow:
+        # --follow ignores --pretty: we exec tail and stream raw bytes.
+        # Pretty live-tail would need a long-running parser loop; not
+        # worth it for v1 — pipe through `jq` or run with --pretty after
+        # the dispatch ends.
         os.execvp("tail", ["tail", "-f", str(log_path)])
-    typer.echo(log_path.read_text(), nl=False)
+    text = log_path.read_text()
+    typer.echo(format_stream(text) if pretty else text, nl=False)
 
 
 @app.command(name="setup-labels")

--- a/fabric/dispatcher.py
+++ b/fabric/dispatcher.py
@@ -336,6 +336,14 @@ class Dispatcher:
             model,
             "--permission-mode",
             "bypassPermissions",
+            # `stream-json --verbose` makes claude emit one JSON event per
+            # tool call / assistant message / tool result, so the log on
+            # disk is a full play-by-play (replay-as-interactive-session,
+            # like the bash scripts using `tee` did). Without --verbose,
+            # stream-json suppresses tool events.
+            "--output-format",
+            "stream-json",
+            "--verbose",
             "--add-dir",
             project_path,
             "--",

--- a/fabric/log_format.py
+++ b/fabric/log_format.py
@@ -1,0 +1,145 @@
+"""Pretty-printer for the JSONL stream `claude -p --output-format stream-json
+--verbose` writes to dispatch logs.
+
+Pure functions over parsed event dicts — no I/O. The CLI's `fabric logs
+--pretty` reads the .log file, splits on newlines, parses each line, and
+calls `format_event` on every dict; the future dashboard does the same
+either off the file (replay) or off the WebSocket fanout (live).
+
+The formatter is deliberately tolerant: unknown event types are dropped
+silently, malformed JSON lines fall through to the input string, missing
+fields render as best-effort with `?` placeholders. We never raise — a
+log with one bad line is still readable.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _truncate(s: str, n: int) -> str:
+    return s if len(s) <= n else s[: n - 1].rstrip() + "…"
+
+
+def _summarize_input(tool_name: str, inp: object) -> str:
+    """Tool-specific short argument display. Falls back to the first
+    string-valued field. Empty string if nothing salient."""
+    if not isinstance(inp, dict):
+        return ""
+    if tool_name in {"Read", "Edit", "Write", "NotebookEdit"} and "file_path" in inp:
+        return str(inp["file_path"])
+    if tool_name == "Bash" and "command" in inp:
+        return _truncate(str(inp["command"]), 80)
+    if tool_name == "Grep" and "pattern" in inp:
+        return _truncate(str(inp["pattern"]), 60)
+    if tool_name == "Glob" and "pattern" in inp:
+        return str(inp["pattern"])
+    if tool_name in {"Task", "Agent"} and "description" in inp:
+        return _truncate(str(inp["description"]), 60)
+    if tool_name == "WebFetch" and "url" in inp:
+        return str(inp["url"])
+    if tool_name == "TodoWrite":
+        todos = inp.get("todos") or []
+        return f"{len(todos)} todo(s)" if isinstance(todos, list) else ""
+    # Fallback: first string value.
+    for v in inp.values():
+        if isinstance(v, str):
+            return _truncate(v, 80)
+    return ""
+
+
+def _tool_result_preview(content: object) -> str:
+    """`tool_result.content` may be a string OR a list of `{type:"text",
+    text:"…"}` blocks. Flatten to a single short preview."""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        pieces = []
+        for c in content:
+            if isinstance(c, dict) and c.get("type") == "text":
+                pieces.append(str(c.get("text", "")))
+        text = "".join(pieces)
+    else:
+        text = str(content)
+    return _truncate(text.replace("\n", " ⏎ "), 200)
+
+
+def format_event(ev: dict) -> list[str]:
+    """Render one stream-json event as zero or more pretty lines.
+
+    Returned strings have no trailing newline. The caller joins with
+    "\\n" — that keeps the formatter unaware of where it's printing to.
+    """
+    et = ev.get("type")
+
+    if et == "system":
+        if ev.get("subtype") == "init":
+            sid = str(ev.get("session_id") or "?")[:8]
+            model = ev.get("model") or "?"
+            return [f"[init] model={model} session={sid}"]
+        return []
+
+    if et == "assistant":
+        out: list[str] = []
+        for block in ev.get("message", {}).get("content", []) or []:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                text = str(block.get("text", "")).rstrip()
+                if text:
+                    out.append(text)
+            elif btype == "tool_use":
+                name = str(block.get("name") or "?")
+                summary = _summarize_input(name, block.get("input", {}))
+                out.append(f"→ {name}({summary})" if summary else f"→ {name}()")
+        return out
+
+    if et == "user":
+        out = []
+        for block in ev.get("message", {}).get("content", []) or []:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_result":
+                preview = _tool_result_preview(block.get("content", ""))
+                out.append(f"← {preview}" if preview else "← (empty)")
+        return out
+
+    if et == "result":
+        if ev.get("is_error"):
+            dur = ev.get("duration_ms", 0)
+            return [f"[result] ERROR duration={dur}ms"]
+        cost = ev.get("total_cost_usd")
+        dur = ev.get("duration_ms", 0)
+        cost_s = f" cost=${float(cost):.4f}" if isinstance(cost, (int, float)) else ""
+        return [f"[result] ok duration={dur}ms{cost_s}"]
+
+    # Unknown event type — silently skip.
+    return []
+
+
+def format_stream(text: str) -> str:
+    """Format an entire stream-json log file (multiline JSONL).
+
+    Tolerates blank lines, non-JSON lines (passed through with a marker),
+    and JSON values that aren't dicts (skipped). Always returns a string
+    ending in a single trailing newline if non-empty.
+    """
+    lines: list[str] = []
+    for raw in text.splitlines():
+        if not raw.strip():
+            continue
+        try:
+            ev = json.loads(raw)
+        except json.JSONDecodeError:
+            lines.append(f"[non-json] {raw}")
+            continue
+        if not isinstance(ev, dict):
+            continue
+        lines.extend(format_event(ev))
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+__all__ = ["format_event", "format_stream"]

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -1,0 +1,88 @@
+"""End-to-end CLI tests for `fabric logs [--pretty]`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from fabric import state
+from fabric.cli import app
+
+runner = CliRunner()
+
+
+def _seed_dispatch(project: str, issue: int, log_path: Path) -> None:
+    """Insert a dispatch row pointing at `log_path` so `fabric logs` finds
+    it without needing a real claude run."""
+    state.upsert_project(name=project, path="/tmp/x", repo="me/x")
+    did = state.record_dispatch(
+        project=project, issue=issue, stage="plan-exec",
+        started_at="2026-05-05T20:00:00+00:00",
+    )
+    state.complete_dispatch(
+        did, ended_at="2026-05-05T20:01:00+00:00", exit_code=0, log_path=str(log_path),
+    )
+
+
+def _stream_json_log(tmp_path: Path) -> Path:
+    """A small but realistic stream-json dispatch log."""
+    events = [
+        {"type": "system", "subtype": "init",
+         "session_id": "abcd1234zz", "model": "claude-opus-4-7"},
+        {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "Reading the issue body."},
+            {"type": "tool_use", "name": "Read",
+             "input": {"file_path": "issue.md"}},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": "issue body text"},
+        ]}},
+        {"type": "result", "is_error": False,
+         "duration_ms": 12345, "total_cost_usd": 0.0123},
+    ]
+    p = tmp_path / "dispatch.log"
+    p.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+    return p
+
+
+def test_logs_default_emits_raw_jsonl(
+    isolated_state_db: Path, tmp_path: Path,
+) -> None:
+    """Without --pretty, `fabric logs` writes the raw JSONL byte-for-byte
+    so it stays greppable / parseable / replayable."""
+    log = _stream_json_log(tmp_path)
+    _seed_dispatch("teach-me-eng-bot", 9, log)
+
+    res = runner.invoke(app, ["logs", "teach-me-eng-bot", "9"])
+    assert res.exit_code == 0
+    # Raw mode contains the source JSONL verbatim and adds no pretty
+    # artifacts (transcript markers, arrows, [init] / [result] tags).
+    assert log.read_text() in res.output
+    assert "[init]" not in res.output
+    assert "[result]" not in res.output
+    assert "→ " not in res.output
+
+
+def test_logs_pretty_renders_transcript(
+    isolated_state_db: Path, tmp_path: Path,
+) -> None:
+    """`--pretty` parses the JSONL and renders one human-readable line
+    per event (init / assistant text / tool calls / tool results / result)."""
+    log = _stream_json_log(tmp_path)
+    _seed_dispatch("teach-me-eng-bot", 9, log)
+
+    res = runner.invoke(app, ["logs", "teach-me-eng-bot", "9", "--pretty"])
+    assert res.exit_code == 0
+    assert "[init] model=claude-opus-4-7" in res.output
+    assert "Reading the issue body." in res.output
+    assert "→ Read(issue.md)" in res.output
+    assert "← issue body text" in res.output
+    assert "[result] ok duration=12345ms cost=$0.0123" in res.output
+
+
+def test_logs_no_dispatch_returns_one(isolated_state_db: Path) -> None:
+    res = runner.invoke(app, ["logs", "no-such-project", "1"])
+    assert res.exit_code == 1
+    assert "no dispatch found" in (res.output + (res.stderr or ""))

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -132,6 +132,27 @@ def test_dispatch_argv_uses_default_model_and_project_path(
     assert any("plan-exec" in a and "issue #7" in a for a in args)
 
 
+def test_dispatch_argv_enables_stream_json_verbose_logging(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """`--output-format stream-json --verbose` makes claude emit one JSON
+    event per tool call / assistant message / tool result. Without
+    --verbose, stream-json suppresses tool events; without stream-json,
+    we get only the final summary message (the pre-existing thin logs)."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+
+    _aiorun(d.dispatch("teach-me-eng-bot", 7, "plan-exec"))
+
+    args = spawner.calls[0]
+    assert "--output-format" in args
+    fmt_idx = args.index("--output-format")
+    assert args[fmt_idx + 1] == "stream-json"
+    assert "--verbose" in args
+
+
 def test_dispatch_argv_isolates_prompt_from_variadic_add_dir(
     isolated_state_db: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_log_format.py
+++ b/tests/test_log_format.py
@@ -1,0 +1,221 @@
+"""Tests for the stream-json pretty-printer."""
+
+from __future__ import annotations
+
+import json
+
+from fabric.log_format import format_event, format_stream
+
+
+# ---------- format_event over individual event types ----------
+
+
+def test_format_system_init_emits_one_summary_line() -> None:
+    ev = {
+        "type": "system",
+        "subtype": "init",
+        "session_id": "abcd1234efgh5678",
+        "model": "claude-opus-4-7",
+    }
+    out = format_event(ev)
+    assert out == ["[init] model=claude-opus-4-7 session=abcd1234"]
+
+
+def test_format_system_non_init_is_silent() -> None:
+    """We don't render every system event — only init."""
+    ev = {"type": "system", "subtype": "session_resumed"}
+    assert format_event(ev) == []
+
+
+def test_format_assistant_text_block() -> None:
+    ev = {
+        "type": "assistant",
+        "message": {
+            "content": [{"type": "text", "text": "Reading the issue body now.\n"}],
+        },
+    }
+    out = format_event(ev)
+    assert out == ["Reading the issue body now."]
+
+
+def test_format_assistant_skips_empty_text_blocks() -> None:
+    ev = {
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": "   \n"}]},
+    }
+    assert format_event(ev) == []
+
+
+def test_format_assistant_tool_use_read_shows_file_path() -> None:
+    ev = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Read",
+                    "input": {"file_path": "/srv/projects/teach-me-eng-bot/bot.py"},
+                }
+            ],
+        },
+    }
+    assert format_event(ev) == ["→ Read(/srv/projects/teach-me-eng-bot/bot.py)"]
+
+
+def test_format_assistant_tool_use_bash_truncates_long_command() -> None:
+    long = "find /srv/projects -type f -name '*.py' -exec grep -l fabric {} \\; | sort | uniq | head"
+    ev = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "name": "Bash", "input": {"command": long}}
+            ],
+        },
+    }
+    [line] = format_event(ev)
+    assert line.startswith("→ Bash(")
+    assert line.endswith(")")
+    assert "…" in line  # truncated
+
+
+def test_format_assistant_tool_use_unknown_tool_uses_first_string_field() -> None:
+    ev = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "MysteryTool",
+                    "input": {"target": "thing-42", "depth": 3},
+                }
+            ],
+        },
+    }
+    assert format_event(ev) == ["→ MysteryTool(thing-42)"]
+
+
+def test_format_assistant_handles_text_and_tool_use_in_one_event() -> None:
+    ev = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "text", "text": "Let me check the file."},
+                {"type": "tool_use", "name": "Read", "input": {"file_path": "x.py"}},
+            ],
+        },
+    }
+    assert format_event(ev) == ["Let me check the file.", "→ Read(x.py)"]
+
+
+def test_format_user_tool_result_shows_truncated_preview() -> None:
+    ev = {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "line 1\nline 2\nline 3",
+                }
+            ]
+        },
+    }
+    [line] = format_event(ev)
+    assert line.startswith("← line 1 ⏎ line 2 ⏎ line 3")
+
+
+def test_format_user_tool_result_handles_block_form() -> None:
+    """The content field can be a list of {type:'text', text:'…'} blocks
+    rather than a bare string — both shapes appear in real claude output."""
+    ev = {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [
+                        {"type": "text", "text": "first\n"},
+                        {"type": "text", "text": "second"},
+                    ],
+                }
+            ]
+        },
+    }
+    [line] = format_event(ev)
+    assert line == "← first ⏎ second"
+
+
+def test_format_result_success_has_cost_and_duration() -> None:
+    ev = {
+        "type": "result",
+        "is_error": False,
+        "duration_ms": 12345,
+        "total_cost_usd": 0.0123,
+    }
+    assert format_event(ev) == ["[result] ok duration=12345ms cost=$0.0123"]
+
+
+def test_format_result_error_marks_failure() -> None:
+    ev = {"type": "result", "is_error": True, "duration_ms": 500}
+    assert format_event(ev) == ["[result] ERROR duration=500ms"]
+
+
+def test_format_unknown_event_type_is_silent() -> None:
+    assert format_event({"type": "no_such_type", "data": 42}) == []
+
+
+# ---------- format_stream over a multi-line file ----------
+
+
+def test_format_stream_renders_full_dispatch() -> None:
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "deadbeef00", "model": "claude-opus-4-7"},
+        {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "Reading issue body."},
+            {"type": "tool_use", "name": "Read", "input": {"file_path": "issue.md"}},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": "issue body here"},
+        ]}},
+        {"type": "result", "is_error": False, "duration_ms": 100, "total_cost_usd": 0.001},
+    ]
+    text = "\n".join(json.dumps(e) for e in events) + "\n"
+    out = format_stream(text)
+
+    assert out.startswith("[init] model=claude-opus-4-7 session=deadbeef")
+    assert "Reading issue body." in out
+    assert "→ Read(issue.md)" in out
+    assert "← issue body here" in out
+    assert out.rstrip().endswith("[result] ok duration=100ms cost=$0.0010")
+    assert out.endswith("\n")
+
+
+def test_format_stream_tolerates_blank_lines() -> None:
+    text = (
+        "\n"
+        + json.dumps({"type": "result", "is_error": False, "duration_ms": 1}) + "\n"
+        + "\n"
+    )
+    out = format_stream(text)
+    assert "[result] ok" in out
+
+
+def test_format_stream_passes_through_non_json_lines() -> None:
+    """Old plain-text logs (pre-stream-json) should still be readable —
+    `--pretty` shouldn't crash on them."""
+    text = "this is not json\n" + json.dumps({"type": "result", "is_error": False, "duration_ms": 1}) + "\n"
+    out = format_stream(text)
+    assert "[non-json] this is not json" in out
+    assert "[result] ok" in out
+
+
+def test_format_stream_skips_non_dict_json() -> None:
+    text = "42\n[1,2,3]\n" + json.dumps({"type": "result", "is_error": False, "duration_ms": 1}) + "\n"
+    out = format_stream(text)
+    assert out.strip() == "[result] ok duration=1ms"
+
+
+def test_format_stream_empty_returns_empty_string() -> None:
+    assert format_stream("") == ""
+    assert format_stream("\n\n\n") == ""


### PR DESCRIPTION
## Summary

Restores the "tee everything" experience the bash scripts had. claude -p was being run without verbosity flags, so each dispatch log was just the agent's final summary message — the entire 11-minute end-to-end run on issue #56 today produced **11 lines of log total**. Post-mortem debugging meant guessing from \`exit_code\` + a sentence.

This PR enables \`--output-format stream-json --verbose\` on the dispatcher's claude invocation, making the disk log a structured, replayable transcript of every agent action: assistant messages, tool calls (Read/Edit/Bash/gh/Task/…), tool results, and the final result event with cost + duration.

## Architecture: disk = source of truth, WS = live fanout

- **Disk file** is durable, queryable, replayable forever; the future dashboard parses it for "watch this dispatch like an interactive session."
- **WebSocket /ws/live** is unchanged — it still fans out one stdout line per WS message. Each line is now a JSON event. Consumers (dashboard) double-parse: outer envelope, then \`line\` field. Single schema, single place to update if claude changes the stream-json shape.

## What ships

- **\`fabric/dispatcher.py\`** — \`_build_argv\` now adds \`--output-format stream-json --verbose\`. (Without \`--verbose\`, stream-json suppresses tool events; without stream-json, you get only the final message.)
- **\`fabric/log_format.py\`** — pure helper: \`format_event(dict)\` and \`format_stream(str)\`. Renders \`[init] model=… session=…\`, assistant text, \`→ ToolName(arg-summary)\`, \`← <preview>\`, \`[result] ok duration=Xms cost=\$Y.YYYY\`. Tolerant: unknown event types skipped, malformed JSON falls through with a \`[non-json]\` marker so pre-existing plain-text logs stay readable through the same viewer.
- **\`fabric/cli.py\`** — \`fabric logs <p> <n>\` keeps raw JSONL as default (greppable, replayable). New \`--pretty\` flag renders the transcript view. \`--follow\` is unchanged (raw \`tail -f\`).

## What didn't ship (deferred)

- **Log rotation.** Confirmed with you to skip. Logs will grow to maybe ~500KB-2MB per dispatch; revisit after a few weeks of operation.
- **Pretty live-tail.** \`--follow\` still uses \`tail -f\`. Pretty live-streaming would need a long-running parser loop; not worth it for v1 — pipe through \`jq\` or run \`--pretty\` after the dispatch ends.
- **Server-side parsing of WS events.** Would couple the fabric to claude's stream-json schema in two places. Dashboard does the double-parse instead.

## Test plan

- [x] \`pytest -q\` — 256 passed (was 234), 6 skipped
- [x] **dispatcher.py** — argv contains \`--output-format stream-json --verbose\`
- [x] **log_format.py** — every documented event type (system/assistant text/assistant tool_use/user tool_result/result ok/result error) renders correctly; malformed JSON, blank lines, non-dict JSON all tolerated; bash command truncation works; tool_result content list-form (claude's two-shape API)
- [x] **CLI** — raw mode is byte-identical to source; \`--pretty\` produces transcript with all expected markers; missing-dispatch returns exit 1
- [ ] **Post-deploy live verification** — restart fabric on VPS, file a test issue, confirm a dispatch log balloons from ~10 lines to hundreds and \`fabric logs <p> <n> --pretty\` renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)