### PR TITLE
feat: deployment table + REST surface for auto-deploy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -566,13 +566,19 @@ machine-applied manifest — it's a runbook the agent (and humans) read.
 | `examples/github-actions/deploy.yml` | Reusable workflow — copied into managed projects, five `CONFIGURE:` values filled per project. |
 | `examples/runbooks/deploy-setup.md` | One-time provisioning runbook (runner registration, install dir ownership, sudoers, deploy state dir). |
 | `/var/lib/<project>/deploy.json` | Per-project current-deploy manifest written by the workflow; read by fabric to surface in `/status`. |
-| `POST /api/projects/<name>/deployments` | Fabric REST endpoint (forward-looking) where the workflow records successes. |
-| `POST /api/projects/<name>/deploy-failures` | Fabric REST endpoint (forward-looking) where the workflow records failures; triggers `deploy-diagnose`. |
+| `POST /api/projects/<name>/deployments` | Fabric REST endpoint where the workflow records successes (returns the persisted `DeploymentOut`). |
+| `POST /api/projects/<name>/deploy-failures` | Fabric REST endpoint where the workflow records failures; will trigger `deploy-diagnose` once that skill lands. |
+| `GET /api/projects/<name>/deployments[?status=]` | Newest-first deployment history; `?status=success` or `failed` to filter. |
+| `GET /api/projects/<name>/deployments/latest[?status=]` | Most recent deployment. Default `status=success` answers "what's currently running" — what an agent reads to ground its work. |
 | `fabric/skill_templates/deploy-diagnose/` | Skill template (forward-looking) — the agent's failure-reading playbook. |
 
-The workflow is shipped now and tolerates fabric not being wired (notify
-steps detect missing `FABRIC_DEPLOY_URL` and skip). The fabric-side
-endpoints + `deploy-diagnose` skill land in a follow-up.
+The workflow and the four REST endpoints (plus the `deployments` table at
+`schema_version=5`) are shipped. The workflow tolerates fabric not being
+wired (notify steps detect missing `FABRIC_DEPLOY_URL` and skip), so projects
+can adopt auto-deploy before subscribing to fabric. The `deploy-diagnose`
+skill template + the auto-dispatch wiring on `deploy-failures` land in a
+follow-up; the failure endpoint already persists the bundle the diagnose
+pass will read.
 
 ### Decision 14 — CLI modes
 

--- a/fabric/api_models.py
+++ b/fabric/api_models.py
@@ -90,6 +90,21 @@ class DispatchSubmittedOut(_ApiModel):
     duration_s: float
 
 
+class DeploymentOut(_ApiModel):
+    id: int
+    project: str
+    sha: str
+    short_sha: str | None = None
+    status: str
+    deployed_at: str
+    branch: str | None = None
+    actor: str | None = None
+    workflow_run_url: str | None = None
+    service_unit: str | None = None
+    journal_tail: str | None = None
+    diagnose_dispatch_id: int | None = None
+
+
 # ---- request shapes ----
 
 
@@ -121,9 +136,38 @@ class PauseRequest(_ApiModel):
     reason: str | None = None
 
 
+class DeploymentRecordRequest(_ApiModel):
+    """Body posted by the deploy workflow on a successful deploy.
+
+    Mirrors the JSON written to `/var/lib/<project>/deploy.json`.
+    """
+    sha: str
+    short_sha: str | None = None
+    deployed_at: str
+    branch: str | None = None
+    actor: str | None = None
+    workflow_run_url: str | None = None
+
+
+class DeployFailureRequest(_ApiModel):
+    """Body posted by the deploy workflow when a deploy fails.
+
+    The fabric records the failure and (forward-looking) auto-dispatches
+    the `deploy-diagnose` skill against this bundle.
+    """
+    sha: str
+    workflow_run_url: str | None = None
+    service_unit: str | None = None
+    journal_tail: str | None = None
+    status: str = "failed"
+
+
 __all__ = [
     "CommentOut",
     "CommentRequest",
+    "DeployFailureRequest",
+    "DeploymentOut",
+    "DeploymentRecordRequest",
     "DispatchOut",
     "DispatchRequest",
     "DispatchSubmittedOut",

--- a/fabric/server.py
+++ b/fabric/server.py
@@ -129,6 +129,23 @@ def _dispatch_to_out(r: state.DispatchRow) -> am.DispatchOut:
     )
 
 
+def _deployment_to_out(r: state.DeploymentRow) -> am.DeploymentOut:
+    return am.DeploymentOut(
+        id=r.id,
+        project=r.project,
+        sha=r.sha,
+        short_sha=r.short_sha,
+        status=r.status,
+        deployed_at=r.deployed_at,
+        branch=r.branch,
+        actor=r.actor,
+        workflow_run_url=r.workflow_run_url,
+        service_unit=r.service_unit,
+        journal_tail=r.journal_tail,
+        diagnose_dispatch_id=r.diagnose_dispatch_id,
+    )
+
+
 def _wire_routes(
     app: FastAPI,
     *,
@@ -172,6 +189,93 @@ def _wire_routes(
         if row is None:
             raise HTTPException(404, f"issue {project}#{number} not found")
         return _issue_to_out(row)
+
+    @app.get(
+        "/api/projects/{project}/deployments",
+        response_model=list[am.DeploymentOut],
+    )
+    async def list_deployments(
+        project: str, limit: int = 50, status: str | None = None
+    ) -> list[am.DeploymentOut]:
+        _require_project(project)
+        rows = await asyncio.to_thread(
+            state.list_deployments, project, limit=limit, status=status
+        )
+        return [_deployment_to_out(r) for r in rows]
+
+    @app.get(
+        "/api/projects/{project}/deployments/latest",
+        response_model=am.DeploymentOut,
+    )
+    async def latest_deployment(
+        project: str, status: str | None = "success"
+    ) -> am.DeploymentOut:
+        """Return the latest deployment for `project`. Defaults to status='success'
+        — i.e. "what is currently running" — but accepts `?status=failed` or
+        `?status=` (blank) to query the most recent attempt of any status."""
+        _require_project(project)
+        normalized = status if status else None
+        row = await asyncio.to_thread(
+            state.latest_deployment, project, status=normalized
+        )
+        if row is None:
+            qualifier = f" with status={normalized}" if normalized else ""
+            raise HTTPException(
+                404, f"no deployments recorded for {project}{qualifier}"
+            )
+        return _deployment_to_out(row)
+
+    @app.post(
+        "/api/projects/{project}/deployments",
+        response_model=am.DeploymentOut,
+    )
+    async def post_deployment(
+        project: str, req: am.DeploymentRecordRequest
+    ) -> am.DeploymentOut:
+        """Record a successful deploy. Posted by the deploy workflow after
+        the smoke check passes (see examples/github-actions/deploy.yml)."""
+        _require_project(project)
+        deployment = await asyncio.to_thread(
+            state.record_deployment,
+            project=project,
+            sha=req.sha,
+            short_sha=req.short_sha,
+            status="success",
+            deployed_at=req.deployed_at,
+            branch=req.branch,
+            actor=req.actor,
+            workflow_run_url=req.workflow_run_url,
+        )
+        return _deployment_to_out(deployment)
+
+    @app.post(
+        "/api/projects/{project}/deploy-failures",
+        response_model=am.DeploymentOut,
+    )
+    async def post_deploy_failure(
+        project: str, req: am.DeployFailureRequest
+    ) -> am.DeploymentOut:
+        """Record a failed deploy. The deploy-diagnose skill auto-dispatch
+        against this row is a follow-up — for now we just persist the bundle
+        so the future diagnose pass has the data it needs."""
+        _require_project(project)
+        deployment = await asyncio.to_thread(
+            state.record_deployment,
+            project=project,
+            sha=req.sha,
+            status="failed",
+            workflow_run_url=req.workflow_run_url,
+            service_unit=req.service_unit,
+            journal_tail=req.journal_tail,
+        )
+        log.warning(
+            "deploy failed: project=%s sha=%s deployment_id=%s "
+            "— diagnose dispatch wiring pending",
+            project,
+            req.sha,
+            deployment.id,
+        )
+        return _deployment_to_out(deployment)
 
     @app.get("/api/dispatches", response_model=list[am.DispatchOut])
     async def list_dispatches(
@@ -352,6 +456,13 @@ def _resolve_repo(project: str) -> str:
     if entry is None:
         raise HTTPException(404, f"project {project!r} not registered")
     return entry.repo
+
+
+def _require_project(project: str) -> None:
+    """404 if the project name isn't registered. Used on routes that don't
+    need the repo string but still want to fail loudly on typos."""
+    if find_project(project) is None:
+        raise HTTPException(404, f"project {project!r} not registered")
 
 
 __all__ = ["create_app"]

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -68,6 +68,22 @@ class DispatchRow:
 
 
 @dataclass(frozen=True)
+class DeploymentRow:
+    id: int
+    project: str
+    sha: str
+    status: str
+    deployed_at: str
+    short_sha: str | None = None
+    branch: str | None = None
+    actor: str | None = None
+    workflow_run_url: str | None = None
+    service_unit: str | None = None
+    journal_tail: str | None = None
+    diagnose_dispatch_id: int | None = None
+
+
+@dataclass(frozen=True)
 class NotificationRow:
     id: int
     kind: str
@@ -174,11 +190,36 @@ ALTER TABLE notifications ADD COLUMN body TEXT;
 """
 
 
+_SCHEMA_V5 = """
+CREATE TABLE deployments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project TEXT NOT NULL,
+  sha TEXT NOT NULL,
+  short_sha TEXT,
+  status TEXT NOT NULL,
+  deployed_at TEXT NOT NULL,
+  branch TEXT,
+  actor TEXT,
+  workflow_run_url TEXT,
+  service_unit TEXT,
+  journal_tail TEXT,
+  diagnose_dispatch_id INTEGER,
+  FOREIGN KEY (project) REFERENCES projects(name) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_deployments_project_time
+  ON deployments(project, deployed_at);
+CREATE INDEX idx_deployments_project_status
+  ON deployments(project, status, deployed_at);
+"""
+
+
 _MIGRATIONS: list[tuple[int, str]] = [
     (1, _SCHEMA_V1),
     (2, _SCHEMA_V2),
     (3, _SCHEMA_V3),
     (4, _SCHEMA_V4),
+    (5, _SCHEMA_V5),
 ]
 
 
@@ -524,6 +565,143 @@ def recent_dispatches(*, project: str | None = None, limit: int = 50) -> list[Di
         return [DispatchRow(**dict(r)) for r in rows]
 
 
+# ---- deployments DAO ----
+
+
+_DEPLOYMENT_COLS = (
+    "id, project, sha, short_sha, status, deployed_at, branch, actor, "
+    "workflow_run_url, service_unit, journal_tail, diagnose_dispatch_id"
+)
+
+
+def record_deployment(
+    *,
+    project: str,
+    sha: str,
+    status: str,
+    deployed_at: str | None = None,
+    short_sha: str | None = None,
+    branch: str | None = None,
+    actor: str | None = None,
+    workflow_run_url: str | None = None,
+    service_unit: str | None = None,
+    journal_tail: str | None = None,
+) -> DeploymentRow:
+    """Insert a deployment row. `status` is 'success' or 'failed'.
+
+    Returns the persisted row. Caller links a `diagnose_dispatch_id` later
+    via `set_deployment_diagnose_dispatch` once the diagnose run has been
+    started (forward-looking — see Decision 15).
+    """
+    if status not in ("success", "failed"):
+        raise StateError(f"deployment status must be 'success' or 'failed', got {status!r}")
+    ts = deployed_at or _utc_now()
+    with connect() as conn:
+        cur = conn.execute(
+            "INSERT INTO deployments (project, sha, short_sha, status, deployed_at, "
+            "                         branch, actor, workflow_run_url, service_unit, "
+            "                         journal_tail) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                project,
+                sha,
+                short_sha,
+                status,
+                ts,
+                branch,
+                actor,
+                workflow_run_url,
+                service_unit,
+                journal_tail,
+            ),
+        )
+        conn.commit()
+        if cur.lastrowid is None:
+            raise StateError("INSERT into deployments returned no rowid")
+    return DeploymentRow(
+        id=cur.lastrowid,
+        project=project,
+        sha=sha,
+        short_sha=short_sha,
+        status=status,
+        deployed_at=ts,
+        branch=branch,
+        actor=actor,
+        workflow_run_url=workflow_run_url,
+        service_unit=service_unit,
+        journal_tail=journal_tail,
+    )
+
+
+def set_deployment_diagnose_dispatch(deployment_id: int, dispatch_id: int) -> None:
+    """Link a deployment failure to the diagnose dispatch we kicked off for it."""
+    with connect() as conn:
+        result = conn.execute(
+            "UPDATE deployments SET diagnose_dispatch_id = ? WHERE id = ?",
+            (dispatch_id, deployment_id),
+        )
+        if result.rowcount == 0:
+            raise StateError(f"deployment {deployment_id} not found")
+        conn.commit()
+
+
+def get_deployment(deployment_id: int) -> DeploymentRow | None:
+    with connect() as conn:
+        row = conn.execute(
+            f"SELECT {_DEPLOYMENT_COLS} FROM deployments WHERE id = ?",
+            (deployment_id,),
+        ).fetchone()
+        return DeploymentRow(**dict(row)) if row else None
+
+
+def list_deployments(
+    project: str, *, limit: int = 50, status: str | None = None
+) -> list[DeploymentRow]:
+    """Newest-first deployment history for one project, optionally filtered by status."""
+    with connect() as conn:
+        if status is None:
+            rows = conn.execute(
+                f"SELECT {_DEPLOYMENT_COLS} FROM deployments WHERE project = ? "
+                "ORDER BY deployed_at DESC, id DESC LIMIT ?",
+                (project, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                f"SELECT {_DEPLOYMENT_COLS} FROM deployments "
+                "WHERE project = ? AND status = ? "
+                "ORDER BY deployed_at DESC, id DESC LIMIT ?",
+                (project, status, limit),
+            ).fetchall()
+        return [DeploymentRow(**dict(r)) for r in rows]
+
+
+def latest_deployment(
+    project: str, *, status: str | None = None
+) -> DeploymentRow | None:
+    """Most recent deployment for a project, optionally filtered by status.
+
+    `status='success'` answers "what's currently running"; the unfiltered
+    form answers "what was the most recent attempt, success or failure".
+    """
+    rows = list_deployments(project, limit=1, status=status)
+    return rows[0] if rows else None
+
+
+def previous_successful_deployment(
+    project: str, *, before_id: int
+) -> DeploymentRow | None:
+    """Last successful deploy strictly before `before_id`. Used by deploy-diagnose
+    to compute the `git log <last_good>..<failed>` range."""
+    with connect() as conn:
+        row = conn.execute(
+            f"SELECT {_DEPLOYMENT_COLS} FROM deployments "
+            "WHERE project = ? AND status = 'success' AND id < ? "
+            "ORDER BY id DESC LIMIT 1",
+            (project, before_id),
+        ).fetchone()
+        return DeploymentRow(**dict(row)) if row else None
+
+
 # ---- quota DAO ----
 
 
@@ -622,6 +800,7 @@ def find_notification_by_tg_message(
 
 
 __all__ = [
+    "DeploymentRow",
     "DispatchRow",
     "IssueRow",
     "NotificationRow",
@@ -636,19 +815,25 @@ __all__ = [
     "delete_setting",
     "dispatches_for_issue",
     "find_notification_by_tg_message",
+    "get_deployment",
     "get_issue",
     "get_project",
     "get_setting",
     "inc_quota",
     "init_db",
+    "latest_deployment",
     "latest_dispatch",
+    "list_deployments",
     "list_issues",
     "list_projects",
     "list_unacked_notifications",
+    "previous_successful_deployment",
     "quota_today",
     "recent_dispatches",
+    "record_deployment",
     "record_dispatch",
     "set_cycle_count",
+    "set_deployment_diagnose_dispatch",
     "set_notification_tg_message",
     "set_project_last_served",
     "set_project_paused",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -304,6 +304,165 @@ def test_post_merge_calls_gh(client: TestClient, setup: dict[str, Any]) -> None:
     assert any("--squash" in c for c in setup["gh_runner"].calls)
 
 
+# ---------- deployments ----------
+
+
+def test_post_deployment_records_success(client: TestClient) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    r = client.post(
+        "/api/projects/teach-me-eng-bot/deployments",
+        json={
+            "sha": "abc1234deadbeef",
+            "short_sha": "abc1234",
+            "deployed_at": "2026-05-06T18:00:00+00:00",
+            "branch": "main",
+            "actor": "valdisd96",
+            "workflow_run_url": "https://github.com/me/x/actions/runs/1",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "success"
+    assert body["sha"] == "abc1234deadbeef"
+    assert body["short_sha"] == "abc1234"
+    assert body["actor"] == "valdisd96"
+    assert body["id"] > 0
+
+
+def test_post_deployment_404_unknown_project(client: TestClient) -> None:
+    r = client.post(
+        "/api/projects/nope/deployments",
+        json={"sha": "abc", "deployed_at": "2026-05-06T18:00:00+00:00"},
+    )
+    assert r.status_code == 404
+
+
+def test_post_deployment_rejects_extra_fields(client: TestClient) -> None:
+    """Pydantic extra='forbid' — typos in the workflow's payload should 422,
+    not silently drop the field."""
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    r = client.post(
+        "/api/projects/teach-me-eng-bot/deployments",
+        json={
+            "sha": "abc",
+            "deployed_at": "2026-05-06T18:00:00+00:00",
+            "unexpected_typo": "x",
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_post_deploy_failure_records_failed(client: TestClient) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    r = client.post(
+        "/api/projects/teach-me-eng-bot/deploy-failures",
+        json={
+            "sha": "def5678",
+            "workflow_run_url": "https://github.com/me/x/actions/runs/2",
+            "service_unit": "teach-me-eng-bot.service",
+            "journal_tail": "ModuleNotFoundError: redis",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "failed"
+    assert body["sha"] == "def5678"
+    assert body["journal_tail"] == "ModuleNotFoundError: redis"
+    assert body["diagnose_dispatch_id"] is None  # diagnose wiring is a follow-up
+
+
+def test_post_deploy_failure_404_unknown_project(client: TestClient) -> None:
+    r = client.post(
+        "/api/projects/nope/deploy-failures",
+        json={"sha": "abc"},
+    )
+    assert r.status_code == 404
+
+
+def test_get_deployments_empty(client: TestClient) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    r = client.get("/api/projects/teach-me-eng-bot/deployments")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_get_deployments_orders_newest_first(client: TestClient) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="aaa", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="bbb", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    r = client.get("/api/projects/teach-me-eng-bot/deployments")
+    assert r.status_code == 200
+    rows = r.json()
+    assert [row["sha"] for row in rows] == ["bbb", "aaa"]
+
+
+def test_get_deployments_filters_by_status(client: TestClient) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="ok", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="bad", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    r = client.get("/api/projects/teach-me-eng-bot/deployments?status=failed")
+    assert r.status_code == 200
+    rows = r.json()
+    assert [row["sha"] for row in rows] == ["bad"]
+
+
+def test_get_deployments_404_unknown_project(client: TestClient) -> None:
+    r = client.get("/api/projects/nope/deployments")
+    assert r.status_code == 404
+
+
+def test_get_latest_deployment_404_when_none(client: TestClient) -> None:
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    r = client.get("/api/projects/teach-me-eng-bot/deployments/latest")
+    assert r.status_code == 404
+
+
+def test_get_latest_deployment_defaults_to_success(client: TestClient) -> None:
+    """Default `status=success` answers 'what's currently running'."""
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="ok", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="bad", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    r = client.get("/api/projects/teach-me-eng-bot/deployments/latest")
+    assert r.status_code == 200
+    assert r.json()["sha"] == "ok"
+
+
+def test_get_latest_deployment_blank_status_includes_failures(
+    client: TestClient,
+) -> None:
+    """Empty `?status=` returns the most recent of any status."""
+    state.upsert_project(name="teach-me-eng-bot", path="/p", repo="me/x")
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="ok", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    state.record_deployment(
+        project="teach-me-eng-bot", sha="bad", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    r = client.get("/api/projects/teach-me-eng-bot/deployments/latest?status=")
+    assert r.status_code == 200
+    assert r.json()["sha"] == "bad"
+
+
 # ---------- websocket ----------
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -14,19 +14,25 @@ from fabric.state import (
     delete_project,
     delete_setting,
     dispatches_for_issue,
+    get_deployment,
     get_issue,
     get_project,
     get_setting,
     inc_quota,
     init_db,
+    latest_deployment,
     latest_dispatch,
+    list_deployments,
     list_issues,
     list_projects,
     list_unacked_notifications,
+    previous_successful_deployment,
     quota_today,
     recent_dispatches,
+    record_deployment,
     record_dispatch,
     set_cycle_count,
+    set_deployment_diagnose_dispatch,
     set_project_last_served,
     set_project_paused,
     set_setting,
@@ -415,6 +421,174 @@ def test_acknowledge_notification_raises_when_missing(isolated_state_db: Path) -
         acknowledge_notification(9999)
 
 
+# ---------- deployments ----------
+
+
+def test_record_deployment_returns_row_and_round_trips(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    dep = record_deployment(
+        project="t",
+        sha="abc1234deadbeef",
+        short_sha="abc1234",
+        status="success",
+        deployed_at="2026-05-06T18:00:00+00:00",
+        branch="main",
+        actor="valdisd96",
+        workflow_run_url="https://github.com/me/t/actions/runs/123",
+    )
+    assert isinstance(dep.id, int) and dep.id > 0
+    assert dep.sha == "abc1234deadbeef"
+    assert dep.diagnose_dispatch_id is None
+
+    # Returned row matches what get_deployment fetches back.
+    fetched = get_deployment(dep.id)
+    assert fetched == dep
+
+
+def test_record_deployment_failure_keeps_journal(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    dep = record_deployment(
+        project="t",
+        sha="def5678",
+        status="failed",
+        deployed_at="2026-05-06T18:05:00+00:00",
+        service_unit="t.service",
+        journal_tail="Traceback (most recent call last)\nModuleNotFoundError: redis",
+        workflow_run_url="https://github.com/me/t/actions/runs/124",
+    )
+    assert dep.status == "failed"
+    assert dep.journal_tail is not None and "ModuleNotFoundError" in dep.journal_tail
+    assert dep.service_unit == "t.service"
+
+
+def test_record_deployment_rejects_bad_status(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    with pytest.raises(StateError, match="must be 'success' or 'failed'"):
+        record_deployment(project="t", sha="abc", status="weird")
+
+
+def test_get_deployment_returns_none_for_unknown(isolated_state_db: Path) -> None:
+    assert get_deployment(9999) is None
+
+
+def test_list_deployments_orders_newest_first(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    record_deployment(
+        project="t", sha="aaa", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    record_deployment(
+        project="t", sha="bbb", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    record_deployment(
+        project="t", sha="ccc", status="success",
+        deployed_at="2026-05-03T10:00:00+00:00",
+    )
+    rows = list_deployments("t")
+    assert [r.sha for r in rows] == ["ccc", "bbb", "aaa"]
+
+
+def test_list_deployments_filters_by_status(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    record_deployment(
+        project="t", sha="ok1", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    record_deployment(
+        project="t", sha="bad1", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    record_deployment(
+        project="t", sha="ok2", status="success",
+        deployed_at="2026-05-03T10:00:00+00:00",
+    )
+    success_only = list_deployments("t", status="success")
+    failed_only = list_deployments("t", status="failed")
+    assert [r.sha for r in success_only] == ["ok2", "ok1"]
+    assert [r.sha for r in failed_only] == ["bad1"]
+
+
+def test_list_deployments_respects_limit(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    for i in range(5):
+        record_deployment(
+            project="t", sha=f"sha{i}", status="success",
+            deployed_at=f"2026-05-0{i + 1}T10:00:00+00:00",
+        )
+    assert len(list_deployments("t", limit=2)) == 2
+
+
+def test_latest_deployment_returns_most_recent(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    record_deployment(
+        project="t", sha="ok", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    record_deployment(
+        project="t", sha="bad", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    # without filter — newest of any status
+    latest = latest_deployment("t")
+    assert latest is not None and latest.sha == "bad"
+    # filtered — newest success only
+    latest_ok = latest_deployment("t", status="success")
+    assert latest_ok is not None and latest_ok.sha == "ok"
+
+
+def test_latest_deployment_returns_none_when_empty(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    assert latest_deployment("t") is None
+    assert latest_deployment("t", status="success") is None
+
+
+def test_previous_successful_deployment(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    ok1 = record_deployment(
+        project="t", sha="ok1", status="success",
+        deployed_at="2026-05-01T10:00:00+00:00",
+    )
+    record_deployment(
+        project="t", sha="bad1", status="failed",
+        deployed_at="2026-05-02T10:00:00+00:00",
+    )
+    ok2 = record_deployment(
+        project="t", sha="ok2", status="success",
+        deployed_at="2026-05-03T10:00:00+00:00",
+    )
+    bad2 = record_deployment(
+        project="t", sha="bad2", status="failed",
+        deployed_at="2026-05-04T10:00:00+00:00",
+    )
+    # the failed bad2 should resolve to the most recent prior success: ok2
+    prev = previous_successful_deployment("t", before_id=bad2.id)
+    assert prev is not None and prev.id == ok2.id
+
+    # before ok1 there is no prior success
+    prev_before_ok1 = previous_successful_deployment("t", before_id=ok1.id)
+    assert prev_before_ok1 is None
+
+
+def test_set_deployment_diagnose_dispatch_links(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    dep = record_deployment(project="t", sha="bad", status="failed")
+    dispatch_id = record_dispatch(
+        project="t", issue=42, stage="deploy-diagnose",
+        triggered_by="auto:deploy-failure",
+    )
+    set_deployment_diagnose_dispatch(dep.id, dispatch_id)
+    row = get_deployment(dep.id)
+    assert row is not None and row.diagnose_dispatch_id == dispatch_id
+
+
+def test_set_deployment_diagnose_dispatch_raises_when_missing(
+    isolated_state_db: Path,
+) -> None:
+    with pytest.raises(StateError, match="not found"):
+        set_deployment_diagnose_dispatch(9999, 1)
+
+
 # ---------- foreign-key cascade ----------
 
 
@@ -424,6 +598,7 @@ def test_delete_project_cascades(isolated_state_db: Path) -> None:
     record_dispatch(project="t", issue=1, stage="plan-exec")
     add_notification(kind="blocked", project="t", issue=1)
     inc_quota("t", day="2026-05-04")
+    record_deployment(project="t", sha="abc", status="success")
 
     delete_project("t")
 
@@ -431,3 +606,4 @@ def test_delete_project_cascades(isolated_state_db: Path) -> None:
     assert recent_dispatches(project="t") == []
     assert list_unacked_notifications() == []
     assert quota_today("t", day="2026-05-04") == 0
+    assert list_deployments("t") == []


### PR DESCRIPTION
## Summary

Receiving side for the auto-deploy workflow shipped in #54:

- `deployments` table at `schema_version=5` (forward-only migration, FK cascade from `projects`, indices on `(project, deployed_at)` and `(project, status, deployed_at)`).
- DAO: `record_deployment`, `get_deployment`, `list_deployments`, `latest_deployment`, `previous_successful_deployment`, `set_deployment_diagnose_dispatch`.
- Four REST endpoints under `/api/projects/{name}/`:
  - `POST /deployments` — workflow records a successful deploy
  - `POST /deploy-failures` — workflow records a failed deploy (just persists the bundle for now; auto-dispatch wiring is the follow-up)
  - `GET /deployments[?status=&limit=]` — newest-first history
  - `GET /deployments/latest[?status=]` — defaults to `status=success`, i.e. "what's currently running"
- DESIGN.md Decision 15 updated to mark endpoints real (only the diagnose skill + auto-dispatch wiring remain forward-looking).

## Why

Until this lands, the deploy workflow's notify steps either skip silently (no `FABRIC_DEPLOY_URL` secret) or 404 on every push. With this in, the loop is closed for record-keeping: every deploy attempt is persisted, queryable via REST, and ready for the diagnose pass to read.

## What this does NOT do (intentional follow-ups)

- The `deploy-diagnose` skill template (`fabric/skill_templates/deploy-diagnose/`) — next PR.
- Auto-dispatching `deploy-diagnose` on `POST /deploy-failures`. The endpoint logs a `WARNING: deploy failed ... — diagnose dispatch wiring pending` and returns 200 so the workflow doesn't retry-loop.
- Telegram notification on deploy events. The data is in SQLite; the bot wiring is a small follow-up once the on-success/on-failure UX is decided (terse one-line vs. full bundle).

## Test plan

- [x] `pytest -q` — 309 passed, 6 skipped (parity, no `TEACH_ME_ENG_BOT_PATH`). +13 state tests (DAO, status filtering, FK cascade, diagnose-link), +13 endpoint tests (CRUD, 404 on unknown project, 422 on extra fields, default-status semantics).
- [x] Migration is idempotent — `init_db()` re-applies cleanly.
- [ ] Manual: once merged + deployed, `curl -X POST 127.0.0.1:7878/api/projects/teach-me-eng-bot/deployments -d '{...}'` against the live fabric to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)