### PR TITLE
feat: TG resume-magic — agent question in body + auto-flip on reply

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -425,7 +425,7 @@ Slash commands:
 - `/projects` — list registered projects
 - `/issue <project> <n>` — quick view
 
-Inline reply: replying to a notification message that's tied to an issue posts the reply as a GH comment on that issue (and, for `clarification-needed`, flips the label to resume the pipeline — "/resume magic" promoted from the orchestrator plan's K3 to v1, since Telegram makes it natural).
+Inline reply: replying to a notification message that's tied to an issue posts the reply as a GH comment on that issue, and for Q&A notifications (`clarification`, `decompose-approval`) flips the issue's state label back to its resume state so the next scheduler tick re-dispatches the agent — "/resume magic" promoted from the orchestrator plan's K3 to v1, since Telegram makes it natural. Resume state is `state:needs-decompose` for an epic (issue carries `type:epic`) or for a `decompose-approval` reply, else `state:in-progress` (the plan-exec / clarify-issue contract). For Q&A transitions, the notification body also embeds the latest `<!-- agent-* -->` comment so the question or proposal is readable directly in the TG message — phone UX, no GH round-trip needed for short answers.
 
 ### Decision 8 — Auth
 

--- a/fabric/github.py
+++ b/fabric/github.py
@@ -19,7 +19,7 @@ import subprocess
 from collections.abc import Callable, Sequence
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 from pydantic.alias_generators import to_camel
 
 
@@ -175,7 +175,12 @@ def get_issue(
         "number,title,body,labels,author,comments,url,createdAt,state",
     ]
     raw = _run_gh_json(args, runner=runner)
-    return IssueDetail.model_validate(raw)
+    try:
+        return IssueDetail.model_validate(raw)
+    except ValidationError as e:
+        # Surface validation errors with the same `GhError` that JSON
+        # decode failures use — callers already handle this exception.
+        raise GhError(f"could not parse issue {number}: {e}") from e
 
 
 def add_labels(

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -101,6 +101,35 @@ def _parse_epic_parent(body: str | None) -> int | None:
     return int(m.group(1)) if m else None
 
 
+# Q&A states the agent uses to park an issue. On transitions INTO these
+# states we fetch the latest agent-marker comment and embed it in the
+# notification body so the human can see the question/proposal in TG
+# without opening GitHub.
+_AGENT_QUESTION_STATES: set[str] = {
+    "state:clarification-needed",
+    "state:awaiting-decompose-approval",
+}
+
+# Marker prefix every fabric agent prepends to its question / proposal
+# comments (e.g. `<!-- agent-decompose-q v1 -->`, `<!-- agent-qualify v1 -->`,
+# `<!-- agent-decompose v1 -->`). Used to distinguish agent-authored
+# comments from human follow-ups.
+_AGENT_COMMENT_MARKER_PREFIX = "<!-- agent-"
+
+
+def _latest_agent_comment_body(comments: list[gh.IssueComment]) -> str | None:
+    """Most recent comment whose body starts with `<!-- agent-... -->`.
+    `gh issue view --json comments` returns comments in chronological
+    order; the last agent-marker comment is the freshest question or
+    proposal. Returns None if no agent-authored comment exists yet.
+    """
+    agent_authored = [
+        c for c in comments
+        if c.body.lstrip().startswith(_AGENT_COMMENT_MARKER_PREFIX)
+    ]
+    return agent_authored[-1].body if agent_authored else None
+
+
 @dataclass(frozen=True)
 class TickWinner:
     project: str
@@ -389,6 +418,22 @@ class Scheduler:
                     actor=actor,
                     url=issue.url,
                 )
+                # On Q&A transitions, embed the agent's most recent
+                # question / proposal so it lands directly in TG. The
+                # extra gh round-trip only fires when the human actually
+                # needs to read the question, not on every transition.
+                if state_label in _AGENT_QUESTION_STATES:
+                    try:
+                        detail = await asyncio.to_thread(
+                            gh.get_issue, entry.repo, issue.number,
+                            runner=self._gh_runner,
+                        )
+                    except gh.GhError:
+                        detail = None
+                    if detail is not None:
+                        agent_body = _latest_agent_comment_body(detail.comments)
+                        if agent_body:
+                            body = f"{body}\n\n{agent_body}"
                 await asyncio.to_thread(
                     state.add_notification,
                     kind=kind,

--- a/fabric/telegram_bot.py
+++ b/fabric/telegram_bot.py
@@ -144,11 +144,21 @@ _NOTIF_HEADERS = {
 }
 
 
+# Telegram caps a single message at 4096 chars; we truncate at 4000 to
+# leave headroom for header lines and a suffix. Long bodies arise when
+# `decompose-approval` notifications carry the full proposed child list.
+_TG_MESSAGE_MAX = 4000
+_TRUNCATION_SUFFIX = "\n\n…(truncated — see GitHub issue for full text)"
+
+
 def render_notification_text(n: state.NotificationRow) -> str:
     header = _NOTIF_HEADERS.get(n.kind, f"🔔 {n.kind}")
-    if n.body:
-        return f"{header}\n{n.body}"
-    return f"{header}\n  {n.project}#{n.issue}"
+    body = n.body if n.body else f"  {n.project}#{n.issue}"
+    text = f"{header}\n{body}"
+    if len(text) <= _TG_MESSAGE_MAX:
+        return text
+    cutoff = _TG_MESSAGE_MAX - len(_TRUNCATION_SUFFIX)
+    return text[:cutoff] + _TRUNCATION_SUFFIX
 
 
 def notification_buttons(n: state.NotificationRow) -> list[list[dict[str, str]]]:
@@ -217,17 +227,74 @@ async def handle_callback(
     return f"unknown action: {a}"
 
 
+# Notification kinds that pause the agent waiting on a human answer.
+# Replies to these auto-flip the issue back to its resume state so the
+# next scheduler tick re-dispatches the agent — closing the "/resume
+# magic" loop that DESIGN.md Decision 7 promised.
+_RESUME_FLIP_KINDS: frozenset[str] = frozenset(
+    {"clarification", "decompose-approval"}
+)
+
+
+def _resume_state_for_reply(kind: str, type_label: str | None) -> str | None:
+    """Decide which `state:*` to flip the issue to after a human reply.
+    `decompose-approval` is always the epic-decompose loop. `clarification`
+    branches on `type:epic`: an epic-decompose Q&A resumes at
+    `state:needs-decompose`; a plan-exec / clarify-issue Q&A resumes at
+    `state:in-progress`. Returns None for kinds with no resume contract.
+    """
+    if kind == "decompose-approval":
+        return "state:needs-decompose"
+    if kind == "clarification":
+        return (
+            "state:needs-decompose" if type_label == "type:epic"
+            else "state:in-progress"
+        )
+    return None
+
+
 async def handle_reply_to_notification(
     rest: httpx.AsyncClient,
     notif: state.NotificationRow,
     body: str,
 ) -> bool:
-    """Post the reply text as a GH comment on the linked issue."""
+    """Post the reply text as a GH comment on the linked issue and, for
+    Q&A notifications, flip the issue's state label back to its resume
+    state so the next tick re-dispatches the agent. The label flip is
+    best-effort — if the API hiccups the comment still lands, and the
+    user can flip the label manually as a fallback.
+    """
     r = await rest.post(
         f"/api/issues/{notif.project}/{notif.issue}/comment",
         json={"body": body},
     )
-    return r.is_success
+    if not r.is_success:
+        return False
+    if notif.kind not in _RESUME_FLIP_KINDS:
+        return True
+
+    try:
+        detail = await rest.get(f"/api/issues/{notif.project}/{notif.issue}")
+        detail.raise_for_status()
+        data = detail.json()
+    except httpx.HTTPError:
+        return True  # comment is the primary action; flip is best-effort
+
+    resume = _resume_state_for_reply(notif.kind, data.get("type_label"))
+    cur = data.get("state_label")
+    if resume is None or resume == cur:
+        return True
+
+    payload: dict[str, list[str]] = {"add": [resume]}
+    if cur:
+        payload["remove"] = [cur]
+    try:
+        await rest.post(
+            f"/api/issues/{notif.project}/{notif.issue}/label", json=payload,
+        )
+    except httpx.HTTPError:
+        pass
+    return True
 
 
 # ---- bot wiring ----

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -871,6 +871,143 @@ def test_no_advance_when_body_lacks_refs(base_setup: Path) -> None:
     )
 
 
+# ---------- agent-comment in clarification body ----------
+
+
+def _issue_view_with_comments(
+    number: int,
+    state_label: str,
+    comments: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"Issue {number}",
+        "url": f"https://example/i/{number}",
+        "createdAt": "2026-05-01T10:00:00Z",
+        "labels": [{"name": state_label}],
+        "author": {"login": "valdisd96"},
+        "body": "",
+        "state": "OPEN",
+        "comments": comments,
+    }
+
+
+def test_clarification_body_embeds_latest_agent_comment(
+    base_setup: Path,
+) -> None:
+    """When an issue transitions to `state:clarification-needed`, the
+    notification body should include the agent's most recent
+    `<!-- agent-* -->` comment so the human can read the question in TG."""
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(8, "state:in-progress", author="randomdude"),
+        ]),
+    ).tick())
+
+    agent_question = (
+        "<!-- agent-decompose-q v1 -->\n"
+        "**Decomposition question (round 1 of up to 8)**\n\n"
+        "Should imports be one-shot or streaming?"
+    )
+    issue_view = _issue_view_with_comments(
+        8, "state:clarification-needed",
+        comments=[
+            {"body": "looks good", "author": {"login": "valdisd96"}, "url": "u"},
+            {"body": agent_question, "author": {"login": "fabric-bot"}, "url": "u"},
+        ],
+    )
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(
+            list_issues_payload=[
+                _issue_payload(8, "state:clarification-needed", author="randomdude"),
+            ],
+            issue_view_payload=issue_view,
+        ),
+    ).tick())
+
+    clar = [n for n in state.list_unacked_notifications() if n.kind == "clarification"]
+    assert len(clar) == 1
+    body = clar[0].body or ""
+    # Header still has the transition info.
+    assert "state:in-progress → state:clarification-needed" in body
+    # And the agent's question text is embedded.
+    assert "agent-decompose-q v1" in body
+    assert "Should imports be one-shot or streaming?" in body
+
+
+def test_decompose_approval_body_embeds_latest_agent_comment(
+    base_setup: Path,
+) -> None:
+    """Same for `state:awaiting-decompose-approval`: embed the proposal."""
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(9, "state:in-progress", type_="type:epic",
+                           author="randomdude"),
+        ]),
+    ).tick())
+
+    proposal = (
+        "<!-- agent-decompose v1 -->\n"
+        "## Proposed decomposition\n\n"
+        "### Child 1 — add ingestion CLI"
+    )
+    issue_view = _issue_view_with_comments(
+        9, "state:awaiting-decompose-approval",
+        comments=[
+            {"body": proposal, "author": {"login": "fabric-bot"}, "url": "u"},
+        ],
+    )
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(
+            list_issues_payload=[
+                _issue_payload(9, "state:awaiting-decompose-approval",
+                               type_="type:epic", author="randomdude"),
+            ],
+            issue_view_payload=issue_view,
+        ),
+    ).tick())
+
+    da = [n for n in state.list_unacked_notifications() if n.kind == "decompose-approval"]
+    assert len(da) == 1
+    body = da[0].body or ""
+    assert "Proposed decomposition" in body
+    assert "Child 1 — add ingestion CLI" in body
+
+
+def test_clarification_body_falls_back_when_no_agent_comment(
+    base_setup: Path,
+) -> None:
+    """If no agent-marker comment exists yet (e.g. the agent just flipped
+    the label without commenting), the body still ships transition
+    metadata — no crash, no spurious agent text."""
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(list_issues_payload=[
+            _issue_payload(10, "state:in-progress", author="randomdude"),
+        ]),
+    ).tick())
+
+    issue_view = _issue_view_with_comments(
+        10, "state:clarification-needed",
+        comments=[
+            {"body": "human note", "author": {"login": "valdisd96"}, "url": "u"},
+        ],
+    )
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(
+            list_issues_payload=[
+                _issue_payload(10, "state:clarification-needed", author="randomdude"),
+            ],
+            issue_view_payload=issue_view,
+        ),
+    ).tick())
+
+    clar = [n for n in state.list_unacked_notifications() if n.kind == "clarification"]
+    assert len(clar) == 1
+    body = clar[0].body or ""
+    assert "state:in-progress → state:clarification-needed" in body
+    assert "<!-- agent-" not in body
+
+
 def test_no_advance_when_parent_lacks_type_epic(base_setup: Path) -> None:
     """A closed issue Refs'ing a non-epic parent (e.g. a regular bug
     cross-referencing another bug) is a coincidence — don't act."""

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -354,6 +354,121 @@ def test_handle_reply_to_notification_posts_comment(
     assert any(c[1:3] == ["issue", "comment"] for c in app_setup["gh_runner"].calls)
 
 
+def test_handle_reply_flips_clarification_to_in_progress_for_non_epic(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    """Replying to a `clarification` notif on a non-epic issue flips the
+    state back to `state:in-progress` so the next tick re-dispatches
+    plan-exec / clarify-issue."""
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=1,
+        state_label="state:clarification-needed",
+        type_label="type:bug",
+    )
+    nid = state.add_notification(
+        kind="clarification", project="teach-me-eng-bot", issue=1,
+    )
+    notif = state.NotificationRow(
+        id=nid, kind="clarification", project="teach-me-eng-bot", issue=1,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    _aiorun(handle_reply_to_notification(rest, notif, "answer"))
+
+    edit_calls = [
+        c for c in app_setup["gh_runner"].calls if c[1:3] == ["issue", "edit"]
+    ]
+    assert any("--add-label" in c and "state:in-progress" in c for c in edit_calls)
+    assert any(
+        "--remove-label" in c and "state:clarification-needed" in c
+        for c in edit_calls
+    )
+
+
+def test_handle_reply_flips_clarification_to_needs_decompose_for_epic(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    """On a `type:epic` issue, the resume state is `state:needs-decompose`
+    so the next tick re-dispatches `epic-decompose`, not plan-exec."""
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=2,
+        state_label="state:clarification-needed",
+        type_label="type:epic",
+    )
+    notif = state.NotificationRow(
+        id=1, kind="clarification", project="teach-me-eng-bot", issue=2,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    _aiorun(handle_reply_to_notification(rest, notif, "the answer"))
+
+    edit_calls = [
+        c for c in app_setup["gh_runner"].calls if c[1:3] == ["issue", "edit"]
+    ]
+    assert any("--add-label" in c and "state:needs-decompose" in c for c in edit_calls)
+
+
+def test_handle_reply_flips_decompose_approval_to_needs_decompose(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    """`/decompose-ok` (or revision feedback) lands as a comment + flip
+    back to `state:needs-decompose` so the next tick files children."""
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=3,
+        state_label="state:awaiting-decompose-approval",
+        type_label="type:epic",
+    )
+    notif = state.NotificationRow(
+        id=1, kind="decompose-approval", project="teach-me-eng-bot", issue=3,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    _aiorun(handle_reply_to_notification(rest, notif, "/decompose-ok"))
+
+    edit_calls = [
+        c for c in app_setup["gh_runner"].calls if c[1:3] == ["issue", "edit"]
+    ]
+    assert any("--add-label" in c and "state:needs-decompose" in c for c in edit_calls)
+
+
+def test_handle_reply_no_flip_for_informational_kinds(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    """Replies to non-Q&A notifications (blocked, issue-completed, etc.)
+    post the comment but never flip labels — those flows have no resume
+    contract to honor."""
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=4,
+        state_label="state:blocked",
+    )
+    notif = state.NotificationRow(
+        id=1, kind="blocked", project="teach-me-eng-bot", issue=4,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    _aiorun(handle_reply_to_notification(rest, notif, "thoughts"))
+
+    edit_calls = [
+        c for c in app_setup["gh_runner"].calls if c[1:3] == ["issue", "edit"]
+    ]
+    assert not edit_calls
+
+
+def test_render_truncates_oversize_notification() -> None:
+    """A `decompose-approval` proposal can run thousands of chars; TG
+    caps at 4096. Verify we trim to the budget and append a marker."""
+    huge_body = "x" * 5000
+    n = state.NotificationRow(
+        id=1, kind="decompose-approval", project="p", issue=1,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+        body=huge_body,
+    )
+    text = render_notification_text(n)
+    assert len(text) <= 4000
+    assert "truncated" in text
+    assert "Decompose approval" in text  # header still present
+
+
 # ---------- TelegramBot handler methods (with mocked context.bot) ----------
 
 


### PR DESCRIPTION
## Summary

Closes the loop on DESIGN.md Decision 7's "/resume magic" promise. Two gaps were making the Telegram Q&A path unusable on a phone:

- **Missing question text.** Notification body carried state-transition metadata only. The agent's actual question (posted as a `<!-- agent-* -->` comment) wasn't visible in TG, forcing a GitHub round-trip every Q&A round.
- **No auto-flip.** Replies posted as comments correctly, but the issue's state label stayed at `state:clarification-needed`, so the scheduler saw no work and the agent never woke up to read the answer.

## What changed

**Scheduler.** On transitions to `state:clarification-needed` or `state:awaiting-decompose-approval`, fetch the issue's comments and append the latest `<!-- agent-* -->` comment to the notification body. The extra `gh issue view` round-trip only fires on these two transitions, not every tick.

**Telegram bot.** `handle_reply_to_notification` now (a) posts the comment as before, (b) for Q&A kinds, looks up the issue via REST, computes the resume state from `notif.kind` + `type_label`, and POSTs a label flip:

| Notification kind | `type:epic`? | Resume state |
|---|---|---|
| `clarification` | yes | `state:needs-decompose` |
| `clarification` | no | `state:in-progress` |
| `decompose-approval` | (always epic) | `state:needs-decompose` |
| any other | — | no flip |

The flip is best-effort — if the API hiccups the comment still lands, the user can flip manually.

**Truncation.** `render_notification_text` caps at 4000 chars (TG's hard cap is 4096), suffixing with `…(truncated — see GitHub issue for full text)`. Long `decompose-approval` proposals fit the channel without surprises (option **a** of the choice we discussed).

**Defensive tweak in `github.py`.** `get_issue` now wraps pydantic `ValidationError` as `GhError`, mirroring the existing JSON-decode wrap. Means the scheduler's existing `except gh.GhError` covers malformed/partial gh payloads.

## Test plan

- [x] `pytest -q` — 275 passed (was 267), 6 parity-skipped.
- [x] `fabric --help` — CLI imports cleanly.
- [x] 3 new scheduler tests: agent comment embedded for `clarification` and `decompose-approval`; falls back when no agent-marker comment exists.
- [x] 4 new telegram_bot tests: reply flips for clarification (epic + non-epic), decompose-approval, no flip for informational kinds.
- [x] 1 new render-truncation test (5000-char body → 4000 cap with suffix).
- [ ] **Manual end-to-end (post-merge):** reply to the next clarification TG message on issue #61 — verify (a) the agent question is visible in the message, (b) the reply re-enters the loop within ~60s.

## DESIGN.md

Decision 7's "Inline reply" paragraph extended to spell out the resume-state lookup table and the body-embedding behavior — what was promised in v1 is now implemented.

## Out of scope

- The `Mute` button on `clarification` / `blocked` notifications is still a no-op stub. Tracked separately.
- The `Approve` / `Reject` buttons on `decompose-approval` notifications post `decompose:approve` / `decompose:reject` as comments but don't run the same flip. Could fold into this contract, but leaving as-is for now since reply works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)