### PR TITLE
fix: run service as root with IS_SANDBOX=1 (drop fabric user)

### DIFF
--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: install
 description: Step-by-step procedure for installing agent-fabric on a fresh Ubuntu 24.04 LTS VPS and registering the first managed project. Invoke when the user asks to "install", "deploy", "set up", "provision", or "bring up" agent-fabric on a server, VM, or VPS — or asks how to run it next to a managed project like teach-me-eng-bot. Project-internal; not rendered into managed projects by `fabric sync`.
-version: 1.2.0
+version: 1.3.0
 ---
 
 # install
@@ -19,26 +19,35 @@ push back rather than improvising. If they're trying to run locally for
 development, point them at `CLAUDE.md` ("Working in this repo") instead —
 this skill is for the deployed service path.
 
+## Deployment model
+
+The service runs as **`root`** with `IS_SANDBOX=1`. This is intentional
+and intended for single-tenant VMs or isolated one-time containers —
+there is no separate `fabric` system user to switch to, no `sudo -u`
+dance for auth, and Claude Code reads its credentials from `/root/.claude`.
+If you need a hardened multi-tenant install with a dedicated service
+user, that's outside the scope of this runbook.
+
 ## What you'll end up with
 
 ```
-/srv/agent-fabric/          # checkout + .venv          (the operator's user)
-/srv/projects/<name>/       # cloned managed repos      (fabric:fabric, 0750)
-/var/lib/fabric/            # FABRIC_HOME (state.db, logs/)   (fabric:fabric)
-/etc/fabric/env             # systemd EnvironmentFile   (fabric:fabric, 0600)
+/srv/agent-fabric/          # checkout + .venv          (root:root)
+/srv/projects/<name>/       # cloned managed repos      (root:root, 0750)
+/var/lib/fabric/            # FABRIC_HOME (state.db, logs/)   (root:root, 0750)
+/etc/fabric/env             # systemd EnvironmentFile   (root:root, 0600)
 /etc/systemd/system/fabric.service
 ```
 
-One systemd unit (`fabric.service`) running as system user `fabric`,
-serving REST on `127.0.0.1:7878` and the Telegram bot inside the same
-process. Scheduler ticks every 60 s; one `claude -p` subprocess at a time
-across all projects (single-flight invariant — see DESIGN.md).
+One systemd unit (`fabric.service`) serving REST on `127.0.0.1:7878` and
+the Telegram bot inside the same process. Scheduler ticks every 60 s;
+one `claude -p` subprocess at a time across all projects (single-flight
+invariant — see DESIGN.md).
 
 ## Prerequisites — confirm before starting
 
 Before running anything, confirm with the user that they have:
 
-- A fresh Ubuntu 24.04 LTS VPS with sudo / root access.
+- A fresh Ubuntu 24.04 LTS VPS with root access (or sudo).
 - A GitHub Personal Access Token with `repo` scope (and `workflow` if any
   managed project's `safety.blocked_paths` permits `.github/workflows/`
   edits — teach-me-eng-bot blocks them, so `repo` alone is enough there).
@@ -52,11 +61,15 @@ Before running anything, confirm with the user that they have:
 If anything is missing, pause and ask — don't guess Telegram chat IDs or
 fabricate PATs.
 
+All commands below assume you're running as root (or prefixed with
+`sudo` if you ssh in as a non-root user). For brevity, the snippets
+elide `sudo`.
+
 ## Step 1 — system packages
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y python3.12 python3.12-venv git curl jq ca-certificates
+apt-get update
+apt-get install -y python3.12 python3.12-venv git curl jq ca-certificates
 ```
 
 Ubuntu 24.04 ships Python 3.12 in the default repos, which matches the
@@ -71,40 +84,41 @@ python3.12 --version       # e.g. Python 3.12.3
 
 ## Step 2 — install `gh` and `claude` CLIs
 
-`gh` (system-wide):
+**`gh`** — recommended path is the apt repository (system-wide, auto-updates
+via `apt upgrade`):
 
 ```bash
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-sudo chmod 0644 /usr/share/keyrings/githubcli-archive-keyring.gpg
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+chmod 0644 /usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-  | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-sudo apt-get update && sudo apt-get install -y gh
+  > /etc/apt/sources.list.d/github-cli.list
+apt-get update && apt-get install -y gh
 ```
 
-`claude` (Anthropic Claude Code CLI): follow
-https://docs.claude.com/en/docs/claude-code — Linux install instructions
-change occasionally, so re-read rather than caching a stale command.
-
-**Critical** — the official curl|sh installer drops the binary at
-`~/.local/share/claude/versions/<v>` (under `$HOME`). The systemd unit
-sets `ProtectHome=true`, which makes `/root/*` and `/home/*`
-**invisible** to the service. A naive `ln -s ~/.local/share/claude/...
-/usr/local/bin/claude` resolves to a hidden path and every dispatch
-fails at exec time with no useful log.
-
-Relocate the binary outside `$HOME` and symlink:
+**`claude`** — recommended path is Anthropic's apt repository (binary
+lands at a system path, no `$HOME` involvement):
 
 ```bash
-sudo install -d -m 0755 /usr/local/share/claude
-V=$(claude --version | awk '{print $1}')        # e.g. 2.1.126
-sudo cp "$(readlink -f "$(command -v claude)")" /usr/local/share/claude/claude-$V
-sudo chmod 0755 /usr/local/share/claude/claude-$V
-sudo ln -sfn /usr/local/share/claude/claude-$V /usr/local/bin/claude
+install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://downloads.claude.ai/keys/claude-code.asc \
+  -o /etc/apt/keyrings/claude-code.asc
+echo "deb [signed-by=/etc/apt/keyrings/claude-code.asc] https://downloads.claude.ai/claude-code/apt/stable stable main" \
+  > /etc/apt/sources.list.d/claude-code.list
+apt-get update && apt-get install -y claude-code
 ```
 
-`scripts/install-systemd.sh` warns if it detects `claude` resolving to
-`/root/*` or `/home/*`, so you'll catch this if you skip the relocation.
+Verify the Anthropic key fingerprint before trusting:
+
+```bash
+gpg --show-keys /etc/apt/keyrings/claude-code.asc
+# Must report: 31DD DE24 DDFA B679 F42D  7BD2 BAA9 29FF 1A7E CACE
+```
+
+The native curl|sh installer (`curl -fsSL https://claude.ai/install.sh
+| bash`) also works, but it drops the binary under `/root/.local/share/claude/`.
+That's fine for this root-mode install (the unit no longer enables
+`ProtectHome=true`), but apt is cleaner.
 
 Verify both:
 
@@ -116,7 +130,7 @@ claude --version
 ## Step 3 — check out and install agent-fabric
 
 ```bash
-sudo install -d -o "$USER" /srv/agent-fabric
+install -d -m 0755 /srv/agent-fabric
 git clone https://github.com/valdisd96/agent-fabric /srv/agent-fabric
 cd /srv/agent-fabric
 python3.12 -m venv .venv
@@ -131,51 +145,41 @@ If `pip install` errors with `Package requires a different Python:
 3.x is not in '>=3.12'`, the venv was created with the wrong interpreter
 — delete `.venv/` and re-run with `python3.12 -m venv` explicitly.
 
-## Step 4 — install the systemd unit (creates the `fabric` user)
+## Step 4 — install the systemd unit
 
 ```bash
-sudo bash /srv/agent-fabric/scripts/install-systemd.sh
+bash /srv/agent-fabric/scripts/install-systemd.sh
 ```
 
 The script is idempotent. It creates:
 
-- system user `fabric` with `$HOME=/var/lib/fabric`, shell `/usr/sbin/nologin`
-- `/srv/projects` (mode 0750, owned by `fabric`) — managed-repo clones land here
-- `/etc/fabric/env` with stub values, mode 0600, owned by `fabric`
-- `/etc/systemd/system/fabric.service` with the hardening flags
-  (`ProtectSystem=full`, `ProtectHome=true`, `PrivateTmp=true`,
-  `NoNewPrivileges=true`, `ReadWritePaths=$FABRIC_HOME`)
+- `/var/lib/fabric` (mode 0750, owned by `root`) — `FABRIC_HOME`
+- `/srv/projects` (mode 0750, owned by `root`) — managed-repo clones land here
+- `/etc/fabric/env` with stub values plus `IS_SANDBOX=1`, mode 0600, owned by `root`
+- `/etc/systemd/system/fabric.service` with `User=root`, plus
+  `ProtectSystem=full`, `PrivateTmp=true`, `ReadWritePaths=$FABRIC_HOME`
 
-It also prints a warning if `claude` resolves to a path under `$HOME`
-(see Step 2 caveat) — heed it before continuing, or every dispatch
-will silently fail under the running unit.
+It prints a warning if `claude` is not on `PATH`. The script does **not**
+auto-start the service — auth comes first.
 
-**Do not start the unit yet** — auth comes first, otherwise the service
-will boot and fail to dispatch because `gh`/`claude` aren't logged in.
+## Step 5 — authenticate `gh` and `claude`
 
-## Step 5 — authenticate `gh` and `claude` **as the `fabric` user**
-
-This is the most-missed gotcha. The service runs as `fabric`, so
-credentials must live in `/var/lib/fabric/.config/gh/` and
-`/var/lib/fabric/.claude/` — not in your sudo user's home.
-
-`nologin` does **not** block `sudo -u fabric -H bash -c '…'` — sudo
-invokes the requested binary directly, ignoring the user's login shell.
-No `usermod` flip is needed.
+The service runs as root, so credentials live in `/root/.config/gh/` and
+`/root/.claude/`. Just run the login commands directly:
 
 ```bash
-# gh — paste the PAT when prompted
-sudo -u fabric -H bash -c 'gh auth login --hostname github.com'
+# gh — paste the PAT when prompted; answer "Yes" to "Authenticate Git"
+gh auth login --hostname github.com
 
 # claude — interactive OAuth; see "Headless claude login" below if no browser
-sudo -u fabric -H bash -c 'claude login'
+claude login
 ```
 
 Verify:
 
 ```bash
-sudo -u fabric -H bash -c 'gh auth status'
-sudo -u fabric -H bash -c 'claude --version && ls -la ~/.claude'
+gh auth status
+claude --version && ls -la /root/.claude
 ```
 
 ### Headless `claude login` (no browser on the VPS)
@@ -198,7 +202,7 @@ every dispatch will fail.
 ## Step 6 — fill `/etc/fabric/env`
 
 ```bash
-sudo -e /etc/fabric/env       # opens with sudo's default editor
+EDITOR=vi visudo -f /etc/fabric/env   # or just: nano /etc/fabric/env
 ```
 
 Set the Telegram pair (omit both for REST-only mode):
@@ -207,34 +211,32 @@ Set the Telegram pair (omit both for REST-only mode):
 FABRIC_HOME=/var/lib/fabric
 FABRIC_HOST=127.0.0.1
 FABRIC_PORT=7878
+IS_SANDBOX=1                                          # baked in by installer
 FABRIC_TELEGRAM_TOKEN=<from BotFather, looks like 1234567890:AA…>
 FABRIC_TELEGRAM_CHAT_ID=<numeric, from @userinfobot>
 
 # Optional:
 # FABRIC_LOG_LEVEL=INFO              # DEBUG for ad-hoc troubleshooting
-# IS_SANDBOX=1                       # only if you deviate from User=fabric
-                                     # and run the unit as root — `claude`
-                                     # refuses to run as root otherwise
 ```
 
-File must end up `fabric:fabric, 0600`. If the editor changed ownership:
+File must end up `root:root, 0600`. If the editor changed mode:
 
 ```bash
-sudo chown fabric:fabric /etc/fabric/env && sudo chmod 0600 /etc/fabric/env
+chown root:root /etc/fabric/env && chmod 0600 /etc/fabric/env
 ```
 
 ## Step 7 — start the service
 
 ```bash
-sudo systemctl start fabric
-sudo systemctl status fabric --no-pager     # expect: active (running)
-sudo journalctl -u fabric -f                # tick loop should log within 60s
+systemctl start fabric
+systemctl status fabric --no-pager     # expect: active (running)
+journalctl -u fabric -f                # tick loop should log within 60s
 ```
 
 If `status` shows `failed`, dump the last 50 lines and inspect:
 
 ```bash
-sudo journalctl -u fabric -n 50 --no-pager
+journalctl -u fabric -n 50 --no-pager
 ```
 
 Common first-boot failures:
@@ -242,16 +244,16 @@ Common first-boot failures:
 | Log signature | Cause | Fix |
 |---|---|---|
 | `ModuleNotFoundError: fabric` | venv at wrong path | confirm `/srv/agent-fabric/.venv/bin/fabric` exists |
-| `gh: command not found` (in dispatch logs) | `gh` not on `fabric`'s `$PATH` | `sudo ln -s "$(command -v gh)" /usr/local/bin/gh` |
-| `OperationalError: unable to open database file` | `$FABRIC_HOME` permissions wrong | `sudo chown -R fabric:fabric /var/lib/fabric` |
+| `gh: command not found` (in dispatch logs) | `gh` not on root's `$PATH` | `ln -s "$(command -v gh)" /usr/local/bin/gh` |
+| `Claude Code may not be run as root … set IS_SANDBOX=1` | env file missing `IS_SANDBOX=1` | add it, `systemctl restart fabric` |
+| `OperationalError: unable to open database file` | `$FABRIC_HOME` missing/unwritable | `install -d -o root -g root -m 0750 /var/lib/fabric` |
 | `telegram error: Unauthorized` | bad bot token | re-check `FABRIC_TELEGRAM_TOKEN`, restart |
 | One-line warning about TG creds, then REST-only | both TG vars unset | expected; fill them and `systemctl restart fabric` |
 
 ## Step 8 — register the first managed project
 
-`/srv/projects` was created by `install-systemd.sh` (Step 4) — fabric
-owned, mode 0750. Clone, configure, register, label, and sync as
-`fabric`.
+`/srv/projects` was created by `install-systemd.sh` (Step 4). Clone,
+configure, register, label, and sync — all as root.
 
 The block below is shaped for **teach-me-eng-bot** specifically — it
 copies the worked-example config from `examples/`. For any other project
@@ -259,16 +261,13 @@ you need an authored `.fabric/config.yaml` first; see the
 `register-project` skill for the end-to-end "design a config from
 scratch + register" walkthrough.
 
-**Critical:** `sudo -u` does *not* load `/etc/fabric/env`, so `FABRIC_HOME`
-is unset by default and the CLI falls back to `~/.fabric/projects.yaml`
-— a path the systemd service does not read. Export it explicitly inside
-every `sudo -u fabric` block. As of fabric 0.2.x, `fabric` itself emits
-a stderr warning when this divergence is detected, so you'll notice
-quickly if the export is missed.
+**Critical:** an interactive shell does *not* automatically source
+`/etc/fabric/env`. Without `FABRIC_HOME`, the CLI writes the registry to
+`~/.fabric/projects.yaml` — a path the systemd service does not read.
+Export it explicitly. As of fabric 0.2.x the CLI emits a stderr warning
+when this divergence is detected, so you'll notice quickly if you forget.
 
 ```bash
-sudo -u fabric -H bash <<'EOF'
-set -euo pipefail
 export FABRIC_HOME=/var/lib/fabric        # ← MUST match /etc/fabric/env
 cd /srv/projects
 git clone https://github.com/<owner>/<repo>
@@ -285,7 +284,6 @@ FABRIC=/srv/agent-fabric/.venv/bin/fabric
 "$FABRIC" setup-labels <project-name> --check     # diff against repo
 "$FABRIC" setup-labels <project-name>             # apply
 "$FABRIC" sync <project-name>                     # renders 7 skill templates into .claude/skills/
-EOF
 ```
 
 Substitute `<owner>/<repo>` and `<project-name>` (the `project.name` from
@@ -293,7 +291,7 @@ Substitute `<owner>/<repo>` and `<project-name>` (the `project.name` from
 in the project working tree — guide the user to commit them upstream:
 
 ```bash
-sudo -u fabric -H bash -c 'cd /srv/projects/<repo> && git status'
+cd /srv/projects/<repo> && git status
 ```
 
 The user creates the commit + PR from their own clone, not the VPS — the
@@ -312,8 +310,8 @@ Have the user open an issue in the managed repo with these labels:
 Then watch progression in three windows:
 
 ```bash
-sudo journalctl -u fabric -f
-sudo -u fabric /srv/agent-fabric/.venv/bin/fabric logs <project> <issue#> --follow
+journalctl -u fabric -f
+/srv/agent-fabric/.venv/bin/fabric logs <project> <issue#> --follow
 # Telegram: /queue and /status
 ```
 
@@ -331,14 +329,14 @@ state:tests-pending   →  state:in-review       (test-writer runs, PR opens)
 
 ```bash
 # Service control
-sudo systemctl restart fabric
-sudo systemctl stop fabric
-sudo systemctl status fabric --no-pager
+systemctl restart fabric
+systemctl stop fabric
+systemctl status fabric --no-pager
 
 # Logs
-sudo journalctl -u fabric -f                       # service stdout/stderr
-sudo ls /var/lib/fabric/logs/                      # per-dispatch claude -p logs
-sudo -u fabric /srv/agent-fabric/.venv/bin/fabric logs <project> <n> --follow
+journalctl -u fabric -f                            # service stdout/stderr
+ls /var/lib/fabric/logs/                           # per-dispatch claude -p logs
+/srv/agent-fabric/.venv/bin/fabric logs <project> <n> --follow
 
 # REST surface (all behind /api/* except liveness; OpenAPI at /docs)
 curl -sS http://127.0.0.1:7878/healthz             # {"ok": true}
@@ -349,26 +347,28 @@ curl -sS http://127.0.0.1:7878/api/dispatches      # recent dispatches
 curl -sS http://127.0.0.1:7878/docs                # interactive OpenAPI UI
 
 # State (read-only is safe while running)
-sudo -u fabric sqlite3 -readonly /var/lib/fabric/state.db '.tables'
+sqlite3 -readonly /var/lib/fabric/state.db '.tables'
 
-# CLI escape hatches (always as fabric)
+# CLI escape hatches — always export FABRIC_HOME first
+export FABRIC_HOME=/var/lib/fabric
 F=/srv/agent-fabric/.venv/bin/fabric
-sudo -u fabric "$F" pause --reason "demo"
-sudo -u fabric "$F" resume
-sudo -u fabric "$F" dispatch <project> <issue#> plan-exec
-sudo -u fabric "$F" sync <project> --check         # drift check
+"$F" pause --reason "demo"
+"$F" resume
+"$F" dispatch <project> <issue#> plan-exec
+"$F" sync <project> --check         # drift check
 ```
 
 ## Upgrading
 
 ```bash
 cd /srv/agent-fabric
-sudo -u fabric git pull --ff-only
-sudo /srv/agent-fabric/.venv/bin/pip install -e .
-sudo systemctl restart fabric
+git pull --ff-only
+/srv/agent-fabric/.venv/bin/pip install -e .
+systemctl restart fabric
 
 # Re-render skills if templates moved (per managed project)
-sudo -u fabric /srv/agent-fabric/.venv/bin/fabric sync <project>
+export FABRIC_HOME=/var/lib/fabric
+/srv/agent-fabric/.venv/bin/fabric sync <project>
 ```
 
 If a template's `fabric_version` bumped major and a managed project's
@@ -381,9 +381,9 @@ Before declaring the install complete, verify all of:
 
 - [ ] `systemctl is-active fabric` → `active`
 - [ ] `journalctl -u fabric --since "1 minute ago"` shows scheduler tick
-- [ ] `sudo -u fabric gh auth status` → logged in
-- [ ] `sudo -u fabric claude --version` → no auth errors
-- [ ] At least one project shows up in `fabric list` (run as fabric)
+- [ ] `gh auth status` → logged in
+- [ ] `claude --version` → no auth errors
+- [ ] At least one project shows up in `fabric list`
 - [ ] `setup-labels <project> --check` → "labels are clean"
 - [ ] `sync <project> --check` → exit 0
 - [ ] Telegram `/status` responds (if TG configured)

--- a/.claude/skills/register-project/SKILL.md
+++ b/.claude/skills/register-project/SKILL.md
@@ -20,7 +20,7 @@ install first (through the hand-off checklist), then come back here.
 ## What you'll end up with
 
 ```
-/srv/projects/<repo>/                          # cloned managed repo (fabric:fabric)
+/srv/projects/<repo>/                          # cloned managed repo (root:root)
 /srv/projects/<repo>/.fabric/config.yaml       # ← the file you author in Step 2
 /srv/projects/<repo>/.claude/skills/{plan-exec,test-writer,review-pr,
                                      clarify-issue,epic-decompose,
@@ -37,10 +37,10 @@ The fabric's next 60-second tick will pick up any pre-existing
 - The fabric service is running (`systemctl is-active fabric` → `active`)
   and at least one project (e.g. teach-me-eng-bot) is already healthy.
 - The new repo exists on GitHub and the fabric's `gh` auth (logged in
-  as the `fabric` system user) has **read + write** access to it. For
-  fine-grained PATs that means `Contents: Read and write` granted to
-  the specific repo — read-only is enough to register but `git push`
-  fails when the dispatcher tries to open a PR.
+  as `root`) has **read + write** access to it. For fine-grained PATs
+  that means `Contents: Read and write` granted to the specific repo —
+  read-only is enough to register but `git push` fails when the
+  dispatcher tries to open a PR.
 - You know what trivial first issue you'll file as a smoke test
   (Step 9) — a one-line README/docs change is ideal.
 - The repo has at least one committed file on `main` (the dispatcher
@@ -154,13 +154,12 @@ refactors, ill-specified issues); lower it (3) for projects where
 runaway looping is more concerning than under-progress.
 
 **Picking `fabric_version`.** Read the running fabric's version:
-`sudo -u fabric /srv/agent-fabric/.venv/bin/fabric --version` — wait,
-`fabric` doesn't have `--version` yet. Use `pip show agent-fabric` from
-inside the venv, or `grep ^version /srv/agent-fabric/pyproject.toml`.
+`fabric` doesn't have `--version` yet, so use `pip show agent-fabric`
+from inside the venv, or `grep ^version /srv/agent-fabric/pyproject.toml`.
 Pin to that exact value. If the running fabric is `0.2.x`, both
 `"0.2.0"` and `"0.2.5"` work; `"0.3.0"` would be future-incompatible.
 
-## Step 3 — clone the repo under `/srv/projects` as the fabric user
+## Step 3 — clone the repo under `/srv/projects`
 
 The path must be `/srv/projects/<repo>` because that's where
 `install-systemd.sh` set up the writable directory and where the
@@ -169,36 +168,29 @@ the GitHub repo name, not necessarily `project.name` (they often
 match anyway).
 
 ```bash
-sudo -u fabric -H bash <<'EOF'
-set -euo pipefail
 export FABRIC_HOME=/var/lib/fabric        # ← MUST match /etc/fabric/env
 cd /srv/projects
 git clone https://github.com/<owner>/<repo>
-EOF
 ```
 
-If `git clone` errors on auth, the fabric's `gh` PAT doesn't have read
-access to this repo. Re-grant via `sudo -u fabric -H gh auth refresh
--h github.com -s repo` or rotate the PAT.
+If `git clone` errors on auth, the `gh` PAT doesn't have read access to
+this repo. Re-grant via `gh auth refresh -h github.com -s repo` or
+rotate the PAT.
 
 ## Step 4 — drop the authored config into the clone
 
 Author the YAML on your laptop (or anywhere convenient), copy it to
 the VPS, then place it under `.fabric/config.yaml` in the new clone.
-The file must be readable by `fabric:fabric`.
 
 ```bash
 # From your laptop:
 scp my-new-bot.config.yaml vps:/tmp/
 
-# On the VPS:
-sudo -u fabric -H bash <<'EOF'
-set -euo pipefail
+# On the VPS (as root):
 export FABRIC_HOME=/var/lib/fabric
 PROJECT=/srv/projects/<repo>
 mkdir -p "$PROJECT/.fabric"
 cp /tmp/my-new-bot.config.yaml "$PROJECT/.fabric/config.yaml"
-EOF
 ```
 
 Don't put the YAML in an `examples/` subdirectory of agent-fabric — it
@@ -209,8 +201,6 @@ authoritative source.
 ## Step 5 — register, provision labels, sync
 
 ```bash
-sudo -u fabric -H bash <<'EOF'
-set -euo pipefail
 export FABRIC_HOME=/var/lib/fabric
 PROJECT=/srv/projects/<repo>
 NAME=<project-name>                         # the project.name from your YAML
@@ -222,7 +212,6 @@ F=/srv/agent-fabric/.venv/bin/fabric
                                             # type:*, area:* labels in the GH repo
 "$F" sync "$NAME"                           # renders the 7 skills into
                                             # $PROJECT/.claude/skills/
-EOF
 ```
 
 What can fail and how to read it:
@@ -267,17 +256,15 @@ gh pr create --base main --title "chore: wire agent-fabric" \
 After the PR merges, on the VPS:
 
 ```bash
-sudo -u fabric -H bash -c '
-  cd /srv/projects/<repo> && git fetch && git reset --hard origin/main
-'
+cd /srv/projects/<repo> && git fetch && git reset --hard origin/main
 ```
 
 The VPS clone now matches what the dispatcher will rebase onto.
 
 **Pragmatic — commit + push directly from the VPS clone.** Works if
-the `fabric` user's `gh` PAT has write access; just be aware the VPS
-clone *is* the dispatcher's working copy, so don't leave dirty trees
-or partial branches behind.
+the host's `gh` PAT has write access; just be aware the VPS clone *is*
+the dispatcher's working copy, so don't leave dirty trees or partial
+branches behind.
 
 ## Step 7 — drop in the drift-CI workflow (recommended)
 
@@ -325,8 +312,8 @@ Open a trivial issue in the new repo:
 Then watch progression in three places, same as the install smoke:
 
 ```bash
-sudo journalctl -u fabric -f
-sudo -u fabric /srv/agent-fabric/.venv/bin/fabric logs <project> <issue#> --follow
+journalctl -u fabric -f
+/srv/agent-fabric/.venv/bin/fabric logs <project> <issue#> --follow
 # Telegram: /queue, /status
 ```
 
@@ -341,8 +328,8 @@ state:needs-planning → state:in-progress → state:tests-pending → state:in-
 
 If the issue sits at `state:needs-planning` for >2 minutes:
 
-- Confirm it appears in `fabric status` (run as fabric, with
-  `FABRIC_HOME` exported). If not, the registry didn't take.
+- Confirm it appears in `fabric status` (export `FABRIC_HOME` first).
+  If not, the registry didn't take.
 - Confirm none of the other paused gates are set: `fabric status`
   also shows the global `paused` flag.
 - Tail `journalctl -u fabric` for "no actionable issues" — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ examples/
 └── github-actions/fabric-sync-check.yml # drift CI workflow projects copy into .github/workflows/
 
 scripts/
-└── install-systemd.sh                   # idempotent VPC VM installer — fabric system user, systemd unit, EnvironmentFile
+└── install-systemd.sh                   # idempotent VPC VM installer — systemd unit (User=root, IS_SANDBOX=1), EnvironmentFile
 
 tests/
 ├── conftest.py        # shared fixtures (fabric_root, isolated_fabric_home, project, isolated_state_db)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -486,8 +486,10 @@ internet for `gh` / `claude` / Telegram polling, and Phase 1 needs **no**
 inbound HTTP — the Telegram bot is long-poll. Phase 2's dashboard adds
 inbound, at which point a private ingress (VPC-internal LB or Tailscale
 exit-node) takes over. The unit is provisioned by `scripts/install-systemd.sh`
-(idempotent; creates the `fabric` system user, drops a 0600 `EnvironmentFile`,
-enables but does not auto-start the service).
+(idempotent; drops a 0600 `EnvironmentFile`, enables but does not auto-start
+the service). The service runs as `root` with `IS_SANDBOX=1` — intended for
+single-tenant VMs or isolated one-time containers, where there is nothing
+else on the host worth isolating the dispatcher from.
 
 ```ini
 [Unit]
@@ -497,16 +499,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=fabric
+User=root
 WorkingDirectory=/srv/agent-fabric
 EnvironmentFile=/etc/fabric/env
 ExecStart=/srv/agent-fabric/.venv/bin/fabric server
 Restart=always
 RestartSec=5
 ProtectSystem=full
-ProtectHome=true
 PrivateTmp=true
-NoNewPrivileges=true
 ReadWritePaths=/var/lib/fabric
 
 [Install]
@@ -514,6 +514,7 @@ WantedBy=multi-user.target
 ```
 
 `/etc/fabric/env` carries `FABRIC_HOME`, `FABRIC_HOST`, `FABRIC_PORT`,
+`IS_SANDBOX=1` (required when running `claude` as root),
 `FABRIC_TELEGRAM_TOKEN`, `FABRIC_TELEGRAM_CHAT_ID`. See SMOKE.md for the
 full bring-up walkthrough on a fresh VM.
 

--- a/SMOKE.md
+++ b/SMOKE.md
@@ -74,6 +74,7 @@ Edit `/etc/fabric/env`:
 FABRIC_HOME=/var/lib/fabric
 FABRIC_HOST=127.0.0.1
 FABRIC_PORT=7878
+IS_SANDBOX=1                          # baked in by installer; required for User=root
 FABRIC_TELEGRAM_TOKEN=<from BotFather>
 FABRIC_TELEGRAM_CHAT_ID=<your numeric chat_id>
 ```
@@ -86,16 +87,16 @@ sudo systemctl status fabric    # should be "active (running)"
 ## 5. Register your first project
 
 ```bash
-sudo -u fabric -i bash -lc '
-  cd /srv/projects
-  git clone https://github.com/valdisd96/teach-me-eng-bot
-  cp /srv/agent-fabric/examples/teach-me-eng-bot.config.yaml \
-     teach-me-eng-bot/.fabric/config.yaml
-  /srv/agent-fabric/.venv/bin/fabric register /srv/projects/teach-me-eng-bot
-  /srv/agent-fabric/.venv/bin/fabric setup-labels teach-me-eng-bot --check
-  /srv/agent-fabric/.venv/bin/fabric setup-labels teach-me-eng-bot
-  /srv/agent-fabric/.venv/bin/fabric sync teach-me-eng-bot
-'
+export FABRIC_HOME=/var/lib/fabric    # interactive shells don't auto-source /etc/fabric/env
+cd /srv/projects
+git clone https://github.com/valdisd96/teach-me-eng-bot
+cp /srv/agent-fabric/examples/teach-me-eng-bot.config.yaml \
+   teach-me-eng-bot/.fabric/config.yaml
+F=/srv/agent-fabric/.venv/bin/fabric
+"$F" register /srv/projects/teach-me-eng-bot
+"$F" setup-labels teach-me-eng-bot --check
+"$F" setup-labels teach-me-eng-bot
+"$F" sync teach-me-eng-bot
 ```
 
 ## 6. File a smoke issue
@@ -130,26 +131,20 @@ Expected progression:
 From the first real run on 2026-05-04 (full post-mortem in
 `docs/install-runs/2026-05-04.md`):
 
-- **`claude` binary under `$HOME` collides with `ProtectHome=true`.** The
-  official installer drops it at `~/.local/share/claude/versions/<v>` —
-  the systemd unit makes that path invisible to the service, so
-  `/usr/local/bin/claude → ~/.local/share/...` resolves to a forbidden
-  path. Relocate to `/usr/local/share/claude/claude-<v>` and re-symlink.
-  `install-systemd.sh` warns if it detects this case.
-- **`sudo -u fabric` does not load `/etc/fabric/env`.** Running
+- **Interactive shells don't auto-source `/etc/fabric/env`.** Running
   `fabric register` without `export FABRIC_HOME=/var/lib/fabric` writes
   the registry to `~/.fabric/projects.yaml` while the service reads
-  `/var/lib/fabric/projects.yaml`. The CLI now prints a stderr warning
-  when this divergence is detected; always set `FABRIC_HOME` in the
-  `sudo -u fabric` block (the install skill's heredoc does this).
+  `/var/lib/fabric/projects.yaml`. The CLI prints a stderr warning when
+  this divergence is detected; always export `FABRIC_HOME` before
+  invoking `fabric` from a fresh shell.
 - **Fine-grained PATs need `Contents: Read and write` per repo to push.**
   Read works (api + ls-remote) but `git push` fails with `denied to
   <user>` if the PAT doesn't grant write to the specific repo.
 - **TG bot `chat_id` is numeric, not `@username`.** Discover via
   [@userinfobot](https://t.me/userinfobot).
-- **`claude` refuses to run as root without `IS_SANDBOX=1`.** Only
-  relevant if you deviate from the canonical `User=fabric` setup
-  (e.g. for testing). Set `IS_SANDBOX=1` in `/etc/fabric/env` if so.
+- **The service runs as root with `IS_SANDBOX=1`.** Claude Code refuses
+  to start as root otherwise. The installer bakes `IS_SANDBOX=1` into
+  `/etc/fabric/env`; don't remove it.
 - **Per-dispatch logs land at `$FABRIC_HOME/logs/<project>/<n>/<stage>-<ts>.log`.**
   No rotation yet; cap is informal. If a project pumps out a lot of
   dispatches, rotate manually for now.
@@ -161,9 +156,9 @@ From the first real run on 2026-05-04 (full post-mortem in
 ssh vm "journalctl -u fabric -f"
 
 # Force-dispatch a specific stage (debug)
-sudo -u fabric /srv/agent-fabric/.venv/bin/fabric dispatch \
-    teach-me-eng-bot 42 plan-exec
+export FABRIC_HOME=/var/lib/fabric
+/srv/agent-fabric/.venv/bin/fabric dispatch teach-me-eng-bot 42 plan-exec
 
 # Pause the fabric without stopping the unit
-sudo -u fabric /srv/agent-fabric/.venv/bin/fabric pause --reason "demo"
+/srv/agent-fabric/.venv/bin/fabric pause --reason "demo"
 ```

--- a/fabric/registry.py
+++ b/fabric/registry.py
@@ -75,12 +75,11 @@ def warn_if_systemd_env_diverges(
     doesn't, or sets it to a different value. Returns True iff a warning
     was emitted.
 
-    The bug this prevents: an operator runs `sudo -u fabric -H fabric
-    register …` outside the systemd unit's environment. Without
-    FABRIC_HOME, the CLI writes the registry to ~/.fabric/projects.yaml
-    while the running service reads $FABRIC_HOME/projects.yaml — the
-    project never appears in /api/projects and the scheduler polls
-    nothing."""
+    The bug this prevents: an operator runs `fabric register …` from a
+    shell that didn't source /etc/fabric/env. Without FABRIC_HOME, the
+    CLI writes the registry to ~/.fabric/projects.yaml while the running
+    service reads $FABRIC_HOME/projects.yaml — the project never appears
+    in /api/projects and the scheduler polls nothing."""
     env_map = os.environ if env is None else env
     declared = parse_env_file_fabric_home(env_file)
     if declared is None:

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
 #
 # install-systemd.sh — idempotent installer for the agent-fabric systemd unit.
-# Targets a generic Linux VPC VM (Debian/Ubuntu tested). Replaces the earlier
-# Pi-on-Tailscale plan; see DESIGN.md "Decision 13 — Deployment".
+# Targets a generic Linux VPC VM (Debian/Ubuntu tested). The service runs as
+# root with IS_SANDBOX=1; intended for single-tenant VMs or isolated one-time
+# containers where there is nothing else on the host worth isolating from.
+# See DESIGN.md "Decision 13 — Deployment".
 #
 # Usage:
 #   sudo bash scripts/install-systemd.sh
 #
 # Environment overrides (optional):
-#   FABRIC_USER         system user to run the service as           [fabric]
 #   FABRIC_HOME         FABRIC_HOME / state.db location             [/var/lib/fabric]
 #   INSTALL_PREFIX      where the agent-fabric checkout lives       [/srv/agent-fabric]
+#   PROJECTS_DIR        where managed-repo clones land              [/srv/projects]
 
 set -euo pipefail
 
-FABRIC_USER=${FABRIC_USER:-fabric}
 FABRIC_HOME=${FABRIC_HOME:-/var/lib/fabric}
 INSTALL_PREFIX=${INSTALL_PREFIX:-/srv/agent-fabric}
 PROJECTS_DIR=${PROJECTS_DIR:-/srv/projects}
@@ -22,7 +23,7 @@ PROJECTS_DIR=${PROJECTS_DIR:-/srv/projects}
 UNIT_PATH=/etc/systemd/system/fabric.service
 ENV_DIR=/etc/fabric
 ENV_FILE=$ENV_DIR/env
-VENV_PYTHON=$INSTALL_PREFIX/.venv/bin/fabric
+VENV_FABRIC=$INSTALL_PREFIX/.venv/bin/fabric
 
 log() { echo "[install-systemd] $*"; }
 warn() { echo "[install-systemd] WARN: $*" >&2; }
@@ -34,61 +35,32 @@ require_root() {
   fi
 }
 
-ensure_user() {
-  if id -u "$FABRIC_USER" >/dev/null 2>&1; then
-    log "user $FABRIC_USER exists"
-  else
-    log "creating system user $FABRIC_USER"
-    useradd --system --home "$FABRIC_HOME" --create-home --shell /usr/sbin/nologin "$FABRIC_USER"
-  fi
-  install -d -o "$FABRIC_USER" -g "$FABRIC_USER" -m 0750 "$FABRIC_HOME"
+ensure_dirs() {
+  install -d -o root -g root -m 0750 "$FABRIC_HOME"
+  install -d -o root -g root -m 0750 "$PROJECTS_DIR"
+  log "ensured $FABRIC_HOME and $PROJECTS_DIR (root:root 0750)"
 }
 
-ensure_projects_dir() {
-  if [[ -d "$PROJECTS_DIR" ]]; then
-    log "$PROJECTS_DIR exists"
-  else
-    log "creating $PROJECTS_DIR ($FABRIC_USER:$FABRIC_USER 0750)"
-  fi
-  install -d -o "$FABRIC_USER" -g "$FABRIC_USER" -m 0750 "$PROJECTS_DIR"
-}
-
-# `claude` installed via the official curl|sh installer lands at
-# ~/.local/share/claude/versions/<v> — under HOME, which the unit's
-# ProtectHome=true makes invisible to the service. A naive symlink from
-# /usr/local/bin/claude resolves to that hidden path and every dispatch
-# fails at exec. Detect and tell the operator how to relocate.
 check_claude_path() {
-  local claude_path
-  claude_path=$(command -v claude 2>/dev/null) || {
+  if ! command -v claude >/dev/null 2>&1; then
     warn "'claude' not on PATH. Install Claude Code (https://docs.claude.com) before starting the service."
     return 0
-  }
-  local resolved
-  resolved=$(readlink -f "$claude_path")
-  case "$resolved" in
-    /root/*|/home/*)
-      warn "claude resolves to $resolved (under \$HOME)."
-      warn "ProtectHome=true in fabric.service will hide this path from the service."
-      warn "Fix: copy the binary out of \$HOME and re-symlink, e.g.:"
-      warn "  install -d /usr/local/share/claude"
-      warn "  cp $resolved /usr/local/share/claude/claude-\$(claude --version | awk '{print \$1}')"
-      warn "  ln -sfn /usr/local/share/claude/claude-* /usr/local/bin/claude"
-      ;;
-    *)
-      log "claude resolves to $resolved (OK — outside \$HOME)"
-      ;;
-  esac
+  fi
+  log "claude resolves to $(readlink -f "$(command -v claude)")"
 }
 
 ensure_env_file() {
   install -d -m 0755 "$ENV_DIR"
   if [[ ! -f "$ENV_FILE" ]]; then
     cat > "$ENV_FILE" <<EOF
-# /etc/fabric/env — sourced by systemd. Mode 0600, owner $FABRIC_USER.
+# /etc/fabric/env — sourced by systemd. Mode 0600, owner root.
 FABRIC_HOME=$FABRIC_HOME
 FABRIC_HOST=127.0.0.1
 FABRIC_PORT=7878
+
+# Claude Code refuses to run as root unless this is set. The service runs as
+# root and we accept that on single-tenant VMs / isolated containers.
+IS_SANDBOX=1
 
 # Telegram bot — fill both to enable. Comment out for REST-only.
 # FABRIC_TELEGRAM_TOKEN=
@@ -97,12 +69,20 @@ EOF
     log "created $ENV_FILE — fill TG creds then: systemctl restart fabric"
   else
     log "env file $ENV_FILE present, leaving as-is"
+    if ! grep -q '^IS_SANDBOX=' "$ENV_FILE"; then
+      echo "IS_SANDBOX=1" >> "$ENV_FILE"
+      log "appended IS_SANDBOX=1 to $ENV_FILE (required when running claude as root)"
+    fi
   fi
-  chown "$FABRIC_USER:$FABRIC_USER" "$ENV_FILE"
+  chown root:root "$ENV_FILE"
   chmod 0600 "$ENV_FILE"
 }
 
 install_unit() {
+  # ProtectHome is intentionally OFF: gh + claude credentials live under
+  # /root/.config/gh and /root/.claude respectively, and the unit needs to
+  # read them. The other hardening flags are kept where they're meaningful
+  # even for a root-uid process.
   cat > "$UNIT_PATH" <<EOF
 [Unit]
 Description=Agent Fabric
@@ -111,17 +91,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=$FABRIC_USER
+User=root
 WorkingDirectory=$INSTALL_PREFIX
 EnvironmentFile=$ENV_FILE
-ExecStart=$VENV_PYTHON server
+ExecStart=$VENV_FABRIC server
 Restart=always
 RestartSec=5
-# Hardening: read-only filesystem except FABRIC_HOME and the temp dir.
 ProtectSystem=full
-ProtectHome=true
 PrivateTmp=true
-NoNewPrivileges=true
 ReadWritePaths=$FABRIC_HOME
 
 [Install]
@@ -132,8 +109,7 @@ EOF
 
 main() {
   require_root
-  ensure_user
-  ensure_projects_dir
+  ensure_dirs
   ensure_env_file
   install_unit
   check_claude_path


### PR DESCRIPTION
## Summary

- `scripts/install-systemd.sh` now provisions a root-uid unit with `IS_SANDBOX=1` baked into `/etc/fabric/env`; no more `fabric` system user, no more `ProtectHome=true`. Idempotent: if the env file already exists without `IS_SANDBOX=`, the line is appended.
- Docs realigned: install skill, register-project skill, `SMOKE.md`, `DESIGN.md` Decision 13, `CLAUDE.md` repo-layout note, `fabric/registry.py` docstring example. The `docs/install-runs/2026-05-04.md` post-mortem is intentionally untouched as a historical record of the prior setup.
- 337 tests still pass (7 parity tests skip without `TEACH_ME_ENG_BOT_PATH`, same as before).

## Why

The fabric system user existed to harden a bare-VPS install, but every doc lean on `sudo -u fabric -H bash <<EOF` heredocs and the `ProtectHome=true` flag forced contortions around where `claude`/`gh` credentials lived (the install skill's "relocate the binary outside \$HOME" gotcha). The intended deployment target going forward is isolated one-time containers, where the host provides the isolation that `User=fabric` was buying.

This is a deployment-only change; no behavioral changes to the dispatcher, scheduler, or REST surface.

## Test plan

- [x] `bash -n scripts/install-systemd.sh` — syntax clean
- [x] `python3 -m py_compile $(git ls-files 'fabric/*.py')` — clean
- [x] `pytest -q` — 337 passed, 7 skipped (parity, expected without `TEACH_ME_ENG_BOT_PATH`)
- [ ] Smoke install on a fresh Ubuntu 24.04 box following the updated install skill end-to-end (deferred to the actual VPS migration the user is doing next)