### PR TITLE
feat: rolling-window dispatch cap (5h) replaces daily cap

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -228,7 +228,8 @@ pipeline:
   cycle_limit: 5
   retry_count: 3
   retry_backoff_seconds: [60, 300, 900]
-  daily_dispatch_cap: 30        # quota guard
+  dispatch_cap: 30              # rolling-window quota guard
+  dispatch_window_hours: 5      # tracks Anthropic's 5h rate-limit window
 
 fabric_version: "0.3.0"          # for sync drift detection
 ```
@@ -325,12 +326,8 @@ CREATE TABLE notifications (
   acknowledged_at TEXT
 );
 
-CREATE TABLE quota_log (
-  project TEXT NOT NULL,
-  day TEXT NOT NULL,          -- YYYY-MM-DD UTC
-  dispatches INTEGER DEFAULT 0,
-  PRIMARY KEY (project, day)
-);
+-- The rolling-window cap (Decision 10) reads from `dispatches.started_at`
+-- directly; no separate counter table. Migration v7 dropped `quota_log`.
 
 CREATE TABLE settings (
   key TEXT PRIMARY KEY,
@@ -456,9 +453,9 @@ Telegram auth: bot only responds to a single hardcoded `chat_id` (yours). Anyone
 
 ### Decision 10 — Quotas & throttling
 
-With 6–8 projects, Claude Pro/Max session quotas become a real constraint. The fabric tracks per-project dispatch counts in `quota_log` and:
+With 6–8 projects, Claude Pro/Max subscription rate limits become a real constraint. Anthropic enforces a 5-hour rolling window on Pro/Max plans, so the fabric mirrors that shape rather than a calendar-day cap (which would burn the whole budget early in the day and stall every project until UTC rollover).
 
-- **Per-project daily cap** — `pipeline.daily_dispatch_cap` in config. Default 30/day. Once hit, the project is skipped until UTC rollover; banner shown in dashboard; Telegram notification at 80%.
+- **Per-project rolling cap** — `pipeline.dispatch_cap` in config (default 30) over `pipeline.dispatch_window_hours` (default 5). The scheduler reads `COUNT(*) FROM dispatches WHERE project = ? AND started_at >= now - window` at dispatch time; once hit, the project is skipped until the oldest dispatch ages past the cutoff. No separate counter table — the dispatches log is the source of truth, so a fabric reinstall doesn't reset the counter mid-window.
 - **Global pause-on-quota-warning** — optional. If you've burned, say, 80% of weekly budget across all projects, fabric auto-pauses with a Telegram notice. (Manual estimate v1; no API to query Anthropic budget directly.)
 - **Sonnet downgrade** — config flag per project: `pipeline.downgrade_low_priority: true` makes `priority:low` issues dispatch with `--model claude-sonnet-4-6`. Off by default.
 

--- a/examples/teach-me-eng-bot.config.yaml
+++ b/examples/teach-me-eng-bot.config.yaml
@@ -59,6 +59,9 @@ pipeline:
   cycle_limit: 5
   retry_count: 3
   retry_backoff_seconds: [60, 300, 900]
-  daily_dispatch_cap: 30
+  # At most 30 dispatches in any rolling 5-hour window — tracks Anthropic's
+  # subscription rate-limit shape so we stay under the wall.
+  dispatch_cap: 30
+  dispatch_window_hours: 5
 
-fabric_version: "0.1.0"
+fabric_version: "0.2.0"

--- a/fabric/config.py
+++ b/fabric/config.py
@@ -67,7 +67,13 @@ class Pipeline(_Strict):
     cycle_limit: int = Field(default=5, gt=0)
     retry_count: int = Field(default=3, ge=0)
     retry_backoff_seconds: list[int] = Field(default_factory=lambda: [60, 300, 900])
-    daily_dispatch_cap: int = Field(default=30, gt=0)
+    # Rolling-window cap: at most `dispatch_cap` dispatches in any
+    # `dispatch_window_hours`-long window. Tracks Anthropic's 5-hour rate
+    # limit by default (30/5h ≈ Pro plan headroom). Window is rolling, not
+    # session-based — slightly more conservative than what Anthropic enforces,
+    # which is fine for staying under the wall.
+    dispatch_cap: int = Field(default=30, gt=0)
+    dispatch_window_hours: int = Field(default=5, gt=0)
     downgrade_low_priority: bool = False
 
     @field_validator("retry_backoff_seconds")

--- a/fabric/dispatcher.py
+++ b/fabric/dispatcher.py
@@ -112,10 +112,16 @@ class Dispatcher:
         entry, config = self._load_project(project)
         await self._ensure_state_project(entry, config)
 
-        used = await asyncio.to_thread(state.quota_today, project)
-        if used >= config.pipeline.daily_dispatch_cap:
+        used = await asyncio.to_thread(
+            state.dispatches_in_window,
+            project,
+            config.pipeline.dispatch_window_hours,
+        )
+        if used >= config.pipeline.dispatch_cap:
             raise QuotaExceeded(
-                f"{project} hit daily cap ({used}/{config.pipeline.daily_dispatch_cap})"
+                f"{project} hit cap "
+                f"({used}/{config.pipeline.dispatch_cap} "
+                f"in last {config.pipeline.dispatch_window_hours}h)"
             )
 
         resolved_model = await self._resolve_model(project, issue, model, config)
@@ -155,10 +161,16 @@ class Dispatcher:
                 f"{deployment.project!r}, not {project!r}"
             )
 
-        used = await asyncio.to_thread(state.quota_today, project)
-        if used >= config.pipeline.daily_dispatch_cap:
+        used = await asyncio.to_thread(
+            state.dispatches_in_window,
+            project,
+            config.pipeline.dispatch_window_hours,
+        )
+        if used >= config.pipeline.dispatch_cap:
             raise QuotaExceeded(
-                f"{project} hit daily cap ({used}/{config.pipeline.daily_dispatch_cap})"
+                f"{project} hit cap "
+                f"({used}/{config.pipeline.dispatch_cap} "
+                f"in last {config.pipeline.dispatch_window_hours}h)"
             )
 
         # Force opus — diagnose is reasoning-heavy; never downgrade.
@@ -371,8 +383,6 @@ class Dispatcher:
             exit_code=exit_code,
             log_path=str(log_path),
         )
-        await asyncio.to_thread(state.inc_quota, entry.name)
-
         duration_s = (ended - started).total_seconds()
         # Bias toward log volume on failure: success at INFO, failure at
         # WARNING with the log path so journalctl alone tells the story.
@@ -540,8 +550,6 @@ class Dispatcher:
             exit_code=exit_code,
             log_path=str(log_path),
         )
-        await asyncio.to_thread(state.inc_quota, entry.name)
-
         duration_s = (ended - started).total_seconds()
         if exit_code == 0:
             log.info(

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -17,7 +17,7 @@ import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from fabric.registry import fabric_home
@@ -225,6 +225,14 @@ CREATE INDEX idx_deployments_project_status
 """
 
 
+# Rolling-window cap reads from `dispatches.started_at` directly, so the
+# separate counter table becomes dead weight. Drop it; data loss is fine
+# because the cap derives from dispatches itself.
+_SCHEMA_V7 = """
+DROP TABLE IF EXISTS quota_log;
+"""
+
+
 _MIGRATIONS: list[tuple[int, str]] = [
     (1, _SCHEMA_V1),
     (2, _SCHEMA_V2),
@@ -232,15 +240,12 @@ _MIGRATIONS: list[tuple[int, str]] = [
     (4, _SCHEMA_V4),
     (5, _SCHEMA_V5),
     (6, _SCHEMA_V6),
+    (7, _SCHEMA_V7),
 ]
 
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
-
-
-def _utc_today() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
 
 @contextmanager
@@ -722,32 +727,26 @@ def previous_successful_deployment(
 # ---- quota DAO ----
 
 
-def inc_quota(project: str, *, day: str | None = None) -> int:
-    """Bump dispatch count for (project, day-UTC). Returns new count."""
-    d = day or _utc_today()
+def dispatches_in_window(
+    project: str, hours: int, *, now: datetime | None = None
+) -> int:
+    """Count dispatches whose `started_at` falls within the last `hours`.
+
+    Rolling window — refills smoothly as old dispatches age past the cutoff,
+    no midnight cliff. Counts in-flight rows too (`ended_at` may be NULL),
+    which is correct: an in-flight dispatch is still consuming the API.
+    """
+    if hours <= 0:
+        raise StateError("hours must be positive")
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(hours=hours)
+    cutoff_iso = cutoff.isoformat(timespec="seconds")
     with connect() as conn:
-        conn.execute(
-            "INSERT INTO quota_log (project, day, dispatches) VALUES (?, ?, 1) "
-            "ON CONFLICT(project, day) DO UPDATE SET "
-            "  dispatches = quota_log.dispatches + 1",
-            (project, d),
-        )
         row = conn.execute(
-            "SELECT dispatches FROM quota_log WHERE project = ? AND day = ?",
-            (project, d),
+            "SELECT COUNT(*) FROM dispatches "
+            "WHERE project = ? AND started_at >= ?",
+            (project, cutoff_iso),
         ).fetchone()
-        conn.commit()
         return int(row[0])
-
-
-def quota_today(project: str, *, day: str | None = None) -> int:
-    d = day or _utc_today()
-    with connect() as conn:
-        row = conn.execute(
-            "SELECT dispatches FROM quota_log WHERE project = ? AND day = ?",
-            (project, d),
-        ).fetchone()
-        return int(row[0]) if row else 0
 
 
 # ---- notifications DAO ----
@@ -831,12 +830,12 @@ __all__ = [
     "delete_project",
     "delete_setting",
     "dispatches_for_issue",
+    "dispatches_in_window",
     "find_notification_by_tg_message",
     "get_deployment",
     "get_issue",
     "get_project",
     "get_setting",
-    "inc_quota",
     "init_db",
     "latest_deployment",
     "latest_dispatch",
@@ -845,7 +844,6 @@ __all__ = [
     "list_projects",
     "list_unacked_notifications",
     "previous_successful_deployment",
-    "quota_today",
     "recent_dispatches",
     "record_deployment",
     "record_dispatch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-fabric"
-version = "0.1.0"
+version = "0.2.0"
 description = "Multi-project agent fabric — drives the plan-exec → test-writer → review-pr Claude pipeline across N repos."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/fixtures/good.yaml
+++ b/tests/fixtures/good.yaml
@@ -31,6 +31,7 @@ pipeline:
   cycle_limit: 5
   retry_count: 3
   retry_backoff_seconds: [60, 300, 900]
-  daily_dispatch_cap: 30
+  dispatch_cap: 30
+  dispatch_window_hours: 5
 
-fabric_version: "0.1.0"
+fabric_version: "0.2.0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,19 +18,36 @@ def test_load_good_config() -> None:
     assert cfg.modules[0].path == "bot.py"
     assert cfg.labels.area_labels == ["bot", "vocab"]
     assert cfg.pipeline.cycle_limit == 5
+    assert cfg.pipeline.dispatch_cap == 30
+    assert cfg.pipeline.dispatch_window_hours == 5
     assert cfg.pipeline.downgrade_low_priority is False
-    assert cfg.fabric_version == "0.1.0"
+    assert cfg.fabric_version == "0.2.0"
 
 
 def test_downgrade_low_priority_can_be_enabled(tmp_path: Path) -> None:
     text = (FIXTURES / "good.yaml").read_text().replace(
-        "daily_dispatch_cap: 30",
-        "daily_dispatch_cap: 30\n  downgrade_low_priority: true",
+        "dispatch_cap: 30",
+        "dispatch_cap: 30\n  downgrade_low_priority: true",
     )
     p = tmp_path / "cfg.yaml"
     p.write_text(text)
     cfg = load_config(p)
     assert cfg.pipeline.downgrade_low_priority is True
+
+
+def test_legacy_daily_dispatch_cap_rejected(tmp_path: Path) -> None:
+    """0.2.0 dropped `daily_dispatch_cap`. A config still using it must fail
+    loudly so the operator updates to the rolling-window fields rather than
+    silently running with defaults."""
+    text = (FIXTURES / "good.yaml").read_text().replace(
+        "dispatch_cap: 30\n  dispatch_window_hours: 5",
+        "daily_dispatch_cap: 30",
+    )
+    p = tmp_path / "cfg.yaml"
+    p.write_text(text)
+    with pytest.raises(ConfigError) as exc:
+        load_config(p)
+    assert "daily_dispatch_cap" in str(exc.value)
 
 
 def test_missing_file_raises() -> None:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -247,7 +247,7 @@ def test_dispatch_records_started_completed_and_quota(
     assert latest.exit_code == 0
     assert latest.ended_at is not None
     assert latest.log_path is not None
-    assert state.quota_today("teach-me-eng-bot") == 1
+    assert state.dispatches_in_window("teach-me-eng-bot", 5) == 1
 
 
 def test_dispatch_propagates_nonzero_exit(
@@ -322,14 +322,45 @@ def test_dispatch_quota_cap_raises(
 ) -> None:
     project = _make_project(tmp_path / "proj")
     register(project)
-    # good.yaml's pipeline.daily_dispatch_cap == 30; pre-fill the quota
+    # good.yaml's pipeline.dispatch_cap == 30 over a 5h window; pre-fill 30
+    # dispatches inside the window so the next one trips the cap.
     state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+    from datetime import datetime, timedelta, timezone
+    inside = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(
+        timespec="seconds"
+    )
     for _ in range(30):
-        state.inc_quota("teach-me-eng-bot")
+        state.record_dispatch(
+            project="teach-me-eng-bot", issue=1, stage="plan-exec",
+            started_at=inside,
+        )
 
     d = Dispatcher(spawner=FakeSpawner())
-    with pytest.raises(QuotaExceeded, match="30/30"):
+    with pytest.raises(QuotaExceeded, match=r"30/30 in last 5h"):
         _aiorun(d.dispatch("teach-me-eng-bot", 1, "plan-exec"))
+
+
+def test_dispatch_quota_window_refills(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    """Dispatches older than the rolling window should not count against the cap."""
+    project = _make_project(tmp_path / "proj")
+    register(project)
+    state.upsert_project(name="teach-me-eng-bot", path=str(project), repo="me/x")
+    from datetime import datetime, timedelta, timezone
+    # 30 old dispatches outside the 5h window — shouldn't block a new one.
+    aged_out = (datetime.now(timezone.utc) - timedelta(hours=6)).isoformat(
+        timespec="seconds"
+    )
+    for _ in range(30):
+        state.record_dispatch(
+            project="teach-me-eng-bot", issue=1, stage="plan-exec",
+            started_at=aged_out,
+        )
+
+    d = Dispatcher(spawner=FakeSpawner(exit_code=0))
+    res = _aiorun(d.dispatch("teach-me-eng-bot", 2, "plan-exec"))
+    assert res.exit_code == 0
 
 
 # ---------- model resolution ----------
@@ -374,8 +405,8 @@ def test_dispatch_downgrades_low_priority_when_flag_set(
     text = cfg_path.read_text()
     cfg_path.write_text(
         text.replace(
-            "daily_dispatch_cap: 30",
-            "daily_dispatch_cap: 30\n  downgrade_low_priority: true",
+            "dispatch_cap: 30",
+            "dispatch_cap: 30\n  downgrade_low_priority: true",
         )
     )
     register(project)
@@ -840,15 +871,22 @@ def test_dispatch_diagnose_rejects_cross_project_deployment(
         _aiorun(d.dispatch_deploy_diagnose("teach-me-eng-bot", other_failure.id))
 
 
-def test_dispatch_diagnose_respects_daily_quota(
+def test_dispatch_diagnose_respects_rolling_quota(
     isolated_state_db: Path, tmp_path: Path
 ) -> None:
     project = _make_project(tmp_path / "proj")
     register(project)
     failed = _record_failed_deployment()
-    # good.yaml fixture caps at 30/day
+    # good.yaml fixture caps at 30 in any 5h rolling window
+    from datetime import datetime, timedelta, timezone
+    inside = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(
+        timespec="seconds"
+    )
     for _ in range(30):
-        state.inc_quota("teach-me-eng-bot")
+        state.record_dispatch(
+            project="teach-me-eng-bot", issue=1, stage="plan-exec",
+            started_at=inside,
+        )
     d = Dispatcher(spawner=FakeSpawner())
     with pytest.raises(QuotaExceeded):
         _aiorun(d.dispatch_deploy_diagnose("teach-me-eng-bot", failed.id))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -345,8 +345,16 @@ def test_tick_dispatches_winner_and_updates_last_served(base_setup: Path) -> Non
 
 def test_tick_quota_exceeded_returns_reason(base_setup: Path) -> None:
     state.upsert_project(name="teach-me-eng-bot", path=str(base_setup), repo="me/x")
-    for _ in range(30):  # good.yaml's daily_dispatch_cap == 30
-        state.inc_quota("teach-me-eng-bot")
+    # good.yaml's dispatch_cap == 30 over a 5h rolling window
+    from datetime import datetime, timedelta, timezone
+    inside = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(
+        timespec="seconds"
+    )
+    for _ in range(30):
+        state.record_dispatch(
+            project="teach-me-eng-bot", issue=1, stage="plan-exec",
+            started_at=inside,
+        )
 
     gh_runner = FakeGhRunner(list_issues_payload=[_issue_payload(1)])
     res = _aiorun(_make_scheduler(gh_runner=gh_runner).tick())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -279,8 +279,16 @@ def test_post_dispatch_429_quota_exceeded(
     client: TestClient, setup: dict[str, Any]
 ) -> None:
     state.upsert_project(name="teach-me-eng-bot", path=str(setup["project"]), repo="me/x")
+    # good.yaml caps at 30 dispatches in 5h
+    from datetime import datetime, timedelta, timezone
+    inside = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(
+        timespec="seconds"
+    )
     for _ in range(30):
-        state.inc_quota("teach-me-eng-bot")
+        state.record_dispatch(
+            project="teach-me-eng-bot", issue=1, stage="plan-exec",
+            started_at=inside,
+        )
 
     r = client.post(
         "/api/issues/teach-me-eng-bot/1/dispatch",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -14,11 +15,11 @@ from fabric.state import (
     delete_project,
     delete_setting,
     dispatches_for_issue,
+    dispatches_in_window,
     get_deployment,
     get_issue,
     get_project,
     get_setting,
-    inc_quota,
     init_db,
     latest_deployment,
     latest_dispatch,
@@ -27,7 +28,6 @@ from fabric.state import (
     list_projects,
     list_unacked_notifications,
     previous_successful_deployment,
-    quota_today,
     recent_dispatches,
     record_deployment,
     record_dispatch,
@@ -58,7 +58,6 @@ def test_init_db_creates_tables(isolated_fabric_home: Path) -> None:
         "issues",
         "dispatches",
         "notifications",
-        "quota_log",
         "settings",
     }
     with connect(p) as conn:
@@ -67,6 +66,8 @@ def test_init_db_creates_tables(isolated_fabric_home: Path) -> None:
         ).fetchall()
     found = {r["name"] for r in rows}
     assert expected.issubset(found)
+    # quota_log was dropped in v7 — rolling-window cap reads from dispatches.
+    assert "quota_log" not in found
 
 
 def test_init_db_records_schema_version(isolated_state_db: Path) -> None:
@@ -363,28 +364,60 @@ def test_recent_dispatches_orders_desc(isolated_state_db: Path) -> None:
     assert [(r.project, r.issue) for r in a_rows] == [("a", 2), ("a", 1)]
 
 
-# ---------- quota ----------
+# ---------- quota (rolling window) ----------
 
 
-def test_inc_quota_increments(isolated_state_db: Path) -> None:
+def test_dispatches_in_window_returns_zero_when_empty(isolated_state_db: Path) -> None:
     upsert_project(name="t", path="/p", repo="me/t")
-    assert inc_quota("t", day="2026-05-04") == 1
-    assert inc_quota("t", day="2026-05-04") == 2
-    assert quota_today("t", day="2026-05-04") == 2
+    assert dispatches_in_window("t", 5) == 0
 
 
-def test_quota_today_returns_zero_when_missing(isolated_state_db: Path) -> None:
+def test_dispatches_in_window_counts_recent(isolated_state_db: Path) -> None:
     upsert_project(name="t", path="/p", repo="me/t")
-    assert quota_today("t", day="2026-05-04") == 0
+    now = datetime(2026, 5, 7, 18, 0, tzinfo=timezone.utc)
+    # Three dispatches inside the last 5h, one just outside, one well past.
+    inside = [now - timedelta(hours=h) for h in (0, 1, 4)]
+    outside = [now - timedelta(hours=5, minutes=1), now - timedelta(hours=10)]
+    for ts in inside + outside:
+        record_dispatch(
+            project="t", issue=1, stage="plan-exec",
+            started_at=ts.isoformat(timespec="seconds"),
+        )
+    assert dispatches_in_window("t", 5, now=now) == 3
+    assert dispatches_in_window("t", 24, now=now) == 5
 
 
-def test_quota_isolated_per_day(isolated_state_db: Path) -> None:
+def test_dispatches_in_window_isolated_per_project(isolated_state_db: Path) -> None:
+    upsert_project(name="a", path="/p", repo="me/a")
+    upsert_project(name="b", path="/p", repo="me/b")
+    now = datetime(2026, 5, 7, 18, 0, tzinfo=timezone.utc)
+    started_at = (now - timedelta(hours=1)).isoformat(timespec="seconds")
+    record_dispatch(project="a", issue=1, stage="plan-exec", started_at=started_at)
+    record_dispatch(project="a", issue=2, stage="plan-exec", started_at=started_at)
+    record_dispatch(project="b", issue=1, stage="plan-exec", started_at=started_at)
+
+    assert dispatches_in_window("a", 5, now=now) == 2
+    assert dispatches_in_window("b", 5, now=now) == 1
+
+
+def test_dispatches_in_window_counts_in_flight(isolated_state_db: Path) -> None:
+    """In-flight rows (ended_at NULL) still consume the window — they're using
+    the API right now."""
     upsert_project(name="t", path="/p", repo="me/t")
-    inc_quota("t", day="2026-05-03")
-    inc_quota("t", day="2026-05-04")
-    inc_quota("t", day="2026-05-04")
-    assert quota_today("t", day="2026-05-03") == 1
-    assert quota_today("t", day="2026-05-04") == 2
+    now = datetime(2026, 5, 7, 18, 0, tzinfo=timezone.utc)
+    record_dispatch(
+        project="t", issue=1, stage="plan-exec",
+        started_at=(now - timedelta(minutes=30)).isoformat(timespec="seconds"),
+    )
+    assert dispatches_in_window("t", 5, now=now) == 1
+
+
+def test_dispatches_in_window_rejects_non_positive_hours(isolated_state_db: Path) -> None:
+    upsert_project(name="t", path="/p", repo="me/t")
+    with pytest.raises(StateError, match="positive"):
+        dispatches_in_window("t", 0)
+    with pytest.raises(StateError, match="positive"):
+        dispatches_in_window("t", -1)
 
 
 # ---------- notifications ----------
@@ -597,7 +630,6 @@ def test_delete_project_cascades(isolated_state_db: Path) -> None:
     upsert_issue(project="t", number=1)
     record_dispatch(project="t", issue=1, stage="plan-exec")
     add_notification(kind="blocked", project="t", issue=1)
-    inc_quota("t", day="2026-05-04")
     record_deployment(project="t", sha="abc", status="success")
 
     delete_project("t")
@@ -605,5 +637,5 @@ def test_delete_project_cascades(isolated_state_db: Path) -> None:
     assert list_issues("t") == []
     assert recent_dispatches(project="t") == []
     assert list_unacked_notifications() == []
-    assert quota_today("t", day="2026-05-04") == 0
+    assert dispatches_in_window("t", 24) == 0
     assert list_deployments("t") == []


### PR DESCRIPTION
## Summary
- Replaces `pipeline.daily_dispatch_cap` (calendar-day, UTC rollover) with `pipeline.dispatch_cap` + `pipeline.dispatch_window_hours` — a rolling-window cap mirroring Anthropic Pro/Max's 5-hour rate-limit shape.
- Drops the `quota_log` table (migration v7) — the `dispatches` table is now the counter, so a fabric reinstall doesn't reset the window mid-flight.
- **Breaking schema change → bumps `fabric_version` 0.1.0 → 0.2.0.** `examples/teach-me-eng-bot.config.yaml` updated. Managed projects pinned to 0.1.0 must migrate; configs still using `daily_dispatch_cap` now fail validation loudly (covered by `test_legacy_daily_dispatch_cap_rejected`).

## Why
The daily cap stalled a project for hours once exhausted (issue #88 in teach-me-eng-bot today: 30 dispatches landed by 16:22 UTC, then nothing dispatched until midnight UTC even though the actionable issue was sitting in `state:needs-planning`). Anthropic doesn't enforce a calendar-day window — they enforce a 5h rolling one — so mirroring that shape stays under the wall without the cliff.

## Test plan
- [x] `pytest -q` — 326 passed, 7 skipped (parity gate inactive)
- [x] `TEACH_ME_ENG_BOT_PATH=/srv/projects/teach-me-eng-bot pytest -q` — 333 passed (parity active, byte-for-byte)
- [x] `python -m py_compile $(find fabric -name '*.py')` — clean
- [x] `fabric --help` — CLI surface imports cleanly
- [ ] After merge + redeploy, verify scheduler picks up teach-me-eng-bot#88 on next tick

## Migration note
After merging + redeploying, the operator must also update teach-me-eng-bot's `.fabric/config.yaml` (live at `/srv/projects/teach-me-eng-bot/.fabric/config.yaml`) to use the new fields — that config is checked separately by `fabric sync` and won't reload from the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)