### PR TITLE
fix: TG Approve button posts /decompose-ok and flips resume state

### DIFF
--- a/fabric/telegram_bot.py
+++ b/fabric/telegram_bot.py
@@ -179,9 +179,12 @@ def notification_buttons(n: state.NotificationRow) -> list[list[dict[str, str]]]
             {"text": "Mute", "callback_data": encode_callback("mute", n.project, n.issue)},
         ]]
     if n.kind == "decompose-approval":
+        # Approve is one-tap (post `/decompose-ok` + flip resume state).
+        # There's deliberately no "Reject" button: revisions need the
+        # human's actual feedback text, which the reply-to-message path
+        # (with the auto-flip from #46) already handles cleanly.
         return [[
             {"text": "Approve", "callback_data": encode_callback("approve_decompose", n.project, n.issue)},
-            {"text": "Reject", "callback_data": encode_callback("reject_decompose", n.project, n.issue)},
         ]]
     return []
 
@@ -215,15 +218,29 @@ async def handle_callback(
             f"/api/prs/{p}/{n}/review", json={"action": "approve"}
         )
         return "approved" if r.is_success else f"error {r.status_code}"
-    if a in ("approve_decompose", "reject_decompose"):
-        # Let the user answer with a comment in the next reply; for now, just
-        # post the verdict as a comment so the agent picks it up next tick.
-        verdict = "approve" if a == "approve_decompose" else "reject"
+    if a == "approve_decompose":
+        # `epic-decompose`'s decision tree §A1 looks for the literal
+        # `/decompose-ok` token in a comment dated after the proposal.
+        # Then we flip the resume state so the next tick re-dispatches
+        # and files the children. Comment-post is the primary action;
+        # the label flip is best-effort.
         r = await rest.post(
             f"/api/issues/{p}/{n}/comment",
-            json={"body": f"decompose:{verdict}"},
+            json={"body": "/decompose-ok"},
         )
-        return verdict if r.is_success else f"error {r.status_code}"
+        if not r.is_success:
+            return f"error {r.status_code}"
+        try:
+            await rest.post(
+                f"/api/issues/{p}/{n}/label",
+                json={
+                    "add": ["state:needs-decompose"],
+                    "remove": ["state:awaiting-decompose-approval"],
+                },
+            )
+        except httpx.HTTPError:
+            pass
+        return "approved"
     return f"unknown action: {a}"
 
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -308,6 +308,20 @@ def test_notification_buttons_dispatch_failed_has_retry_and_block() -> None:
     assert "block" in actions
 
 
+def test_notification_buttons_decompose_approval_has_only_approve() -> None:
+    """Approve is one-tap (post `/decompose-ok` + flip). Reject was
+    removed because revisions need feedback text — handled by the
+    reply-to-message path with its auto-flip."""
+    n = state.NotificationRow(
+        id=1, kind="decompose-approval", project="p", issue=2,
+        created_at="t", delivered_to=None, acknowledged_at=None,
+    )
+    rows = notification_buttons(n)
+    flat = [b for row in rows for b in row]
+    actions = {decode_callback(b["callback_data"]).action for b in flat if b.get("callback_data")}  # type: ignore[union-attr]
+    assert actions == {"approve_decompose"}
+
+
 # ---------- callback dispatch ----------
 
 
@@ -335,6 +349,61 @@ def test_handle_callback_unknown_action_returns_explanation(
 ) -> None:
     result = _aiorun(handle_callback(rest, CallbackPayload(action="nuke", project="p", number=1)))
     assert "unknown action" in result
+
+
+def test_handle_callback_reject_decompose_no_longer_supported(
+    rest: httpx.AsyncClient,
+) -> None:
+    """The Reject button was removed (see `notification_buttons`) so
+    `reject_decompose` is no longer a valid action — it should fall
+    through to the unknown-action branch instead of silently posting
+    the meaningless `decompose:reject` comment it used to."""
+    result = _aiorun(handle_callback(
+        rest,
+        CallbackPayload(action="reject_decompose", project="p", number=1),
+    ))
+    assert "unknown action" in result
+
+
+def test_handle_callback_approve_decompose_posts_decompose_ok_literal(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    """The agent's decision tree §A1 looks for the literal `/decompose-ok`
+    token. The previous "decompose:approve" string was a no-op."""
+    payload = CallbackPayload(
+        action="approve_decompose", project="teach-me-eng-bot", number=1,
+    )
+    result = _aiorun(handle_callback(rest, payload))
+    assert result == "approved"
+
+    comment_calls = [
+        c for c in app_setup["gh_runner"].calls if c[1:3] == ["issue", "comment"]
+    ]
+    assert comment_calls, "expected a `gh issue comment` call"
+    body_idx = comment_calls[0].index("--body")
+    assert comment_calls[0][body_idx + 1] == "/decompose-ok"
+
+
+def test_handle_callback_approve_decompose_flips_resume_state(
+    isolated_state_db: Path, app_setup: dict[str, Any], rest: httpx.AsyncClient
+) -> None:
+    """After Approve: state:awaiting-decompose-approval → state:needs-decompose
+    so the next tick re-dispatches `epic-decompose` to file children."""
+    payload = CallbackPayload(
+        action="approve_decompose", project="teach-me-eng-bot", number=1,
+    )
+    _aiorun(handle_callback(rest, payload))
+
+    edit_calls = [
+        c for c in app_setup["gh_runner"].calls if c[1:3] == ["issue", "edit"]
+    ]
+    assert any(
+        "--add-label" in c and "state:needs-decompose" in c for c in edit_calls
+    )
+    assert any(
+        "--remove-label" in c and "state:awaiting-decompose-approval" in c
+        for c in edit_calls
+    )
 
 
 # ---------- reply-to-message ----------


### PR DESCRIPTION
## Summary

Discovered while testing the new epic flow on teach-me-eng-bot#61: tapping the **Approve** button on a `decompose-approval` Telegram notification was a double no-op:

1. **Wrong comment text.** The button posted `decompose:approve`. The `epic-decompose` skill's decision tree §A1 searches for the literal `/decompose-ok` token in a comment dated after its proposal — "decompose:approve" matched nothing.
2. **No label flip.** The issue stayed at `state:awaiting-decompose-approval`, which isn't in the scheduler's `_STAGE_BY_STATE`, so the agent would never re-run *even if* the comment text had been right.

Net effect: tapping Approve looked like it did something (the `gh issue comment` call did succeed) but the epic was silently stuck.

## What changed

- **Approve button** (`approve_decompose` callback): now posts the literal `/decompose-ok` and flips `state:awaiting-decompose-approval` → `state:needs-decompose`. Comment is the primary action; the label flip is best-effort, mirroring the pattern from #46.
- **Reject button removed.** A "reject" with no text payload had no actionable meaning. Revisions need the user's actual feedback, and the reply-to-message path with #46's auto-flip already covers it (reply with feedback → comment posted + flip back to `state:needs-decompose` → next tick agent revises). The `reject_decompose` action handler is dropped — it now falls through to the unknown-action branch (`"unknown action: reject_decompose"`).

## Manual remediation already applied to #61

While diagnosing, I posted `/decompose-ok` and flipped `state:awaiting-decompose-approval` → `state:needs-decompose` on teach-me-eng-bot#61 by hand so the user's in-progress test could continue. Next scheduler tick should pick that up and file the 4 children. No DB cleanup needed.

## Test plan

- [x] `pytest -q` — 279 passed (was 275), 6 parity-skipped.
- [x] 4 new tests:
  - `test_notification_buttons_decompose_approval_has_only_approve` — verifies Reject is gone.
  - `test_handle_callback_reject_decompose_no_longer_supported` — verifies the action falls through to unknown.
  - `test_handle_callback_approve_decompose_posts_decompose_ok_literal` — verifies the comment body is exactly `/decompose-ok`.
  - `test_handle_callback_approve_decompose_flips_resume_state` — verifies the `--remove-label state:awaiting-decompose-approval` + `--add-label state:needs-decompose` calls.
- [ ] **Manual end-to-end (post-merge):** tap Approve on the next `decompose-approval` TG notification — within ~60s, the epic should advance to children-filed (no manual unblock needed).

## DESIGN.md

Decision 7's notification table previously listed `Approve` `Reject` `Open` for `state:awaiting-decompose-approval`. The actual implementation today (post-#46 + this PR) is just `Approve` — the table is sketchy enough that I'd rather update it once the per-notification button matrix stabilizes than churn it now. Happy to do a follow-up doc PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)