### PR TITLE
fix: dispatcher stream overflow + cycle-counter increment

### DIFF
--- a/fabric/dispatcher.py
+++ b/fabric/dispatcher.py
@@ -55,6 +55,17 @@ _LOW_PRIORITY_LABEL = "priority:low"
 _CYCLE_MARKER = "cycle"
 _CYCLE_SENTINEL = f"<!-- agent-fabric:{_CYCLE_MARKER} -->"
 
+# Asyncio's StreamReader defaults to a 64 KB buffer per readline. The agent
+# runs with `--output-format stream-json --verbose`, which emits one JSON
+# event per tool call; a single big tool result (long file read, verbose
+# bash output) easily exceeds 64 KB. When that happens the reader raises
+# LimitOverrunError mid-dispatch and the subprocess gets orphaned. 16 MB
+# fits any realistic event without forcing a defensive overflow path on
+# the hot path.
+_STREAM_READER_LIMIT = 16 * 1024 * 1024
+_OVERFLOW_EXIT_CODE = -1
+_TERMINATE_GRACE_S = 5.0
+
 
 async def _default_spawner(args: list[str], **kwargs: Any) -> asyncio.subprocess.Process:
     return await asyncio.create_subprocess_exec(*args, **kwargs)
@@ -248,26 +259,56 @@ class Dispatcher:
             argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            limit=_STREAM_READER_LIMIT,
         )
 
+        stream_overflow = False
         with log_path.open("w", encoding="utf-8") as logf:
             assert proc.stdout is not None
-            async for line_bytes in proc.stdout:
-                line = line_bytes.decode(errors="replace")
-                logf.write(line)
-                logf.flush()
-                await self._publish(
-                    {
-                        "kind": "dispatch_stdout",
-                        "dispatch_id": dispatch_id,
-                        "project": entry.name,
-                        "issue": issue,
-                        "stage": stage,
-                        "line": line.rstrip("\n"),
-                    }
+            try:
+                async for line_bytes in proc.stdout:
+                    line = line_bytes.decode(errors="replace")
+                    logf.write(line)
+                    logf.flush()
+                    await self._publish(
+                        {
+                            "kind": "dispatch_stdout",
+                            "dispatch_id": dispatch_id,
+                            "project": entry.name,
+                            "issue": issue,
+                            "stage": stage,
+                            "line": line.rstrip("\n"),
+                        }
+                    )
+            except asyncio.LimitOverrunError as e:
+                # Single stdout line still bigger than 16 MB. Defensive —
+                # don't leave the subprocess orphaned the way the prior
+                # 64 KB default did. Terminate, fall through, and let the
+                # standard end-of-dispatch path close the DB row with a
+                # synthetic failure code so single-flight stays honest.
+                log.error(
+                    "dispatch %d: stdout line exceeded reader limit "
+                    "(%s); terminating subprocess",
+                    dispatch_id,
+                    e,
                 )
+                stream_overflow = True
+                proc.terminate()
+                logf.write(
+                    f"\n[fabric] stdout line exceeded reader limit; "
+                    f"subprocess terminated by dispatcher\n"
+                )
+                logf.flush()
 
-        exit_code = await proc.wait()
+        if stream_overflow:
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_GRACE_S)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+            exit_code = _OVERFLOW_EXIT_CODE
+        else:
+            exit_code = await proc.wait()
         ended = datetime.now(timezone.utc)
 
         await asyncio.to_thread(

--- a/fabric/scheduler.py
+++ b/fabric/scheduler.py
@@ -15,6 +15,7 @@ the synchronous decision layer + the CLI hook.
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -26,6 +27,9 @@ from fabric import state
 from fabric.config import FabricConfig, load_project_config
 from fabric.dispatcher import Dispatcher, DispatchError, QuotaExceeded
 from fabric.registry import ProjectEntry, fabric_home, load_registry
+
+
+log = logging.getLogger("fabric.scheduler")
 
 
 # Pseudo-state used internally when an open issue has no `state:*` label on
@@ -441,6 +445,27 @@ class Scheduler:
                     issue=issue.number,
                     body=body,
                 )
+
+            # Cycle-counter bump on entry into state:needs-rework. Without
+            # this the cap is dead — `Dispatcher.bump_cycle` exists but no
+            # call site invokes it, so cycle_count stays at 0 forever and
+            # runaway rework loops never auto-block. We bump only on
+            # observed transitions (not first-sight) so a fabric restart
+            # mid-rework doesn't double-count. `bump_cycle` itself does
+            # `max(GH-comment, DB) + 1` so a fabric reinstall recovers
+            # the right counter from the GH HTML comment.
+            if (
+                prev_state is not None
+                and prev_state != "state:needs-rework"
+                and state_label == "state:needs-rework"
+            ):
+                try:
+                    await self._dispatcher.bump_cycle(entry.name, issue.number)
+                except Exception:
+                    log.exception(
+                        "bump_cycle failed for %s#%d",
+                        entry.name, issue.number,
+                    )
 
             if author not in config.project.trusted_authors:
                 continue

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -46,29 +46,64 @@ class _AsyncByteLines:
 
 
 @dataclass
+class _OverflowingByteLines:
+    """Yields some lines then raises asyncio.LimitOverrunError, simulating
+    a single stdout line bigger than the StreamReader's buffer limit."""
+
+    lines: list[bytes]
+
+    def __aiter__(self) -> "_OverflowingByteLines":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self.lines:
+            return self.lines.pop(0)
+        raise asyncio.LimitOverrunError("simulated", consumed=2**16)
+
+
+@dataclass
 class FakeProc:
-    stdout: _AsyncByteLines
+    stdout: Any  # _AsyncByteLines or _OverflowingByteLines
     exit_code: int = 0
+    terminate_called: bool = False
+    kill_called: bool = False
 
     async def wait(self) -> int:
         return self.exit_code
 
+    def terminate(self) -> None:
+        self.terminate_called = True
+
+    def kill(self) -> None:
+        self.kill_called = True
+
 
 @dataclass
 class FakeSpawner:
-    """Records argv per call, returns scripted FakeProc instances."""
+    """Records argv + kwargs per call, returns scripted FakeProc instances."""
 
     lines: list[str] = field(default_factory=list)
     exit_code: int = 0
+    overflow_after_lines: bool = False
     calls: list[list[str]] = field(default_factory=list)
+    kwargs_calls: list[dict[str, Any]] = field(default_factory=list)
+    procs: list[FakeProc] = field(default_factory=list)
     on_call: Any = None
 
     async def __call__(self, args: list[str], **kwargs: Any) -> FakeProc:
         self.calls.append(list(args))
+        self.kwargs_calls.append(dict(kwargs))
         if self.on_call is not None:
             await self.on_call()
         bytes_lines = [(line + "\n").encode() for line in self.lines]
-        return FakeProc(stdout=_AsyncByteLines(bytes_lines), exit_code=self.exit_code)
+        stdout: Any = (
+            _OverflowingByteLines(bytes_lines)
+            if self.overflow_after_lines
+            else _AsyncByteLines(bytes_lines)
+        )
+        proc = FakeProc(stdout=stdout, exit_code=self.exit_code)
+        self.procs.append(proc)
+        return proc
 
 
 @dataclass
@@ -554,3 +589,78 @@ def test_bump_cycle_ignores_unparseable_comment(
 
     # falls back to DB-only counter (4 + 1)
     assert n == 5
+
+
+# ---------- stream overflow recovery ----------
+
+
+def test_dispatch_passes_large_stream_limit_to_spawner(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """Asyncio's default 64 KB buffer overflows on big stream-json events
+    from the agent. We pass a 16 MB limit so the read survives any
+    realistic tool-result payload."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner()
+    d = Dispatcher(spawner=spawner)
+
+    _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    assert spawner.kwargs_calls, "spawner not called"
+    limit = spawner.kwargs_calls[0].get("limit")
+    assert limit is not None
+    assert limit >= 16 * 1024 * 1024
+
+
+def test_dispatch_recovers_from_stdout_overflow(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """If a single stdout line exceeds the 16 MB reader limit anyway,
+    the dispatcher must terminate the subprocess (not orphan it),
+    record the dispatch row as failed (exit_code=-1), and return
+    cleanly so the scheduler can retry / block via the normal path.
+    Without this fix the row stayed open and parallel `claude -p`
+    subprocesses ran simultaneously, breaking the single-flight
+    invariant."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner(
+        lines=["pre-overflow line"],
+        exit_code=0,
+        overflow_after_lines=True,
+    )
+    d = Dispatcher(spawner=spawner)
+
+    result = _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    assert result.exit_code == -1, "expected synthetic overflow failure code"
+    assert spawner.procs, "spawner did not return any procs"
+    assert spawner.procs[-1].terminate_called, "subprocess was not terminated"
+
+    # Dispatch row is closed (ended_at populated) so consecutive_failures
+    # accounting and single-flight stay coherent.
+    rows = state.dispatches_for_issue("teach-me-eng-bot", 1)
+    assert rows, "no dispatch row recorded"
+    assert all(r.ended_at for r in rows), "row left with NULL ended_at"
+    assert rows[-1].exit_code == -1
+
+
+def test_dispatch_overflow_log_captures_truncation_marker(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """The on-disk log gets a clear marker at the truncation point so an
+    operator reading the log knows why output stopped."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    spawner = FakeSpawner(
+        lines=["normal output line"],
+        overflow_after_lines=True,
+    )
+    d = Dispatcher(spawner=spawner)
+    result = _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+    log_text = result.log_path.read_text()
+    assert "normal output line" in log_text
+    assert "stdout line exceeded reader limit" in log_text
+    assert "subprocess terminated" in log_text

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1008,6 +1008,85 @@ def test_clarification_body_falls_back_when_no_agent_comment(
     assert "<!-- agent-" not in body
 
 
+# ---------- cycle-counter on rework entry ----------
+
+
+def test_transition_to_needs_rework_bumps_cycle_count(
+    base_setup: Path,
+) -> None:
+    """`Dispatcher.bump_cycle` exists but had no call site — cycle_count
+    stayed at 0 forever, the cap was dead, and runaway rework loops
+    couldn't auto-block. The scheduler must now bump on every observed
+    transition into `state:needs-rework`."""
+    state.upsert_project(
+        name="teach-me-eng-bot", path=str(base_setup),
+        repo="valdisd96/teach-me-eng-bot",
+    )
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=1,
+        state_label="state:in-review", title="t", url="u",
+        author="valdisd96", created_at="2026-05-01T10:00:00Z",
+    )
+
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[_issue_payload(1, "state:needs-rework")],
+    )
+    _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    row = state.get_issue("teach-me-eng-bot", 1)
+    assert row is not None
+    assert row.cycle_count == 1
+
+
+def test_repeated_observation_at_needs_rework_does_not_double_bump(
+    base_setup: Path,
+) -> None:
+    """If two consecutive ticks both see the issue at `state:needs-rework`
+    (no transition), cycle_count must NOT increment again. The bump fires
+    only on the entry transition."""
+    state.upsert_project(
+        name="teach-me-eng-bot", path=str(base_setup),
+        repo="valdisd96/teach-me-eng-bot",
+    )
+    state.upsert_issue(
+        project="teach-me-eng-bot", number=1,
+        state_label="state:in-review", title="t", url="u",
+        author="valdisd96", created_at="2026-05-01T10:00:00Z",
+    )
+    # Tick 1: in-review → needs-rework. Bump fires.
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(
+            list_issues_payload=[_issue_payload(1, "state:needs-rework")],
+        ),
+    ).tick())
+    # Tick 2: needs-rework → needs-rework (no transition). No bump.
+    _aiorun(_make_scheduler(
+        gh_runner=FakeGhRunner(
+            list_issues_payload=[_issue_payload(1, "state:needs-rework")],
+        ),
+    ).tick())
+
+    row = state.get_issue("teach-me-eng-bot", 1)
+    assert row is not None
+    assert row.cycle_count == 1
+
+
+def test_first_sight_at_needs_rework_does_not_bump(base_setup: Path) -> None:
+    """If the issue is observed for the very first time at
+    `state:needs-rework` (e.g. fabric just installed), don't bump —
+    we don't know if this is cycle 1 or cycle 5. `bump_cycle` itself
+    recovers the right counter from the GH HTML comment when we DO
+    have a transition to bump on, so this caution is harmless."""
+    gh_runner = FakeGhRunner(
+        list_issues_payload=[_issue_payload(1, "state:needs-rework")],
+    )
+    _aiorun(_make_scheduler(gh_runner=gh_runner).tick())
+
+    row = state.get_issue("teach-me-eng-bot", 1)
+    assert row is not None
+    assert row.cycle_count == 0
+
+
 def test_no_advance_when_parent_lacks_type_epic(base_setup: Path) -> None:
     """A closed issue Refs'ing a non-epic parent (e.g. a regular bug
     cross-referencing another bug) is a coincidence — don't act."""


### PR DESCRIPTION
## Summary

Two reliability bugs surfaced while testing the new epic flow on teach-me-eng-bot#65 (4 plan comments posted, only 1 real rework cycle). Diagnosis lives in the conversation; this PR ships the fixes.

## Bug A — dispatcher stream overflow

Asyncio's `StreamReader` defaults to a **64 KB per-line buffer**. The agent runs with `--output-format stream-json --verbose`, which emits one JSON event per tool call; a single big tool result (long file read, verbose bash output, etc.) easily exceeds 64 KB and the reader raises `LimitOverrunError` mid-dispatch. The exception propagated out of `_run` *before* `state.complete_dispatch` ran:

- DB row left with `ended_at=NULL`, `exit_code=NULL`.
- `async with self._sem:` exited and **released the semaphore early**.
- `claude -p` subprocess kept running orphaned, still writing to the issue.
- Next tick (~60s later) dispatched plan-exec **again** — and again — single-flight effectively broken.

Concrete evidence on #65: dispatches `id=33`, `34`, `39` all started, none logged "dispatch end", three plan comments posted within minutes by parallel subprocesses. Journal showed two `LimitOverrunError`s at `00:57:39` and `00:59:05`.

Fix:

1. Pass `limit=16 * 1024 * 1024` to the subprocess spawner so realistic stream-json events fit without triggering the defensive path.
2. Wrap the stdout-read with `try/except asyncio.LimitOverrunError`. On overflow: terminate the subprocess (with a 5s grace then `kill()` if needed), record the dispatch row with `exit_code=-1` (so single-flight and `consecutive_failures` stay coherent), and append a clear marker to the on-disk log.

## Bug B — cycle counter never incremented

`Dispatcher.bump_cycle()` exists, writes both DB and the GH HTML comment, but **no call site ever invokes it**. So `cycle_count` stays `0` forever and the cycle cap is dead — runaway rework loops can't auto-block.

Fix: scheduler calls `bump_cycle` on every observed transition INTO `state:needs-rework`. We skip first-sight (no `prev_state`) to avoid guessing cycles after a fabric reinstall — `bump_cycle` itself recovers the counter from the GH HTML comment via `max(GH-comment, DB) + 1` when a real transition is later observed.

## Test plan

- [x] `pytest -q` — 285 passed (was 279), 6 parity-skipped.
- [x] 3 new dispatcher tests:
  - `test_dispatch_passes_large_stream_limit_to_spawner` — verifies the `limit` kwarg.
  - `test_dispatch_recovers_from_stdout_overflow` — simulates the overflow, asserts subprocess termination + DB row closed with `exit_code=-1`.
  - `test_dispatch_overflow_log_captures_truncation_marker` — log file gets a "stdout line exceeded reader limit" marker.
- [x] 3 new scheduler tests:
  - `test_transition_to_needs_rework_bumps_cycle_count` — happy path.
  - `test_repeated_observation_at_needs_rework_does_not_double_bump` — idempotence on consecutive ticks.
  - `test_first_sight_at_needs_rework_does_not_bump` — fabric reinstall guard.
- [ ] **Manual end-to-end (post-merge):** trigger a rework on a child issue, verify (a) `cycle_count` now bumps in `fabric status` output, (b) cap-fired auto-block path actually fires when the configured `cycle_limit` is reached, (c) no orphan dispatch rows after a long agent run.

## Cleanup already done

While diagnosing, killed the 2 zombie `claude -p` processes still running on the closed #65 and marked all 8 orphan dispatch rows in `state.db` with `exit_code=-1`/`ended_at` so `consecutive_failures` accounting is clean.

## Service restart

I'm holding the production restart on `/srv/agent-fabric` until this PR merges, so the next restart picks up both this fix AND PR #50's Approve-button fix in one blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)