### PR TITLE
feat: managed-project auto-deploy template (Decision 15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ tests/
 | The config schema | `fabric/config.py` (pydantic v2 models) |
 | Sample managed-project config | `examples/teach-me-eng-bot.config.yaml` |
 | Drift CI workflow | `examples/github-actions/fabric-sync-check.yml` |
+| Auto-deploy workflow + runbook | `examples/github-actions/deploy.yml`, `examples/runbooks/deploy-setup.md` |
 
 ## Invariants
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -147,7 +147,12 @@ agent-fabric/
 │   ├── epic-decompose.md.j2
 │   └── qualify-issue.md.j2
 ├── examples/
-│   └── teach-me-eng-bot.config.yaml
+│   ├── teach-me-eng-bot.config.yaml
+│   ├── github-actions/
+│   │   ├── fabric-sync-check.yml      # drift gate for rendered skills
+│   │   └── deploy.yml                  # auto-deploy on push to main (Decision 15)
+│   └── runbooks/
+│       └── deploy-setup.md             # one-time provisioning for auto-deploy
 ├── scripts/
 │   ├── install-systemd.sh
 │   └── setup-labels.sh       # provisioned per-project, copied from here
@@ -511,6 +516,63 @@ WantedBy=multi-user.target
 `/etc/fabric/env` carries `FABRIC_HOME`, `FABRIC_HOST`, `FABRIC_PORT`,
 `FABRIC_TELEGRAM_TOKEN`, `FABRIC_TELEGRAM_CHAT_ID`. See SMOKE.md for the
 full bring-up walkthrough on a fresh VM.
+
+### Decision 15 — Deployment of managed projects
+
+Auto-deploy each managed project on push to `main` via GitHub Actions on a
+**repo-scoped self-hosted runner** living on the same VM as the fabric. The
+pipeline finishes at "user merges PR"; this decision picks up from there.
+
+**Why GH Actions on a self-hosted runner, not a fabric subsystem.** Production
+deploys must be deterministic, fast, and replayable; that's what `bash` + a
+static workflow gives you. The fabric stays out of the runtime path. Running
+on a self-hosted runner (vs. `ubuntu-latest`) avoids opening inbound HTTP /
+SSH on the VM — the runner pulls jobs over outbound HTTPS.
+
+**Why repo-scoped, not org-scoped.** A self-hosted runner registered to an
+org cannot serve a personal-account repo. Each managed project gets its own
+runner installation under `/srv/runners/<project>/` (separate systemd unit),
+labelled `self-hosted,deploy-target,<project>`. Multiple projects coexisting
+on one VM is fine — each has its own runner, its own working tree, its own
+service unit.
+
+**No auto-rollback. Self-healing via the agent loop instead.** When a deploy
+fails, the broken version stays running on the host. The workflow POSTs a
+failure bundle (sha, journal tail, workflow URL) to fabric, which dispatches
+the `deploy-diagnose` skill. Diagnose reads the failure plus the project's
+`docs/deploy.md` contract plus `git log <last_good>..main`, then files a GH
+issue labelled `state:needs-planning` with a hypothesised root cause. The
+existing scheduler picks the issue up like any other. The fix-PR's merge
+auto-deploys and supersedes the broken version. This makes "deploy
+regression" just another shape of work the fabric already knows how to do.
+
+**No PR-time deploy-impact gating.** An earlier draft proposed a
+`Deploy-Impact:` commit trailer + `review-pr` block on missing trailers. We
+dropped it: the deploy diff itself, the PR body, and `docs/deploy.md` are
+already enough signal for `deploy-diagnose` at the scale of single-project,
+small-changeset deploys. The trailer is a candidate to add back if diagnose
+starts mis-diagnosing in practice.
+
+**The deploy contract per project.** Every managed project carries a
+hand-maintained `docs/deploy.md` describing system deps, env vars, service
+topology, external services, and known failure modes. This is the document
+`deploy-diagnose` reads when reasoning about a failure. It is *not* a
+machine-applied manifest — it's a runbook the agent (and humans) read.
+
+**Surfaces and artifacts.**
+
+| Where | What |
+|---|---|
+| `examples/github-actions/deploy.yml` | Reusable workflow — copied into managed projects, five `CONFIGURE:` values filled per project. |
+| `examples/runbooks/deploy-setup.md` | One-time provisioning runbook (runner registration, install dir ownership, sudoers, deploy state dir). |
+| `/var/lib/<project>/deploy.json` | Per-project current-deploy manifest written by the workflow; read by fabric to surface in `/status`. |
+| `POST /api/projects/<name>/deployments` | Fabric REST endpoint (forward-looking) where the workflow records successes. |
+| `POST /api/projects/<name>/deploy-failures` | Fabric REST endpoint (forward-looking) where the workflow records failures; triggers `deploy-diagnose`. |
+| `fabric/skill_templates/deploy-diagnose/` | Skill template (forward-looking) — the agent's failure-reading playbook. |
+
+The workflow is shipped now and tolerates fabric not being wired (notify
+steps detect missing `FABRIC_DEPLOY_URL` and skip). The fabric-side
+endpoints + `deploy-diagnose` skill land in a follow-up.
 
 ### Decision 14 — CLI modes
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ cp /path/to/agent-fabric/examples/github-actions/fabric-sync-check.yml \
 
 The workflow installs agent-fabric at the pinned SHA and runs `fabric sync . --check` against the project. A failure means someone edited a file under `.claude/skills/` directly instead of changing the template in agent-fabric — the fix is to change the template, run `fabric sync <project>` locally, and commit the regenerated files.
 
+## Auto-deploy for managed projects
+
+A second workflow ships an opt-in auto-deploy pipeline: every push to `main`
+fetches the new commit on the host VM, refreshes the venv only if
+`requirements.txt` changed, runs an optional `scripts/migrate.sh`, restarts
+the systemd unit, smoke-checks, and writes `/var/lib/<project>/deploy.json`.
+
+```bash
+mkdir -p .github/workflows
+cp /path/to/agent-fabric/examples/github-actions/deploy.yml \
+   .github/workflows/deploy.yml
+# then edit the five CONFIGURE: values at the top of the file.
+```
+
+One-time host setup — registering a repo-scoped self-hosted runner, picking
+an install directory the runner can write to, and creating
+`/var/lib/<project>/` — is documented in
+[`examples/runbooks/deploy-setup.md`](examples/runbooks/deploy-setup.md).
+
+Deploy failures intentionally do **not** auto-rollback. The broken version
+stays running while the fabric's `deploy-diagnose` skill (forthcoming) reads
+the failure, files a GH issue, and lets the existing pipeline ship the fix.
+See DESIGN.md "Decision 15 — Deployment of managed projects" for the full
+shape and rationale.
+
 Bump the pinned SHA intentionally to adopt fabric updates — you'll see the resulting skill diff in the same PR.
 
 ## Roadmap

--- a/examples/github-actions/deploy.yml
+++ b/examples/github-actions/deploy.yml
@@ -1,0 +1,174 @@
+# Auto-deploy a managed project on push to `main`.
+#
+# Copy this file into a managed project at `.github/workflows/deploy.yml`,
+# fill in the five `CONFIGURE:` values in the `env:` block below, then
+# follow `examples/runbooks/deploy-setup.md` to register the self-hosted
+# runner and grant it the sudo capabilities it needs.
+#
+# What this does on push to main:
+#   1. Fetch + hard-reset the project's install directory on the host.
+#   2. Rebuild the venv only if `requirements.txt` changed (sha256 compare).
+#   3. Run `scripts/migrate.sh` if present (idempotent).
+#   4. Restart the systemd unit and verify it's active + journal is clean.
+#   5. Write `/var/lib/<project>/deploy.json` with the deploy manifest.
+#   6. POST the manifest (or failure bundle) to fabric, if configured.
+#
+# Failure handling: on any step's failure, the workflow exits non-zero and
+# (if FABRIC_DEPLOY_URL is set) posts a failure bundle to fabric. Auto-rollback
+# is intentionally NOT performed — the broken version stays running so the
+# `deploy-diagnose` skill can read live state, and the next merged fix-PR
+# triggers a fresh deploy that supersedes it.
+
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# ─────── CONFIGURE: project-specific values ───────
+env:
+  PROJECT_NAME: REPLACE_WITH_PROJECT_NAME            # matches `fabric register` name
+  INSTALL_DIR: /srv/REPLACE_WITH_PROJECT_NAME        # absolute path on the host VM
+  SERVICE_UNIT: REPLACE_WITH_PROJECT_NAME.service    # systemd unit to restart
+  REQUIREMENTS_FILE: requirements.txt                # leave blank if no Python deps
+  MIGRATE_SCRIPT: scripts/migrate.sh                 # leave blank if not used
+# ──────────────────────────────────────────────────
+
+jobs:
+  deploy:
+    # The runner must be registered to THIS repo (not an org/enterprise) and
+    # must carry the `deploy-target` label. See examples/runbooks/deploy-setup.md.
+    runs-on: [self-hosted, deploy-target]
+    concurrency:
+      # Queue concurrent deploys; do not cancel an in-flight one. Latest wins.
+      group: deploy-${{ github.workflow }}
+      cancel-in-progress: false
+
+    steps:
+      - name: pull latest into install dir
+        run: |
+          set -euo pipefail
+          sudo -n git -C "$INSTALL_DIR" fetch --quiet origin main
+          sudo -n git -C "$INSTALL_DIR" reset --hard "$GITHUB_SHA"
+          echo "host now at $(sudo -n git -C "$INSTALL_DIR" rev-parse --short HEAD)"
+
+      - name: refresh venv if requirements changed
+        run: |
+          set -euo pipefail
+          if [ -z "${REQUIREMENTS_FILE:-}" ] || ! sudo -n test -f "$INSTALL_DIR/$REQUIREMENTS_FILE"; then
+            echo "no requirements file declared — skipping venv refresh"
+            exit 0
+          fi
+          new_hash="$(sudo -n sha256sum "$INSTALL_DIR/$REQUIREMENTS_FILE" | awk '{print $1}')"
+          live_hash="$(sudo -n cat "$INSTALL_DIR/.venv/.requirements.sha256" 2>/dev/null || echo none)"
+          if [ "$live_hash" = "$new_hash" ]; then
+            echo "requirements unchanged ($new_hash) — reusing venv"
+            exit 0
+          fi
+          echo "requirements changed (was ${live_hash:0:12}, now ${new_hash:0:12}) — rebuilding venv"
+          sudo -n bash -eu -c "
+            cd '$INSTALL_DIR'
+            rm -rf .venv
+            python3 -m venv .venv
+            .venv/bin/pip install --quiet --upgrade pip
+            .venv/bin/pip install --quiet -r '$REQUIREMENTS_FILE'
+            echo '$new_hash' > .venv/.requirements.sha256
+          "
+
+      - name: run migrations if present
+        run: |
+          set -euo pipefail
+          if [ -n "${MIGRATE_SCRIPT:-}" ] && sudo -n test -x "$INSTALL_DIR/$MIGRATE_SCRIPT"; then
+            echo "running $MIGRATE_SCRIPT"
+            sudo -n "$INSTALL_DIR/$MIGRATE_SCRIPT"
+          else
+            echo "no migration script — skipping"
+          fi
+
+      - name: restart service
+        run: sudo -n systemctl restart "$SERVICE_UNIT"
+
+      - name: smoke check
+        run: |
+          set -euo pipefail
+          # Give the process time to load before judging it.
+          sleep 8
+          if ! sudo -n systemctl is-active --quiet "$SERVICE_UNIT"; then
+            echo "::error::$SERVICE_UNIT is not active after restart"
+            sudo -n journalctl -u "$SERVICE_UNIT" -n 200 --no-pager
+            exit 1
+          fi
+          # Fail if any error pattern appears in the first 60s of journal output.
+          if sudo -n journalctl -u "$SERVICE_UNIT" --since '60 seconds ago' --no-pager \
+              | grep -E '\b(ERROR|CRITICAL|Traceback)\b' >&2; then
+            echo "::error::error pattern in journal within 60s of restart"
+            exit 1
+          fi
+          echo "service healthy"
+
+      - name: write deploy manifest
+        if: success()
+        run: |
+          set -euo pipefail
+          ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          short_sha="${GITHUB_SHA:0:7}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # /var/lib/<project>/ is created at provisioning time and owned by the
+          # runner user (see runbook). The cat below will fail loudly if it isn't.
+          cat > "/var/lib/$PROJECT_NAME/deploy.json" <<EOF
+          {
+            "sha": "$GITHUB_SHA",
+            "short_sha": "$short_sha",
+            "deployed_at": "$ts",
+            "branch": "$GITHUB_REF_NAME",
+            "actor": "$GITHUB_ACTOR",
+            "workflow_run_url": "$run_url"
+          }
+          EOF
+          echo "wrote /var/lib/$PROJECT_NAME/deploy.json"
+
+      - name: notify fabric (success)
+        if: success()
+        env:
+          FABRIC_DEPLOY_URL: ${{ secrets.FABRIC_DEPLOY_URL }}
+          FABRIC_TOKEN: ${{ secrets.FABRIC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FABRIC_DEPLOY_URL:-}" ]; then
+            echo "FABRIC_DEPLOY_URL not set — skipping fabric notification (bootstrap mode)"
+            exit 0
+          fi
+          curl --silent --fail --max-time 10 \
+            -H "Authorization: Bearer $FABRIC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d @"/var/lib/$PROJECT_NAME/deploy.json" \
+            "$FABRIC_DEPLOY_URL/api/projects/$PROJECT_NAME/deployments"
+
+      - name: notify fabric (failure)
+        if: failure()
+        env:
+          FABRIC_DEPLOY_URL: ${{ secrets.FABRIC_DEPLOY_URL }}
+          FABRIC_TOKEN: ${{ secrets.FABRIC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FABRIC_DEPLOY_URL:-}" ]; then
+            echo "FABRIC_DEPLOY_URL not set — skipping fabric notification (bootstrap mode)"
+            exit 0
+          fi
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          journal_tail="$(sudo -n journalctl -u "$SERVICE_UNIT" --since '5 minutes ago' --no-pager 2>&1 | tail -100 || echo '<no journal>')"
+          payload="$(jq -n \
+            --arg sha "$GITHUB_SHA" \
+            --arg run_url "$run_url" \
+            --arg unit "$SERVICE_UNIT" \
+            --arg journal "$journal_tail" \
+            '{sha: $sha, status: "failed", workflow_run_url: $run_url, service_unit: $unit, journal_tail: $journal}')"
+          curl --silent --fail --max-time 10 \
+            -H "Authorization: Bearer $FABRIC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$FABRIC_DEPLOY_URL/api/projects/$PROJECT_NAME/deploy-failures"

--- a/examples/runbooks/deploy-setup.md
+++ b/examples/runbooks/deploy-setup.md
@@ -1,0 +1,145 @@
+# Auto-deploy setup — one-time provisioning runbook
+
+A managed project that wants the auto-deploy described in DESIGN.md
+"Decision 15 — Deployment of managed projects" needs three pieces of host
+state set up once. After that, every push to `main` auto-deploys via
+`examples/github-actions/deploy.yml`.
+
+This runbook is for the human operator. It does not need to be re-run on
+each deploy.
+
+## Prerequisites
+
+- The project is already installed on a Linux VM and runs under a systemd
+  unit (e.g. `teach-me-eng-bot.service`).
+- `gh` CLI is installed and authenticated with the GitHub account that
+  owns the project repo.
+- The VM has internet access (the runner needs outbound HTTPS to GitHub).
+
+## 1. Pick an install directory the runner can write to
+
+The deploy workflow does `git reset --hard` inside the project's install
+directory. The runner user (`github-runner` by default) needs to be able
+to read+write it.
+
+If the project currently lives under `/root/<project>` (root-owned), you
+have two options:
+
+- **Recommended**: relocate to `/srv/<project>`, owned by `github-runner`.
+  ```bash
+  sudo systemctl stop <project>.service
+  sudo mv /root/<project> /srv/<project>
+  sudo chown -R github-runner:github-runner /srv/<project>
+  # Point the systemd unit at the new path. Edit:
+  #   WorkingDirectory=/srv/<project>
+  #   EnvironmentFile=/srv/<project>/.env
+  #   ExecStart=/srv/<project>/.venv/bin/python <entrypoint>
+  sudo systemctl daemon-reload
+  sudo systemctl start <project>.service
+  ```
+- **Pragmatic**: keep the existing path and let the workflow run the git
+  ops via `sudo -n`. The shipped `deploy.yml` already uses `sudo -n` for
+  every host operation, so this works as long as `github-runner` has
+  passwordless sudo (it does on this fabric VM).
+
+Whichever you pick, set `INSTALL_DIR` in the workflow to match.
+
+## 2. Register a repo-scoped self-hosted runner
+
+The fabric VM may already host an organization-scoped runner (e.g. the
+`Contable-Bot-ViVi` runner registered under `/home/github-runner/`). That
+runner cannot serve a personal-account repo. Add a second runner scoped
+to *this* repo.
+
+```bash
+# As root, in a fresh location:
+sudo install -d -o github-runner -g github-runner /srv/runners/<project>
+sudo -u github-runner -i bash <<'EOF'
+  cd /srv/runners/<project>
+  curl -fsSL -o runner.tar.gz \
+    https://github.com/actions/runner/releases/download/v2.329.0/actions-runner-linux-x64-2.329.0.tar.gz
+  tar xzf runner.tar.gz
+EOF
+
+# Get a registration token (one-time, expires in ~1h):
+gh api -X POST repos/<owner>/<project>/actions/runners/registration-token --jq .token
+
+# Configure (interactive — follow the prompts):
+sudo -u github-runner -i bash -c "
+  cd /srv/runners/<project>
+  ./config.sh \
+    --url https://github.com/<owner>/<project> \
+    --token <TOKEN_FROM_ABOVE> \
+    --name <project>-runner \
+    --labels self-hosted,deploy-target,<project> \
+    --work _work \
+    --unattended
+"
+
+# Install as a systemd service so it starts on boot:
+sudo /srv/runners/<project>/svc.sh install github-runner
+sudo /srv/runners/<project>/svc.sh start
+```
+
+Verify with `gh api repos/<owner>/<project>/actions/runners` — the new
+runner should appear with status `online` and the labels you set.
+
+The label `deploy-target` is what the workflow's `runs-on:` matches on.
+Keep it; add the project name as a second label so a future multi-project
+deploy can route correctly.
+
+## 3. Create the deploy state directory
+
+The workflow writes the per-deploy manifest to
+`/var/lib/<project>/deploy.json`. Create the directory once, owned by the
+runner user:
+
+```bash
+sudo install -d -o github-runner -g github-runner -m 0755 /var/lib/<project>
+```
+
+## 4. (Optional) Connect the workflow to fabric
+
+If fabric is running on the same VM and you want deploys recorded in its
+SQLite + surfaced via Telegram, set two repo secrets:
+
+```bash
+gh secret set FABRIC_DEPLOY_URL -R <owner>/<project> --body "http://127.0.0.1:7878"
+gh secret set FABRIC_TOKEN      -R <owner>/<project> --body "$(openssl rand -hex 32)"
+```
+
+The matching token must also be added to fabric's `/etc/fabric/env` once
+the `/api/projects/<name>/deployments` endpoint lands (Phase: post-deploy
+template). Until that endpoint exists, leave the secrets unset — the
+workflow's notify steps detect the missing URL and skip silently. Auto-deploy
+itself works in this bootstrap mode.
+
+## 5. Drop the workflow file into the project repo
+
+Copy `examples/github-actions/deploy.yml` from agent-fabric into the
+project at `.github/workflows/deploy.yml`, fill in the five `CONFIGURE:`
+values in the `env:` block at the top, commit, and merge to `main`. The
+workflow does NOT trigger on the merge that introduces it (the workflow
+file isn't yet on `main` from the runner's perspective at evaluation
+time); the next merge after that is the first auto-deploy.
+
+## Verifying the first deploy
+
+1. Open a trivial PR (e.g., `README.md` typo). Merge it.
+2. Watch `gh run watch -R <owner>/<project>` from your laptop.
+3. On the VM: `journalctl -u <project>.service -f` — you should see the
+   process exit + restart cleanly.
+4. Confirm `/var/lib/<project>/deploy.json` has the new sha.
+
+If the workflow fails mid-deploy, the broken version is still running on
+the host (no auto-rollback). The next fix-PR redeploys and supersedes it.
+
+## What this does NOT cover
+
+- Zero-downtime deploys. The unit restarts; expect a 2–5s blip.
+- Database migrations beyond what `scripts/migrate.sh` provides. The
+  workflow runs that script if it exists; nothing more.
+- Deploying multiple branches. Only `main` triggers; `workflow_dispatch`
+  re-deploys whatever is at `main` on demand.
+- Secret rotation. `FABRIC_TOKEN` and any project secrets in `.env` are
+  managed out-of-band.


### PR DESCRIPTION
## Summary

- Adds `examples/github-actions/deploy.yml` — a parameterized GitHub Actions workflow that managed projects copy into `.github/workflows/deploy.yml` to auto-deploy on push to `main`.
- Adds `examples/runbooks/deploy-setup.md` — the one-time host provisioning runbook (registering a repo-scoped self-hosted runner, picking an install dir the runner can write to, creating `/var/lib/<project>/`, optional fabric secrets).
- Adds **Decision 15 — Deployment of managed projects** to DESIGN.md, capturing the rationale: GH Actions on a repo-scoped self-hosted runner (org-scoped runners can't serve personal repos), no auto-rollback (broken version stays running while `deploy-diagnose` reads it and files a fix-issue), no PR-time deploy-impact gating (the diff + PR body + `docs/deploy.md` are enough signal at this scale).
- Cross-references in README.md ("Auto-deploy for managed projects") and CLAUDE.md ("Where things live").

## Why

The pipeline today ends at "user merges PR". After that, deploying a managed project requires manual SSH + `git pull` + `systemctl restart`. This closes the loop end-to-end without coupling deploy to the agent runtime path: the workflow is dumb-deterministic bash; the agent intelligence enters at failure-diagnosis time, not at deploy-execute time.

## What this does NOT do (intentional follow-ups)

- No fabric-side `POST /api/projects/<name>/deployments` / `deploy-failures` endpoints yet.
- No `deploy-diagnose` skill template yet.
- The workflow's notify steps tolerate that absence — if `FABRIC_DEPLOY_URL` secret is unset, they skip silently and auto-deploy still works in bootstrap mode.

## Test plan

- [x] `pytest -q` — 285 passed, 6 skipped (parity, no `TEACH_ME_ENG_BOT_PATH`).
- [x] YAML parses (`yaml.safe_load`).
- [ ] Manual: copy the workflow into `valdisd96/teach-me-eng-bot`, run through the runbook on the fabric VM, watch a real merge auto-deploy. (To be done after this PR merges, before wiring fabric.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)