### PR TITLE
feat: epic-flow coordinator (B3 hold-and-release)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -312,7 +312,7 @@ CREATE TABLE dispatches (
 
 CREATE TABLE notifications (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  kind TEXT NOT NULL,         -- clarification | decompose-approval | blocked | dispatch-failed
+  kind TEXT NOT NULL,         -- clarification | decompose-approval | blocked | dispatch-failed | epic-advanced | epic-completed
   project TEXT NOT NULL,
   issue INTEGER NOT NULL,
   created_at TEXT NOT NULL,
@@ -364,7 +364,7 @@ When multiple projects have actionable work this tick, who goes first?
 |---|---|---|
 | D1 | Per-project round-robin within state priority | Fair; no project starves. |
 | D2 | Pure cross-project priority (any project's `priority:high in-review` beats any project's `priority:medium`) | Urgent stuff jumps repos. |
-| **D3** | **Hybrid: state priority first (in-review > rework > tests-pending > needs-planning > epic / unqualified), then `priority:*` across projects, then round-robin between projects at same level, then createdAt** | Drains in-flight; respects priority; no starvation. |
+| **D3** | **Hybrid: state priority first (in-review > rework > tests-pending > needs-planning > needs-decompose / unqualified), then `priority:*` across projects, then round-robin between projects at same level, then createdAt** | Drains in-flight; respects priority; no starvation. |
 
 **Choice: D3.** Same spirit as the in-repo plan's E3, generalized across projects. Round-robin tiebreak ensures one chatty project can't monopolise the fabric.
 

--- a/fabric/github.py
+++ b/fabric/github.py
@@ -223,6 +223,20 @@ def comment(
     return CommentRef(url=out.strip())
 
 
+def close_issue(
+    repo: str,
+    number: int,
+    *,
+    comment_body: str | None = None,
+    runner: SubprocessRunner = _default_runner,
+) -> None:
+    """Close `repo#number`, optionally posting a closing comment in one call."""
+    args = ["issue", "close", str(number), "--repo", repo]
+    if comment_body is not None:
+        args += ["--comment", comment_body]
+    _run_gh(args, runner=runner)
+
+
 _ISSUE_PR_LINK_RE = re.compile(r"#issuecomment-(\d+)$")
 
 
@@ -424,6 +438,7 @@ __all__ = [
     "PRSummary",
     "SubprocessRunner",
     "add_labels",
+    "close_issue",
     "comment",
     "create_label",
     "edit_label",

--- a/fabric/labels.py
+++ b/fabric/labels.py
@@ -32,9 +32,9 @@ STATE_LABELS: list[LabelSpec] = [
         "Author-marked WIP — agents ignore until label is removed",
     ),
     LabelSpec(
-        "state:epic",
+        "state:needs-decompose",
         "8b5cf6",
-        "Complex feature; epic-decompose runs to split into children",
+        "Epic awaiting decomposition into child issues",
     ),
     LabelSpec("state:needs-planning", "0e8a16", "Ready for plan-exec"),
     LabelSpec("state:in-progress", "fbca04", "Agent currently working"),
@@ -52,6 +52,11 @@ STATE_LABELS: list[LabelSpec] = [
         "Decomposition awaits human approval",
     ),
     LabelSpec(
+        "state:tracking",
+        "b3e5fc",
+        "Epic with children filed; auto-closes when all children close",
+    ),
+    LabelSpec(
         "state:blocked",
         "b60205",
         "Cycle cap or repeated failure; human intervention required",
@@ -66,13 +71,16 @@ PRIORITY_LABELS: list[LabelSpec] = [
     LabelSpec("priority:low", "0e8a16", "Eligible for sonnet downgrade"),
 ]
 
-# Type — informational; not pipeline-load-bearing.
+# Type — informational; not pipeline-load-bearing. `type:epic` is the
+# permanent marker on a parent issue; the transient state lives in the
+# `state:*` family (`state:needs-decompose`, `state:tracking`, etc.).
 TYPE_LABELS: list[LabelSpec] = [
     LabelSpec("type:feature", "1d76db", ""),
     LabelSpec("type:bug", "d93f0b", ""),
     LabelSpec("type:refactor", "5319e7", ""),
     LabelSpec("type:test", "0e8a16", ""),
     LabelSpec("type:docs", "fef2c0", ""),
+    LabelSpec("type:epic", "8b5cf6", "Multi-PR initiative; child issues track the work"),
 ]
 
 

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -15,6 +15,7 @@ the synchronous decision layer + the CLI hook.
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -40,7 +41,7 @@ _STATE_TIER: dict[str, int] = {
     "state:needs-rework": 1,
     "state:tests-pending": 2,
     "state:needs-planning": 3,
-    "state:epic": 4,
+    "state:needs-decompose": 4,
     _UNQUALIFIED_STATE: 4,
 }
 
@@ -49,7 +50,7 @@ _STAGE_BY_STATE: dict[str, str] = {
     "state:needs-rework": "plan-exec",
     "state:tests-pending": "test-writer",
     "state:in-review": "review-pr",
-    "state:epic": "epic-decompose",
+    "state:needs-decompose": "epic-decompose",
     _UNQUALIFIED_STATE: "qualify-issue",
 }
 
@@ -80,6 +81,24 @@ _ATTRIBUTION_WINDOW_SECONDS = 300
 
 _DONE_STATE_LABEL = "state:done"
 _COMPLETED_NOTIF_KIND = "issue-completed"
+
+# Epic coordinator (B3 — hold-and-release).
+_EPIC_TYPE_LABEL = "type:epic"
+_DRAFT_STATE_LABEL = "state:draft"
+_NEEDS_PLANNING_LABEL = "state:needs-planning"
+_EPIC_ADVANCED_KIND = "epic-advanced"
+_EPIC_COMPLETED_KIND = "epic-completed"
+
+# `Refs #<N>` in a child issue's body marks the epic parent. Children are
+# filed by the `epic-decompose` skill with this exact line.
+_REFS_PARENT_RE = re.compile(r"\bRefs\s+#(\d+)\b", re.IGNORECASE)
+
+
+def _parse_epic_parent(body: str | None) -> int | None:
+    if not body:
+        return None
+    m = _REFS_PARENT_RE.search(body)
+    return int(m.group(1)) if m else None
 
 
 @dataclass(frozen=True)
@@ -481,6 +500,108 @@ class Scheduler:
                 project=entry.name,
                 issue=row.number,
             )
+            await self._advance_or_close_parent(entry, detail)
+
+    async def _advance_or_close_parent(
+        self,
+        entry: ProjectEntry,
+        closed_detail: gh.IssueDetail,
+    ) -> None:
+        """B3 coordinator. When a `type:epic` parent's child closes, advance
+        the oldest `state:draft` sibling to `state:needs-planning`. If no
+        drafts remain and no other siblings are open, close the parent.
+
+        Best-effort — gh hiccups silently no-op so a transient API blip
+        doesn't poison the tick. Next closure will re-trigger.
+        """
+        parent_num = _parse_epic_parent(closed_detail.body)
+        if parent_num is None:
+            return
+        try:
+            parent = await asyncio.to_thread(
+                gh.get_issue, entry.repo, parent_num, runner=self._gh_runner,
+            )
+        except gh.GhError:
+            return
+        if not any(lbl.name == _EPIC_TYPE_LABEL for lbl in parent.labels):
+            return
+        if parent.state.upper() == "CLOSED":
+            return
+
+        try:
+            siblings = await asyncio.to_thread(
+                gh.list_issues,
+                entry.repo,
+                label_query=f'in:body "Refs #{parent_num}"',
+                state="open",
+                runner=self._gh_runner,
+            )
+        except gh.GhError:
+            return
+
+        # Defensive: gh search may briefly include the just-closed issue.
+        siblings = [s for s in siblings if s.number != closed_detail.number]
+
+        drafts = [
+            s for s in siblings
+            if any(lbl.name == _DRAFT_STATE_LABEL for lbl in s.labels)
+        ]
+        non_drafts = [
+            s for s in siblings
+            if not any(lbl.name == _DRAFT_STATE_LABEL for lbl in s.labels)
+        ]
+
+        # Another sibling is already in flight; let it finish before
+        # advancing — its closure will trigger the next advance.
+        if non_drafts:
+            return
+
+        if drafts:
+            oldest = min(drafts, key=lambda s: s.created_at or "")
+            try:
+                await asyncio.to_thread(
+                    gh.remove_labels, entry.repo, oldest.number,
+                    [_DRAFT_STATE_LABEL], runner=self._gh_runner,
+                )
+                await asyncio.to_thread(
+                    gh.add_labels, entry.repo, oldest.number,
+                    [_NEEDS_PLANNING_LABEL], runner=self._gh_runner,
+                )
+            except gh.GhError:
+                return
+            await asyncio.to_thread(
+                state.add_notification,
+                kind=_EPIC_ADVANCED_KIND,
+                project=entry.name,
+                issue=parent_num,
+                body=(
+                    f"{entry.name}#{parent_num} — epic advanced\n"
+                    f"#{closed_detail.number} closed → "
+                    f"#{oldest.number} now {_NEEDS_PLANNING_LABEL}"
+                ),
+            )
+            return
+
+        # No active siblings, no drafts left — all children done.
+        try:
+            await asyncio.to_thread(
+                gh.close_issue,
+                entry.repo,
+                parent_num,
+                comment_body=(
+                    "Auto-closed by agent-fabric: all epic children have closed."
+                ),
+                runner=self._gh_runner,
+            )
+        except gh.GhError:
+            return
+        await asyncio.to_thread(
+            state.add_notification,
+            kind=_EPIC_COMPLETED_KIND,
+            project=entry.name,
+            issue=parent_num,
+            body=f"{entry.name}#{parent_num} — epic completed (all children closed)",
+        )
 
     def _in_backoff(
         self, failures: int, ended_at: str, backoffs: list[int]

--- a/fabric/skill_templates/epic-decompose/SKILL.md.j2
+++ b/fabric/skill_templates/epic-decompose/SKILL.md.j2
@@ -1,12 +1,12 @@
 ---
 name: epic-decompose
-description: Pre-Stage-1 skill for issues labelled `type:epic`. Runs headless from `scripts/agent-epic-decompose.sh` on a single epic and decomposes it into a set of child issues that the regular plan-exec → test-writer → reviewer pipeline can ship. Multi-round Socratic Q&A with the user across many invocations (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files the children with `Refs #<parent>`, and parks the parent at `state:tracking`. Does NOT cut branches, write code, or open PRs.
-version: 1.0.0
+description: Decomposition stage for `type:epic` issues at `state:needs-decompose`. Multi-round Socratic Q&A with the user (one round per dispatch), then proposes a child-issue list, awaits explicit approval (`/decompose-ok`), files children with `Refs #<parent>`, and parks the parent at `state:tracking`. Children are filed B3-style — child #1 at `state:needs-planning`, the rest at `state:draft` — so the fabric's coordinator can release them one at a time as each predecessor closes. Does NOT cut branches, write code, or open PRs.
+version: 2.0.0
 ---
 
 # epic-decompose
 
-Decomposition stage for big features. Splits a `type:epic` parent issue into smaller child issues that the existing pipeline can ship one at a time. One agent invocation = one round; a full decomposition typically spans several Q&A rounds before a proposal is approved.
+Decomposition stage for `type:epic` parents. Splits the epic into smaller child issues that the existing pipeline ships one at a time, in the order you propose. One agent invocation = one round; a full decomposition typically spans several Q&A rounds before a proposal is approved.
 
 ## Hard boundaries
 
@@ -22,14 +22,12 @@ You MUST NOT:
 
 ## Inputs and exit conditions
 
-Dispatched at one of two states:
-- `state:needs-planning` — the entry/resume state. Either the first round, or the user resumed after a clarification answer or feedback on a proposal.
-- `state:awaiting-decompose-approval` — defensive; the runner script accepts this too. In practice the user flips back to `needs-planning` when they want the next dispatch to act.
+Dispatched on a `type:epic` parent at `state:needs-decompose`. That's the entry state on the very first dispatch (set by `qualify-issue`) and also the resume state after the user answers a clarification or asks for proposal revisions.
 
-Exits the run by flipping to one of:
+Exits the run by flipping the state label to one of:
 - `state:clarification-needed` — you posted a question, awaiting answer.
 - `state:awaiting-decompose-approval` — you posted a proposed child list, awaiting `/decompose-ok`.
-- `state:tracking` — children filed, parent now waits for them to merge.
+- `state:tracking` — children filed, parent now waits for them to merge. The fabric's coordinator advances child #2 to planning when child #1 closes, and so on; when the last child closes the parent auto-closes too.
 - `state:blocked` — round cap exhausted or unresolvable error (rare).
 
 ## The decision tree (do this every dispatch)
@@ -54,7 +52,7 @@ Read the issue body and **all** comments. Then walk this tree top-down — first
 
 ```bash
 gh issue edit <N> \
-  --remove-label "state:needs-planning,state:awaiting-decompose-approval" \
+  --remove-label "state:needs-decompose,state:awaiting-decompose-approval" \
   --add-label "state:in-progress"
 ```
 
@@ -78,7 +76,7 @@ gh issue comment <N> --body "$(cat <<'EOF'
 
 Context: <one sentence — what you've already concluded, what depends on this>.
 
-When you answer, flip the label back to `state:needs-planning` to re-enter the loop.
+When you answer, flip the label back to `state:needs-decompose` to re-enter the loop.
 EOF
 )"
 ```
@@ -121,7 +119,7 @@ gh issue comment <N> --body "$(cat <<'EOF'
 
 ---
 
-**Reply `/decompose-ok` to approve.** Then flip `state:awaiting-decompose-approval` → `state:needs-planning` and the next dispatch will file these as child issues. To request changes, comment your feedback and flip back to `state:needs-planning` — I'll revise.
+**Reply `/decompose-ok` to approve.** Then flip `state:awaiting-decompose-approval` → `state:needs-decompose` and the next dispatch will file these as child issues. To request changes, comment your feedback and flip back to `state:needs-decompose` — I'll revise.
 EOF
 )"
 ```
@@ -140,9 +138,15 @@ Print `proposal posted: <N> children, awaiting approval` and exit.
 
 ## 4. File-children round (after `/decompose-ok`)
 
-Triggered when §A1 of the decision tree matches. For each child in the most recent proposal, in the order you listed them:
+Triggered when §A1 of the decision tree matches. For each child in the most recent proposal, **in the order you listed them**:
+
+- The **first** child gets `state:needs-planning` — that's the one the pipeline will pick up immediately.
+- Every **subsequent** child gets `state:draft` — held until its predecessor closes. The fabric's coordinator (in `scheduler.py`) detects each child's closure, parses `Refs #<parent>` from its body, and flips the next `state:draft` sibling to `state:needs-planning` automatically. When the last child closes, the parent auto-closes too.
+
+The `Refs #<N>` line in the body is **load-bearing** — the coordinator parses it. Don't drop it, don't reword it.
 
 ```bash
+# Child #1 — the kick-off:
 gh issue create \
   --title "<imperative title>" \
   --label "type:feat,priority:medium,area:vocab,state:needs-planning" \
@@ -160,6 +164,24 @@ Part of epic #<N>.
 Refs #<N>
 EOF
 )"
+
+# Children #2..K — held until their predecessor closes:
+gh issue create \
+  --title "<imperative title>" \
+  --label "type:feat,priority:medium,area:vocab,state:draft" \
+  --body "$(cat <<EOF
+<one-paragraph problem statement>
+
+## Acceptance criteria
+- AC1: ...
+
+## Out of scope
+- ...
+
+Part of epic #<N>.
+Refs #<N>
+EOF
+)"
 ```
 
 Capture each new issue number from the URL `gh issue create` prints. Then post one closing comment on the parent that lists the child links and flip to `state:tracking`:
@@ -167,13 +189,14 @@ Capture each new issue number from the URL `gh issue create` prints. Then post o
 ```bash
 gh issue comment <N> --body "$(cat <<EOF
 <!-- agent-decompose-filed v1 -->
-**Decomposition filed.** Children:
+**Decomposition filed.** Children (will be released one at a time as each predecessor closes):
 
-- #<C1> — <title>
-- #<C2> — <title>
+- #<C1> — <title> · `state:needs-planning` (active)
+- #<C2> — <title> · `state:draft` (held)
+- #<C3> — <title> · `state:draft` (held)
 - ...
 
-Parent will auto-close once all children are closed (orchestrator coordinator).
+The fabric will advance the next held child to `state:needs-planning` automatically when each closes. Parent auto-closes once the last child is done.
 EOF
 )"
 
@@ -183,8 +206,6 @@ gh issue edit <N> \
 ```
 
 Print `filed <K> children for epic #<N>: <numbers>` and exit.
-
-> **Coordinator caveat:** the auto-close-on-children-done coordinator lives in the orchestrator (separate increment). Until that ships, the parent stays at `state:tracking` and the user closes it manually after all children merge. Mention this in the closing comment if the orchestrator is not yet deployed.
 
 ## 5. What "must-answer" questions look like for an epic
 

--- a/fabric/skill_templates/qualify-issue/SKILL.md.j2
+++ b/fabric/skill_templates/qualify-issue/SKILL.md.j2
@@ -1,7 +1,7 @@
 ---
 name: qualify-issue
-description: Triage stage for freshly-filed open issues that have no `state:*` label. Reads the body and routes the issue into one of four buckets — `state:draft` (ignored), `state:epic` (decompose), `state:clarification-needed` (ask the human), or `state:needs-planning` (ready for plan-exec) — by setting labels and, where appropriate, a single short comment. Read-and-label only; never edits code, never opens PRs, never touches more than one issue per dispatch.
-version: 1.0.0
+description: Triage stage for freshly-filed open issues that have no `state:*` label. Reads the body and routes the issue into one of four buckets — `state:draft` (ignored), `type:epic` + `state:needs-decompose` (decompose), `state:clarification-needed` (ask the human), or `state:needs-planning` (ready for plan-exec) — by setting labels and, where appropriate, a single short comment. Read-and-label only; never edits code, never opens PRs, never touches more than one issue per dispatch.
+version: 1.1.0
 ---
 
 # qualify-issue
@@ -81,11 +81,11 @@ Match if **any** of these are clearly true from the body:
 Most issues are **not epics.** A single feature, a bug fix, a refactor, a docs update, even a moderate cross-module change — these are plan-ready, not epics. Bias toward Branch 4. Reach for "epic" only when splitting it would be obviously wrong to do in a single PR.
 
 ```bash
-gh issue edit <N> --add-label "state:epic" --add-label "type:feature"
-gh issue comment <N> --body "Classified as \`state:epic\` — \`epic-decompose\` will pick this up to start the Q&A and propose a child-issue list."
+gh issue edit <N> --add-label "type:epic" --add-label "state:needs-decompose"
+gh issue comment <N> --body "Classified as \`type:epic\` + \`state:needs-decompose\` — \`epic-decompose\` will pick this up to start the Q&A and propose a child-issue list."
 ```
 
-Stop. Skip `type:feature` if a different `type:*` is already set.
+Stop. `type:epic` is the permanent marker on the parent (separates "what kind of issue" from "where in the pipeline"); `state:needs-decompose` is the transient routing state the scheduler keys on. Don't also set `type:feature` — `type:epic` covers it.
 
 ### Branch 4 — Plan-ready (default)
 
@@ -140,7 +140,7 @@ These are sketches based on real issue shapes — actual classification will var
 → Branch 4. `state:needs-planning` + `priority:high` + `type:bug`. A defect with a concrete reproducer and a real consequence.
 
 **Title: "Migrate auth + storage + UI to multi-tenant"** (body: lists 6 ACs spanning DB schema, OAuth, frontend, new admin pages, billing, docs)
-→ Branch 3. `state:epic` + `type:feature`. 3+ PRs, different concerns. epic-decompose takes it from here.
+→ Branch 3. `type:epic` + `state:needs-decompose`. 3+ PRs, different concerns. epic-decompose takes it from here.
 
 **Title: "Refactor"** (body: empty)
 → Branch 2. Ask: "What part of the codebase, and what's wrong with the current shape that motivates the refactor?" Cannot reasonably plan from this.

--- a/fabric/telegram_bot.py
+++ b/fabric/telegram_bot.py
@@ -139,6 +139,8 @@ _NOTIF_HEADERS = {
     "quota-warning": "⚠️ Quota warning",
     "issue-completed": "✅ Issue completed",
     "state-changed": "🔄 State changed",
+    "epic-advanced": "➡️ Epic advanced",
+    "epic-completed": "🎉 Epic completed",
 }
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -9,6 +9,7 @@ import pytest
 from fabric.github import (
     GhError,
     add_labels,
+    close_issue,
     comment,
     find_pr_for_issue,
     get_issue,
@@ -195,6 +196,27 @@ def test_comment_returns_url_and_passes_body() -> None:
     args = r.calls[0]
     body_idx = args.index("--body")
     assert args[body_idx + 1] == "hello"
+
+
+# ---------- close_issue ----------
+
+
+def test_close_issue_invokes_correct_argv() -> None:
+    r = FakeRunner()
+    r.queue()
+    close_issue("me/r", 5, runner=r)
+    args = r.calls[0]
+    assert args[:6] == ["gh", "issue", "close", "5", "--repo", "me/r"]
+    assert "--comment" not in args
+
+
+def test_close_issue_with_comment_body_passes_flag() -> None:
+    r = FakeRunner()
+    r.queue()
+    close_issue("me/r", 5, comment_body="all done", runner=r)
+    args = r.calls[0]
+    body_idx = args.index("--comment")
+    assert args[body_idx + 1] == "all done"
 
 
 # ---------- find_pr_for_issue ----------

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -61,12 +61,22 @@ def test_state_labels_cover_all_pipeline_states() -> None:
         assert state_label in spec_names, f"missing canonical: {state_label}"
 
 
-def test_draft_and_epic_states_are_canonical() -> None:
-    """The triage states added with the qualify-issue stage must exist in
-    the canonical set so `setup-labels` provisions them on every project."""
+def test_epic_flow_states_are_canonical() -> None:
+    """Triage + epic-coordinator states must exist in the canonical set so
+    `setup-labels` provisions them on every project."""
     spec_names = {s.name for s in STATE_LABELS}
     assert "state:draft" in spec_names
-    assert "state:epic" in spec_names
+    assert "state:needs-decompose" in spec_names
+    assert "state:tracking" in spec_names
+    # The legacy `state:epic` was renamed to `state:needs-decompose`.
+    assert "state:epic" not in spec_names
+
+
+def test_type_epic_is_canonical_type_label() -> None:
+    """`type:epic` is the permanent marker on a parent issue — separates
+    'what kind of issue' from 'where in the pipeline' (state:*)."""
+    type_names = {s.name for s in TYPE_LABELS}
+    assert "type:epic" in type_names
 
 
 def test_priority_labels_cover_all_dispatcher_priorities() -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -227,8 +227,12 @@ def test_tick_state_draft_is_ignored(base_setup: Path) -> None:
     assert res.candidates == 0
 
 
-def test_tick_state_epic_dispatches_decompose(base_setup: Path) -> None:
-    gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1, "state:epic")])
+def test_tick_state_needs_decompose_dispatches_epic_decompose(base_setup: Path) -> None:
+    """`state:needs-decompose` (the post-rename epic entry state) routes to
+    the `epic-decompose` stage."""
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[_issue_payload(1, "state:needs-decompose")]
+    )
     res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
     assert res.winner is not None
     assert res.winner.stage == "epic-decompose"
@@ -649,3 +653,242 @@ def test_blocked_state_does_not_double_fire(base_setup: Path) -> None:
     notifs = state.list_unacked_notifications()
     assert any(n.kind == "blocked" for n in notifs)
     assert not any(n.kind == "state-changed" for n in notifs)
+
+
+# ---------- epic coordinator (B3) ----------
+
+
+@dataclass
+class _CoordinatorRunner:
+    """Per-issue `gh issue view` payloads + sequential `gh issue list`
+    payloads. The plain FakeGhRunner returns one canned `issue_view`
+    payload for every call, which collides with the coordinator path
+    (which needs distinct payloads for the closed child and the parent).
+    """
+
+    issue_view_by_number: dict[int, dict[str, Any]] = field(default_factory=dict)
+    list_issues_payloads: list[list[dict[str, Any]]] = field(default_factory=list)
+    calls: list[list[str]] = field(default_factory=list)
+    _list_idx: int = 0
+
+    def __call__(self, args: list[str], **kwargs: Any) -> _GhRunResult:
+        self.calls.append(list(args))
+        if args[1:4] == ["issue", "list", "--repo"]:
+            payloads = self.list_issues_payloads or [[]]
+            idx = min(self._list_idx, len(payloads) - 1)
+            self._list_idx += 1
+            return _GhRunResult(stdout=json.dumps(payloads[idx]))
+        if args[1:3] == ["issue", "view"]:
+            try:
+                num = int(args[3])
+            except (IndexError, ValueError):
+                num = 0
+            payload = self.issue_view_by_number.get(num, {"comments": []})
+            return _GhRunResult(stdout=json.dumps(payload))
+        return _GhRunResult(stdout="https://example/c/1\n")
+
+
+def _epic_parent_view(
+    number: int, *, state: str = "OPEN", labels: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"Epic {number}",
+        "labels": [{"name": n} for n in (labels or ["type:epic", "state:tracking"])],
+        "author": {"login": "valdisd96"},
+        "url": f"https://example/i/{number}",
+        "createdAt": "2026-04-29T10:00:00Z",
+        "body": "Epic body",
+        "state": state,
+        "comments": [],
+    }
+
+
+def _closed_child_view(
+    number: int, parent: int, *, body: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"Child {number}",
+        "labels": [],
+        "author": {"login": "valdisd96"},
+        "url": f"https://example/i/{number}",
+        "createdAt": "2026-05-01T10:00:00Z",
+        "body": body if body is not None else f"Part of epic.\nRefs #{parent}",
+        "state": "CLOSED",
+        "comments": [],
+    }
+
+
+def _seed_tracked_issue(
+    project: str, number: int, state_label: str = "state:in-review"
+) -> None:
+    state.upsert_project(name=project, path="/p", repo="me/x")
+    state.upsert_issue(
+        project=project, number=number, state_label=state_label,
+        title=f"Issue {number}", url=f"u{number}",
+        author="valdisd96", created_at="2026-05-01T10:00:00Z",
+    )
+
+
+def test_parse_epic_parent_extracts_number() -> None:
+    """The Refs-line parser is the contract between epic-decompose's
+    file-children template and the scheduler's coordinator. Be loud about
+    it being load-bearing."""
+    from fabric.scheduler import _parse_epic_parent
+
+    assert _parse_epic_parent("Refs #42") == 42
+    assert _parse_epic_parent("Part of epic #5.\nRefs #5\n") == 5
+    assert _parse_epic_parent("REFS #7") == 7  # case-insensitive
+    assert _parse_epic_parent("see #99") is None  # bare # ref doesn't count
+    assert _parse_epic_parent("") is None
+    assert _parse_epic_parent(None) is None
+
+
+def test_advance_oldest_draft_sibling_when_child_closes(
+    base_setup: Path,
+) -> None:
+    """When a child of a `type:epic` parent closes and another sibling is
+    in `state:draft`, flip the oldest draft to `state:needs-planning` and
+    fire `epic-advanced`."""
+    _seed_tracked_issue("teach-me-eng-bot", 2, "state:in-review")
+
+    runner = _CoordinatorRunner(
+        list_issues_payloads=[
+            [],  # main poll: child #2 is no longer open
+            [   # sibling search by Refs #5
+                _issue_payload(3, "state:draft", created_at="2026-05-02T10:00:00Z"),
+                _issue_payload(4, "state:draft", created_at="2026-05-03T10:00:00Z"),
+            ],
+        ],
+        issue_view_by_number={
+            2: _closed_child_view(2, parent=5),
+            5: _epic_parent_view(5),
+        },
+    )
+    _aiorun(_make_scheduler(gh_runner=runner).tick())
+
+    # Oldest draft (#3) was flipped: --remove-label state:draft + --add-label state:needs-planning.
+    edit_three = [c for c in runner.calls if c[1:3] == ["issue", "edit"] and "3" in c]
+    assert any("--remove-label" in c and "state:draft" in c for c in edit_three)
+    assert any(
+        "--add-label" in c and "state:needs-planning" in c for c in edit_three
+    )
+    # And NOT on #4 (the newer draft).
+    edit_four = [c for c in runner.calls if c[1:3] == ["issue", "edit"] and "4" in c]
+    assert not edit_four
+
+    # Notification fired on the parent.
+    notifs = state.list_unacked_notifications()
+    advanced = [n for n in notifs if n.kind == "epic-advanced"]
+    assert len(advanced) == 1
+    assert advanced[0].issue == 5
+    assert "#3" in (advanced[0].body or "")
+
+
+def test_parent_auto_closes_when_no_drafts_left(base_setup: Path) -> None:
+    """Last child of an epic closes → no open siblings → fabric closes the
+    parent and fires `epic-completed`."""
+    _seed_tracked_issue("teach-me-eng-bot", 2, "state:in-review")
+
+    runner = _CoordinatorRunner(
+        list_issues_payloads=[
+            [],  # main poll
+            [],  # sibling search returns nothing → close parent
+        ],
+        issue_view_by_number={
+            2: _closed_child_view(2, parent=5),
+            5: _epic_parent_view(5),
+        },
+    )
+    _aiorun(_make_scheduler(gh_runner=runner).tick())
+
+    close_calls = [c for c in runner.calls if c[1:3] == ["issue", "close"]]
+    assert len(close_calls) == 1
+    assert "5" in close_calls[0]
+
+    notifs = state.list_unacked_notifications()
+    assert any(
+        n.kind == "epic-completed" and n.issue == 5 for n in notifs
+    )
+
+
+def test_no_advance_when_another_sibling_is_active(base_setup: Path) -> None:
+    """If another sibling is already non-draft (in-progress, in-review,
+    needs-planning, etc.), don't advance — its closure will trigger the
+    next advance later."""
+    _seed_tracked_issue("teach-me-eng-bot", 2, "state:in-review")
+
+    runner = _CoordinatorRunner(
+        list_issues_payloads=[
+            [],
+            [
+                _issue_payload(3, "state:in-progress"),  # active — leave alone
+                _issue_payload(4, "state:draft"),
+            ],
+        ],
+        issue_view_by_number={
+            2: _closed_child_view(2, parent=5),
+            5: _epic_parent_view(5),
+        },
+    )
+    _aiorun(_make_scheduler(gh_runner=runner).tick())
+
+    # No advance edit on #4, and parent stays open (no close call).
+    edit_four = [
+        c for c in runner.calls
+        if c[1:3] == ["issue", "edit"] and "4" in c and "--add-label" in c
+    ]
+    assert not edit_four
+    assert not any(c[1:3] == ["issue", "close"] for c in runner.calls)
+    assert all(
+        n.kind not in ("epic-advanced", "epic-completed")
+        for n in state.list_unacked_notifications()
+    )
+
+
+def test_no_advance_when_body_lacks_refs(base_setup: Path) -> None:
+    """A closed issue with no `Refs #N` in the body is just a regular
+    closure — no coordinator action."""
+    _seed_tracked_issue("teach-me-eng-bot", 2, "state:in-review")
+
+    runner = _CoordinatorRunner(
+        issue_view_by_number={
+            2: _closed_child_view(2, parent=5, body="just a regular issue"),
+        },
+    )
+    _aiorun(_make_scheduler(gh_runner=runner).tick())
+
+    # No parent fetch (no `gh issue view <parent>` call).
+    parent_views = [
+        c for c in runner.calls
+        if c[1:3] == ["issue", "view"] and len(c) > 3 and c[3] == "5"
+    ]
+    assert not parent_views
+    assert all(
+        n.kind not in ("epic-advanced", "epic-completed")
+        for n in state.list_unacked_notifications()
+    )
+
+
+def test_no_advance_when_parent_lacks_type_epic(base_setup: Path) -> None:
+    """A closed issue Refs'ing a non-epic parent (e.g. a regular bug
+    cross-referencing another bug) is a coincidence — don't act."""
+    _seed_tracked_issue("teach-me-eng-bot", 2, "state:in-review")
+
+    runner = _CoordinatorRunner(
+        list_issues_payloads=[[]],  # main poll only — no sibling search expected
+        issue_view_by_number={
+            2: _closed_child_view(2, parent=5),
+            5: _epic_parent_view(5, labels=["type:bug"]),  # not type:epic
+        },
+    )
+    _aiorun(_make_scheduler(gh_runner=runner).tick())
+
+    # No sibling search was issued (we bailed out at the type:epic check).
+    sibling_searches = [
+        c for c in runner.calls
+        if c[1:4] == ["issue", "list", "--repo"] and "--search" in c
+    ]
+    assert not sibling_searches
+    assert not any(c[1:3] == ["issue", "close"] for c in runner.calls)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -241,6 +241,32 @@ def test_render_issue_completed_notification() -> None:
     assert "p#7" in text
 
 
+def test_render_epic_advanced_notification() -> None:
+    """Fired by the B3 coordinator when the next held child gets advanced
+    to `state:needs-planning` after its predecessor closes."""
+    body = "p#5 — epic advanced\n#2 closed → #3 now state:needs-planning"
+    n = state.NotificationRow(
+        id=1, kind="epic-advanced", project="p", issue=5,
+        created_at="t", delivered_to=None, acknowledged_at=None, body=body,
+    )
+    text = render_notification_text(n)
+    assert "Epic advanced" in text
+    assert "#3 now state:needs-planning" in text
+
+
+def test_render_epic_completed_notification() -> None:
+    """Fired by the B3 coordinator when the parent auto-closes after the
+    last child closes."""
+    n = state.NotificationRow(
+        id=1, kind="epic-completed", project="p", issue=5,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+        body="p#5 — epic completed (all children closed)",
+    )
+    text = render_notification_text(n)
+    assert "Epic completed" in text
+    assert "all children closed" in text
+
+
 def test_render_state_changed_uses_body_when_present() -> None:
     body = (
         "teach-me-eng-bot#7 — Rewrite README\n"


### PR DESCRIPTION
## Summary

Completes the epic flow that `qualify-issue` + `epic-decompose` started, and finishes a half-migrated label vocabulary at the same time.

- **Label split.** `type:epic` (new, permanent) marks the parent; `state:needs-decompose` (renamed from `state:epic`) is the transient routing state. `state:tracking` (new) replaces a phantom label the template was using but `setup-labels` never provisioned. Result: `state:*` consistently means "where in the pipeline", not "what kind of issue".
- **B3 hold-and-release.** `epic-decompose` (v2.0.0) files child #1 at `state:needs-planning` and the rest at `state:draft`. Scheduler's new `_advance_or_close_parent` detects each child's closure via the `Refs #<parent>` line, advances the oldest remaining draft sibling, or closes the parent if no drafts remain.
- **Two new notifications.** `epic-advanced` (informational, fires when a sibling is unblocked) and `epic-completed` (fires on parent auto-close). Headers added to the TG bot; no buttons since both are informational.

## Skill template changes — projects re-sync needed

| Skill | Old version | New version | Why |
|---|---|---|---|
| `qualify-issue` | 1.0.0 | 1.1.0 | Branch 3 sets `type:epic` + `state:needs-decompose` instead of `state:epic` + `type:feature` |
| `epic-decompose` | 1.0.0 | 2.0.0 | Resume state is now `state:needs-decompose`; §4 files children B3-style; coordinator caveat dropped |

`teach-me-eng-bot` is the only managed project today. After this PR merges, its drift CI will fail until it `fabric sync`s and commits the re-rendered skills.

## Post-merge follow-ups (manual)

On `teach-me-eng-bot`:
1. `fabric sync teach-me-eng-bot && git commit` (re-rendered skills).
2. `gh label delete state:epic` if the legacy label exists.
3. Manually relabel any open issues at `state:epic` → `type:epic` + `state:needs-decompose`.

## Test plan

- [x] `pytest -q` — 267 passed, 6 parity-skipped (no `TEACH_ME_ENG_BOT_PATH` in CI).
- [x] `fabric --help` — CLI surface still imports cleanly.
- [x] 5 new coordinator tests cover advance, auto-close, no-advance-when-active, no-advance-when-no-Refs, no-advance-when-parent-not-epic.
- [x] New tests for `close_issue` argv, `_parse_epic_parent` edge cases, `epic-advanced` / `epic-completed` rendering, `type:epic` / `state:tracking` in canonical sets.
- [ ] **Manual:** after merge, `fabric sync teach-me-eng-bot --check` should report two skills drift; after `fabric sync teach-me-eng-bot`, no drift.
- [ ] **End-to-end:** file a fresh issue with epic shape, watch it route through `qualify-issue` → `state:needs-decompose` → Q&A → `/decompose-ok` → children filed (one active, rest draft) → child #1 closes → child #2 advances → ... → all closed → parent auto-closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)